### PR TITLE
fix: show classmates when deregistration deadline has passed

### DIFF
--- a/src/utils/parsers/exams/registeredTermsParser.ts
+++ b/src/utils/parsers/exams/registeredTermsParser.ts
@@ -32,7 +32,10 @@ export function parseRegisteredTerms(doc: Document, getOrCreateSubject: (c: stri
         const normalizedDateStr = normalizeDateString(dateStr, isEn);
         const [date, time] = normalizedDateStr.split(' ');
 
-        const termId = row.querySelector('a[href*="odhlasit_ihned=1"]')?.getAttribute('href')?.match(/termin=(\d+)/)?.[1] || '';
+        const termId =
+            row.querySelector('a[href*="odhlasit_ihned=1"]')?.getAttribute('href')?.match(/termin=(\d+)/)?.[1] ||
+            row.querySelector('a[href*="terminy_info"]')?.getAttribute('href')?.match(/termin=(\d+)/)?.[1] ||
+            '';
 
         let deregistrationDeadline: string | undefined;
         for (let i = 0; i < cols.length; i++) {


### PR DESCRIPTION
## Summary

- Parser extracted `termId` only from the `odhlasit_ihned=1` unregister link, which IS Mendelu removes once the deadline passes
- Adds fallback to the always-present `terminy_info.pl` info link ("Podrobnosti") to get the same termId
- Evidence: `reis-scraper/termin-seznam.html` confirms termin=336592 in both links before deadline; `exam-terms-cz.html` (completed past term) confirms info link persists after deadline; `scripts/fetch-termin-spoluzaci.ts` already uses the same `a[href*="terminy_info"]` selector

## Test plan
- [ ] Load exams tab with a registered exam whose deregistration deadline is in the past — classmates button (👥) should appear
- [ ] Exams with future deadlines unaffected (odhlasit link still used as primary source)