### PR TITLE
feat: open doc server files for past-semester subjects

### DIFF
--- a/src/api/__tests__/parsePastSubjectTree.test.ts
+++ b/src/api/__tests__/parsePastSubjectTree.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../../services/storage/IndexedDBService', () => ({
+    IndexedDBService: {}
+}));
+
+import { parsePastSubjectTree } from '../pastSubjects';
+
+const FIXTURE = `
+<div class="subtree"><ul>
+  <li><div class="node-container"><div class="node-label">
+    <a href="slozka.pl?;id=6;lang=cz">Předměty minulých období</a>
+  </div></div></li>
+  <li><div class="node-container"><div class="node-label">
+    <a href="slozka.pl?;id=10400;lang=cz">PEF</a>
+  </div></div></li>
+  <li><div class="node-container"><div class="node-label">
+    <a href="slozka.pl?;id=151957;lang=cz">ZS 2025/2026</a>
+  </div></div></li>
+  <li><div class="node-container"><div class="node-label">
+    <a href="slozka.pl?;id=150953;lang=cz">EBC-ALG Algoritmizace</a>&nbsp;(24)
+  </div></div></li>
+  <li><div class="node-container"><div class="node-label">
+    <a href="slozka.pl?;id=150954;lang=cz">EBC-AP Architektura počítačů</a>&nbsp;(21)
+  </div></div></li>
+  <li><div class="node-container"><div class="node-label">
+    <a href="slozka.pl?;id=150180;lang=cz"><b>EBC-KOM Komunikace</b></a>&nbsp;(<b>2</b>/12)
+  </div></div></li>
+  <li><div class="node-container"><div class="node-label">
+    <a href="slozka.pl?;id=150955;lang=cz">EBC-TZI Teoretické základy informatiky</a>
+  </div></div></li>
+  <li><div class="node-container"><div class="node-label">
+    <a href="slozka.pl?;id=152415;lang=cz">EBC-TZI / Informace k&nbsp;výuce</a>&nbsp;(1)
+  </div></div></li>
+  <li><div class="node-container"><div class="node-label">
+    <a href="slozka.pl?;id=152416;lang=cz">EBC-TZI / Materiály z&nbsp;přednášek</a>&nbsp;(10)
+  </div></div></li>
+</ul></div>
+`;
+
+describe('parsePastSubjectTree', () => {
+    it('extracts subject-level folders, ignoring container/subfolder nodes', () => {
+        const result = parsePastSubjectTree(FIXTURE);
+
+        expect(Object.keys(result).sort()).toEqual([
+            'EBC-ALG', 'EBC-AP', 'EBC-KOM', 'EBC-TZI',
+        ]);
+
+        expect(result['EBC-ALG']).toEqual({
+            subjectCode: 'EBC-ALG',
+            displayName: 'Algoritmizace',
+            folderUrl: 'https://is.mendelu.cz/auth/dok_server/slozka.pl?id=150953',
+        });
+
+        expect(result['EBC-KOM']).toEqual({
+            subjectCode: 'EBC-KOM',
+            displayName: 'Komunikace',
+            folderUrl: 'https://is.mendelu.cz/auth/dok_server/slozka.pl?id=150180',
+        });
+    });
+
+    it('returns empty object for empty or malformed HTML', () => {
+        expect(parsePastSubjectTree('')).toEqual({});
+        expect(parsePastSubjectTree('<div>no links</div>')).toEqual({});
+    });
+
+    it('skips subfolder nodes with " / " in the label', () => {
+        const result = parsePastSubjectTree(FIXTURE);
+        expect(result).not.toHaveProperty('EBC-TZI / Informace k výuce');
+    });
+});

--- a/src/api/pastSubjects.ts
+++ b/src/api/pastSubjects.ts
@@ -1,0 +1,55 @@
+import { fetchWithAuth, BASE_URL } from "./client";
+
+const PAST_SUBJECTS_TREE_URL = `${BASE_URL}/auth/dok_server/strom_od.pl?id=6`;
+
+export interface PastSubjectFolder {
+    subjectCode: string;
+    displayName: string;
+    folderUrl: string;
+}
+
+export async function fetchPastSubjectFolders(lang: string = 'cz'): Promise<Record<string, PastSubjectFolder>> {
+    try {
+        const url = `${PAST_SUBJECTS_TREE_URL};lang=${lang}`;
+        const response = await fetchWithAuth(url);
+        const html = await response.text();
+        return parsePastSubjectTree(html);
+    } catch (e) {
+        console.warn('[pastSubjects] fetchPastSubjectFolders failed:', e);
+        return {};
+    }
+}
+
+export async function fetchDualLanguagePastSubjects(): Promise<{ cz: Record<string, PastSubjectFolder>; en: Record<string, PastSubjectFolder> }> {
+    const [cz, en] = await Promise.all([
+        fetchPastSubjectFolders('cz'),
+        fetchPastSubjectFolders('en'),
+    ]);
+    return { cz, en };
+}
+
+export function parsePastSubjectTree(htmlString: string): Record<string, PastSubjectFolder> {
+    const result: Record<string, PastSubjectFolder> = {};
+    const doc = new DOMParser().parseFromString(htmlString, 'text/html');
+
+    const links = doc.querySelectorAll('a[href*="slozka.pl"]');
+    for (const link of links) {
+        const anchor = link as HTMLAnchorElement;
+        const text = (anchor.textContent || '').replace(/\s+/g, ' ').trim();
+        if (!text || text.includes(' / ')) continue;
+
+        const match = text.match(/^([A-Z][A-Z0-9]+(?:-[A-Z0-9]+)+)\s+(.+)$/);
+        if (!match) continue;
+
+        const [, subjectCode, displayName] = match;
+        if (result[subjectCode]) continue;
+
+        const href = anchor.getAttribute('href') || '';
+        const idMatch = href.match(/[?&;]id=(\d+)/);
+        if (!idMatch) continue;
+
+        const folderUrl = `${BASE_URL}/auth/dok_server/slozka.pl?id=${idMatch[1]}`;
+        result[subjectCode] = { subjectCode, displayName, folderUrl };
+    }
+    return result;
+}

--- a/src/components/AppMain.tsx
+++ b/src/components/AppMain.tsx
@@ -13,7 +13,7 @@ interface AppMainProps {
     handlePrevWeek: () => void;
     handleNextWeek: () => void;
     handleToday: () => void;
-    handleOpenSubjectFromSearch: (courseCode: string, courseName?: string, courseId?: string) => void;
+    handleOpenSubjectFromSearch: (courseCode: string, courseName?: string, courseId?: string, facultyCode?: string, initialTab?: 'files' | 'stats' | 'syllabus' | 'classmates', isFulfilled?: boolean) => void;
     dateRangeLabel: string;
     searchPrefillRef?: React.MutableRefObject<((query: string) => void) | null>;
     setCurrentView?: (view: AppView) => void;

--- a/src/components/SubjectFileDrawer/DrawerHeader.tsx
+++ b/src/components/SubjectFileDrawer/DrawerHeader.tsx
@@ -8,6 +8,10 @@ import { HeaderTabs } from './Header/HeaderTabs';
 import { useTranslation } from '../../hooks/useTranslation';
 import { useTimeline } from '../../hooks/useTimeline';
 
+const NO_ID_DISABLED: string[] = ['files', 'classmates', 'cvicneTests'];
+const CLASSMATES_ONLY: string[] = ['classmates'];
+const EMPTY_TABS: string[] = [];
+
 function formatDate(ds: string, t: (k: string) => string) {
     if (!ds || ds.length !== 8) return '';
     const d = new Date(parseInt(ds.substring(0, 4)), parseInt(ds.substring(4, 6)) - 1, parseInt(ds.substring(6, 8)));
@@ -89,7 +93,7 @@ export function DrawerHeader({ lesson, courseId, courseInfo, subjectInfo, select
             <HeaderTabs
                 activeTab={activeTab}
                 onTabChange={onTabChange}
-                disabledTabs={!subjectInfo?.subjectId ? ['files', 'classmates', 'cvicneTests'] : (lesson && 'isFulfilled' in lesson && lesson.isFulfilled ? ['classmates'] : [])}
+                disabledTabs={!subjectInfo?.subjectId ? NO_ID_DISABLED : (lesson && 'isFulfilled' in lesson && lesson.isFulfilled ? CLASSMATES_ONLY : EMPTY_TABS)}
                 counts={tabCounts}
             />
         </div>

--- a/src/components/SubjectFileDrawer/DrawerHeader.tsx
+++ b/src/components/SubjectFileDrawer/DrawerHeader.tsx
@@ -89,7 +89,7 @@ export function DrawerHeader({ lesson, courseId, courseInfo, subjectInfo, select
             <HeaderTabs
                 activeTab={activeTab}
                 onTabChange={onTabChange}
-                disabledTabs={!subjectInfo?.subjectId ? ['files', 'classmates', 'cvicneTests'] : []}
+                disabledTabs={!subjectInfo?.subjectId ? ['files', 'classmates', 'cvicneTests'] : (lesson && 'isFulfilled' in lesson && lesson.isFulfilled ? ['classmates'] : [])}
                 counts={tabCounts}
             />
         </div>

--- a/src/components/SubjectsPanel/SemesterSection.tsx
+++ b/src/components/SubjectsPanel/SemesterSection.tsx
@@ -13,7 +13,7 @@ interface SemesterSectionProps {
   zameraniLookup?: Map<string, Zamerani>;
   zameraniProgress?: Map<string, ZameraniProgress>;
   onToggle: () => void;
-  onOpenSubject: (courseCode: string, courseName: string, courseId: string, facultyCode?: string, initialTab?: string) => void;
+  onOpenSubject: (courseCode: string, courseName: string, courseId: string, facultyCode?: string, initialTab?: 'files' | 'stats' | 'syllabus' | 'classmates', isFulfilled?: boolean) => void;
   onSearchSubject: (name: string) => void;
 }
 

--- a/src/components/SubjectsPanel/SubjectRow.tsx
+++ b/src/components/SubjectsPanel/SubjectRow.tsx
@@ -9,7 +9,7 @@ interface SubjectRowProps {
   subject: SubjectStatus;
   compact?: boolean;
   failRate?: number | null;
-  onOpenSubject: (courseCode: string, courseName: string, courseId: string, facultyCode?: string, initialTab?: 'files' | 'stats' | 'syllabus' | 'classmates') => void;
+  onOpenSubject: (courseCode: string, courseName: string, courseId: string, facultyCode?: string, initialTab?: 'files' | 'stats' | 'syllabus' | 'classmates', isFulfilled?: boolean) => void;
   onSearchSubject: (name: string) => void;
   hideStatus?: boolean;
   zamerani?: Zamerani | null;
@@ -34,7 +34,7 @@ export function SubjectRow({ subject, compact, failRate, hideStatus, onOpenSubje
   const handleClick = () => {
     if (isZamerani) return; // pseudo-row, not openable
     if (hasId) {
-      onOpenSubject(subject.code, subject.name, subject.id);
+      onOpenSubject(subject.code, subject.name, subject.id, undefined, undefined, subject.isFulfilled);
     } else {
       onSearchSubject(subject.name);
     }

--- a/src/components/SubjectsPanel/index.tsx
+++ b/src/components/SubjectsPanel/index.tsx
@@ -21,7 +21,7 @@ function normalizeZameraniName(s: string): string {
 }
 
 interface SubjectsPanelProps {
-  onOpenSubject: (courseCode: string, courseName: string, courseId: string, facultyCode?: string, initialTab?: string) => void;
+  onOpenSubject: (courseCode: string, courseName: string, courseId: string, facultyCode?: string, initialTab?: 'files' | 'stats' | 'syllabus' | 'classmates', isFulfilled?: boolean) => void;
   onSearchSubject: (name: string) => void;
 }
 

--- a/src/hooks/useAppLogic.ts
+++ b/src/hooks/useAppLogic.ts
@@ -212,8 +212,8 @@ export function useAppLogic() {
         return () => window.removeEventListener('message', handle);
     }, []);
 
-    const handleOpenSubjectFromSearch = (courseCode: string, courseName?: string, courseId?: string, facultyCode?: string, initialTab?: 'files' | 'stats' | 'syllabus' | 'classmates') => {
-        setSelectedSubject({ courseCode, courseName: courseName || courseCode, courseId: courseId || '', id: `search-${courseCode}`, isFromSearch: true, facultyCode, initialTab });
+    const handleOpenSubjectFromSearch = (courseCode: string, courseName?: string, courseId?: string, facultyCode?: string, initialTab?: 'files' | 'stats' | 'syllabus' | 'classmates', isFulfilled?: boolean) => {
+        setSelectedSubject({ courseCode, courseName: courseName || courseCode, courseId: courseId || '', id: `search-${courseCode}`, isFromSearch: true, facultyCode, initialTab, isFulfilled });
     };
 
     return { currentDate, setCurrentDate, currentView, setCurrentView, selectedSubject, setSelectedSubject, weekNavCount, setWeekNavCount, isFeedbackOpen, setIsFeedbackOpen, openSettingsRef, searchPrefillRef, outlookSyncEnabled, handleOpenSubjectFromSearch };

--- a/src/injector/syncService.ts
+++ b/src/injector/syncService.ts
@@ -2,6 +2,7 @@ import pLimit from "p-limit";
 import { Messages } from "../types/messages";
 import { fetchDualLanguageExams } from "../api/exams";
 import { fetchDualLanguageSubjects } from "../api/subjects";
+import { fetchDualLanguagePastSubjects } from "../api/pastSubjects";
 import { fetchFilesFromFolder } from "../api/documents";
 import { fetchAssessments } from "../api/assessments";
 import { fetchDualLanguageStudyPlan } from "../api/studyPlan";
@@ -51,6 +52,10 @@ export async function syncAllData() {
             return plan;
         }) : Promise.resolve(null);
 
+        // Past-semester folders from doc server history — used to backfill
+        // SubjectInfo for fulfilled subjects that list.pl no longer returns.
+        const pastSubjectsPromise = fetchDualLanguagePastSubjects();
+
         const studyStatsPromise = (studium && userParams?.obdobi)
             ? fetchStudyStats(studium, userParams.obdobi).then(stats => {
                 if (stats) cachedData = { ...cachedData, studyStats: stats };
@@ -75,7 +80,7 @@ export async function syncAllData() {
             : Promise.resolve(null);
 
         // Phase 2b: Full schedule + exams in parallel (subjects/studyPlan/studyStats re-uses already-started promises)
-        const [fullSchedule, exams, subjects, studyPlan, studyStats, cvicneTests, odevzdavarnyResult] = await Promise.allSettled([
+        const [fullSchedule, exams, subjects, studyPlan, studyStats, cvicneTests, odevzdavarnyResult, pastSubjects] = await Promise.allSettled([
             fetchFullSemesterSchedule(),
             fetchDualLanguageExams(),
             subjectsPromise,
@@ -83,7 +88,19 @@ export async function syncAllData() {
             studyStatsPromise,
             cvicneTestsPromise,
             odevzdavarnyPromise,
+            pastSubjectsPromise,
         ]);
+
+        if (
+            subjects.status === "fulfilled" && subjects.value &&
+            pastSubjects.status === "fulfilled" && pastSubjects.value
+        ) {
+            mergePastSubjects(
+                subjects.value.subjects,
+                pastSubjects.value,
+                studyPlan.status === "fulfilled" ? studyPlan.value : null,
+            );
+        }
 
         cachedData = {
             ...cachedData,
@@ -169,6 +186,45 @@ async function syncSubjectDetails(subjectsValue: { data: Record<string, { folder
         await Promise.all(classmateTasks);
     } catch (e) {
         console.error('[syncClassmates] Error fetching group map:', e);
+    }
+}
+
+type PastFoldersByLang = Awaited<ReturnType<typeof fetchDualLanguagePastSubjects>>;
+type DualStudyPlan = Awaited<ReturnType<typeof fetchDualLanguageStudyPlan>>;
+
+function mergePastSubjects(
+    subjectsData: { data: Record<string, { displayName: string; fullName: string; nameCs?: string; nameEn?: string; subjectCode: string; subjectId?: string; folderUrl: string; fetchedAt: string }> },
+    past: PastFoldersByLang,
+    plan: DualStudyPlan | null,
+) {
+    const planById = new Map<string, string>();
+    const planNameCs = new Map<string, string>();
+    const planNameEn = new Map<string, string>();
+    if (plan) {
+        for (const block of plan.cz.blocks) for (const group of block.groups) for (const s of group.subjects) {
+            planById.set(s.code, s.id);
+            planNameCs.set(s.code, s.name);
+        }
+        for (const block of plan.en.blocks) for (const group of block.groups) for (const s of group.subjects) {
+            planNameEn.set(s.code, s.name);
+        }
+    }
+
+    const now = new Date().toISOString();
+    for (const [code, czFolder] of Object.entries(past.cz)) {
+        if (subjectsData.data[code]) continue;
+        const nameCs = planNameCs.get(code) ?? czFolder.displayName;
+        const nameEn = planNameEn.get(code) ?? past.en[code]?.displayName;
+        subjectsData.data[code] = {
+            subjectCode: code,
+            displayName: nameCs,
+            fullName: `${code} ${nameCs}`,
+            nameCs,
+            nameEn,
+            subjectId: planById.get(code),
+            folderUrl: czFolder.folderUrl,
+            fetchedAt: now,
+        };
     }
 }
 

--- a/src/injector/syncService.ts
+++ b/src/injector/syncService.ts
@@ -11,6 +11,7 @@ import { fetchSyllabus } from "../api/syllabus";
 import { syncCvicneTests } from "../services/sync/syncCvicneTests";
 import { syncOdevzdavarny } from "../services/sync/syncOdevzdavarny";
 import { fetchSeminarGroupIds, fetchClassmates } from "../api/classmates";
+import { mergePastSubjects } from "../services/sync/mergePastSubjects";
 
 import { getUserParams } from "../utils/userParams";
 import { fetchFullSemesterSchedule } from "./dataFetchers";
@@ -186,45 +187,6 @@ async function syncSubjectDetails(subjectsValue: { data: Record<string, { folder
         await Promise.all(classmateTasks);
     } catch (e) {
         console.error('[syncClassmates] Error fetching group map:', e);
-    }
-}
-
-type PastFoldersByLang = Awaited<ReturnType<typeof fetchDualLanguagePastSubjects>>;
-type DualStudyPlan = Awaited<ReturnType<typeof fetchDualLanguageStudyPlan>>;
-
-function mergePastSubjects(
-    subjectsData: { data: Record<string, { displayName: string; fullName: string; nameCs?: string; nameEn?: string; subjectCode: string; subjectId?: string; folderUrl: string; fetchedAt: string }> },
-    past: PastFoldersByLang,
-    plan: DualStudyPlan | null,
-) {
-    const planById = new Map<string, string>();
-    const planNameCs = new Map<string, string>();
-    const planNameEn = new Map<string, string>();
-    if (plan) {
-        for (const block of plan.cz.blocks) for (const group of block.groups) for (const s of group.subjects) {
-            planById.set(s.code, s.id);
-            planNameCs.set(s.code, s.name);
-        }
-        for (const block of plan.en.blocks) for (const group of block.groups) for (const s of group.subjects) {
-            planNameEn.set(s.code, s.name);
-        }
-    }
-
-    const now = new Date().toISOString();
-    for (const [code, czFolder] of Object.entries(past.cz)) {
-        if (subjectsData.data[code]) continue;
-        const nameCs = planNameCs.get(code) ?? czFolder.displayName;
-        const nameEn = planNameEn.get(code) ?? past.en[code]?.displayName;
-        subjectsData.data[code] = {
-            subjectCode: code,
-            displayName: nameCs,
-            fullName: `${code} ${nameCs}`,
-            nameCs,
-            nameEn,
-            subjectId: planById.get(code),
-            folderUrl: czFolder.folderUrl,
-            fetchedAt: now,
-        };
     }
 }
 

--- a/src/services/sync/mergePastSubjects.ts
+++ b/src/services/sync/mergePastSubjects.ts
@@ -1,0 +1,41 @@
+import type { fetchDualLanguagePastSubjects } from "../../api/pastSubjects";
+import type { fetchDualLanguageStudyPlan } from "../../api/studyPlan";
+
+type PastFoldersByLang = Awaited<ReturnType<typeof fetchDualLanguagePastSubjects>>;
+type DualStudyPlan = Awaited<ReturnType<typeof fetchDualLanguageStudyPlan>>;
+
+export function mergePastSubjects(
+    subjectsData: { data: Record<string, { displayName: string; fullName: string; nameCs?: string; nameEn?: string; subjectCode: string; subjectId?: string; folderUrl: string; fetchedAt: string }> },
+    past: PastFoldersByLang,
+    plan: DualStudyPlan | null,
+) {
+    const planById = new Map<string, string>();
+    const planNameCs = new Map<string, string>();
+    const planNameEn = new Map<string, string>();
+    if (plan) {
+        for (const block of plan.cz.blocks) for (const group of block.groups) for (const s of group.subjects) {
+            planById.set(s.code, s.id);
+            planNameCs.set(s.code, s.name);
+        }
+        for (const block of plan.en.blocks) for (const group of block.groups) for (const s of group.subjects) {
+            planNameEn.set(s.code, s.name);
+        }
+    }
+
+    const now = new Date().toISOString();
+    for (const [code, czFolder] of Object.entries(past.cz)) {
+        if (subjectsData.data[code]) continue;
+        const nameCs = planNameCs.get(code) ?? czFolder.displayName;
+        const nameEn = planNameEn.get(code) ?? past.en[code]?.displayName;
+        subjectsData.data[code] = {
+            subjectCode: code,
+            displayName: nameCs,
+            fullName: `${code} ${nameCs}`,
+            nameCs,
+            nameEn,
+            subjectId: planById.get(code),
+            folderUrl: czFolder.folderUrl,
+            fetchedAt: now,
+        };
+    }
+}

--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -8,4 +8,5 @@ export interface SelectedSubject {
     isFromSearch?: boolean;
     facultyCode?: string;
     initialTab?: 'files' | 'stats' | 'syllabus' | 'classmates';
+    isFulfilled?: boolean;
 }


### PR DESCRIPTION
## Summary

- Fetches the IS Mendelu doc server history tree (`strom_od.pl?id=6`) for both CZ and EN to discover folder URLs for past-semester subjects (e.g. ZS 2025/2026 subjects no longer returned by `list.pl`)
- Merges these into the subjects store via `mergePastSubjects()` in `syncService.ts`, backfilling `folderUrl` and `subjectId` (from study plan) so the file drawer can open them
- Disables the Spolužáci tab for fulfilled past subjects (classmates data is not available for past semesters) while keeping files, Úkoly, and syllabus accessible
- Adds unit tests for `parsePastSubjectTree`

## Test plan

- [x] Open Předměty → 1. semestr ZS 2025/2026 → click a fulfilled subject (e.g. Algoritmizace) → file drawer opens and shows files
- [ ] Spolužáci tab is greyed out / disabled for the fulfilled subject
- [ ] Úkoly tab is still enabled and shows grade results
- [ ] Current-semester subjects are unaffected (all tabs enabled as before)
- [ ] `npm run test:run` passes