### PR TITLE
refactor: remove Zapsané předměty section, auto-expand current semester

### DIFF
--- a/src/api/__tests__/parsePastSubjectTree.test.ts
+++ b/src/api/__tests__/parsePastSubjectTree.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../../services/storage/IndexedDBService', () => ({
+    IndexedDBService: {}
+}));
+
+import { parsePastSubjectTree } from '../pastSubjects';
+
+const FIXTURE = `
+<div class="subtree"><ul>
+  <li><div class="node-container"><div class="node-label">
+    <a href="slozka.pl?;id=6;lang=cz">Předměty minulých období</a>
+  </div></div></li>
+  <li><div class="node-container"><div class="node-label">
+    <a href="slozka.pl?;id=10400;lang=cz">PEF</a>
+  </div></div></li>
+  <li><div class="node-container"><div class="node-label">
+    <a href="slozka.pl?;id=151957;lang=cz">ZS 2025/2026</a>
+  </div></div></li>
+  <li><div class="node-container"><div class="node-label">
+    <a href="slozka.pl?;id=150953;lang=cz">EBC-ALG Algoritmizace</a>&nbsp;(24)
+  </div></div></li>
+  <li><div class="node-container"><div class="node-label">
+    <a href="slozka.pl?;id=150954;lang=cz">EBC-AP Architektura počítačů</a>&nbsp;(21)
+  </div></div></li>
+  <li><div class="node-container"><div class="node-label">
+    <a href="slozka.pl?;id=150180;lang=cz"><b>EBC-KOM Komunikace</b></a>&nbsp;(<b>2</b>/12)
+  </div></div></li>
+  <li><div class="node-container"><div class="node-label">
+    <a href="slozka.pl?;id=150955;lang=cz">EBC-TZI Teoretické základy informatiky</a>
+  </div></div></li>
+  <li><div class="node-container"><div class="node-label">
+    <a href="slozka.pl?;id=152415;lang=cz">EBC-TZI / Informace k&nbsp;výuce</a>&nbsp;(1)
+  </div></div></li>
+  <li><div class="node-container"><div class="node-label">
+    <a href="slozka.pl?;id=152416;lang=cz">EBC-TZI / Materiály z&nbsp;přednášek</a>&nbsp;(10)
+  </div></div></li>
+</ul></div>
+`;
+
+describe('parsePastSubjectTree', () => {
+    it('extracts subject-level folders, ignoring container/subfolder nodes', () => {
+        const result = parsePastSubjectTree(FIXTURE);
+
+        expect(Object.keys(result).sort()).toEqual([
+            'EBC-ALG', 'EBC-AP', 'EBC-KOM', 'EBC-TZI',
+        ]);
+
+        expect(result['EBC-ALG']).toEqual({
+            subjectCode: 'EBC-ALG',
+            displayName: 'Algoritmizace',
+            folderUrl: 'https://is.mendelu.cz/auth/dok_server/slozka.pl?id=150953',
+        });
+
+        expect(result['EBC-KOM']).toEqual({
+            subjectCode: 'EBC-KOM',
+            displayName: 'Komunikace',
+            folderUrl: 'https://is.mendelu.cz/auth/dok_server/slozka.pl?id=150180',
+        });
+    });
+
+    it('returns empty object for empty or malformed HTML', () => {
+        expect(parsePastSubjectTree('')).toEqual({});
+        expect(parsePastSubjectTree('<div>no links</div>')).toEqual({});
+    });
+
+    it('skips subfolder nodes with " / " in the label', () => {
+        const result = parsePastSubjectTree(FIXTURE);
+        expect(result).not.toHaveProperty('EBC-TZI / Informace k výuce');
+    });
+});

--- a/src/api/pastSubjects.ts
+++ b/src/api/pastSubjects.ts
@@ -1,0 +1,55 @@
+import { fetchWithAuth, BASE_URL } from "./client";
+
+const PAST_SUBJECTS_TREE_URL = `${BASE_URL}/auth/dok_server/strom_od.pl?id=6`;
+
+export interface PastSubjectFolder {
+    subjectCode: string;
+    displayName: string;
+    folderUrl: string;
+}
+
+export async function fetchPastSubjectFolders(lang: string = 'cz'): Promise<Record<string, PastSubjectFolder>> {
+    try {
+        const url = `${PAST_SUBJECTS_TREE_URL};lang=${lang}`;
+        const response = await fetchWithAuth(url);
+        const html = await response.text();
+        return parsePastSubjectTree(html);
+    } catch (e) {
+        console.warn('[pastSubjects] fetchPastSubjectFolders failed:', e);
+        return {};
+    }
+}
+
+export async function fetchDualLanguagePastSubjects(): Promise<{ cz: Record<string, PastSubjectFolder>; en: Record<string, PastSubjectFolder> }> {
+    const [cz, en] = await Promise.all([
+        fetchPastSubjectFolders('cz'),
+        fetchPastSubjectFolders('en'),
+    ]);
+    return { cz, en };
+}
+
+export function parsePastSubjectTree(htmlString: string): Record<string, PastSubjectFolder> {
+    const result: Record<string, PastSubjectFolder> = {};
+    const doc = new DOMParser().parseFromString(htmlString, 'text/html');
+
+    const links = doc.querySelectorAll('a[href*="slozka.pl"]');
+    for (const link of links) {
+        const anchor = link as HTMLAnchorElement;
+        const text = (anchor.textContent || '').replace(/\s+/g, ' ').trim();
+        if (!text || text.includes(' / ')) continue;
+
+        const match = text.match(/^([A-Z][A-Z0-9]+(?:-[A-Z0-9]+)+)\s+(.+)$/);
+        if (!match) continue;
+
+        const [, subjectCode, displayName] = match;
+        if (result[subjectCode]) continue;
+
+        const href = anchor.getAttribute('href') || '';
+        const idMatch = href.match(/[?&;]id=(\d+)/);
+        if (!idMatch) continue;
+
+        const folderUrl = `${BASE_URL}/auth/dok_server/slozka.pl?id=${idMatch[1]}`;
+        result[subjectCode] = { subjectCode, displayName, folderUrl };
+    }
+    return result;
+}

--- a/src/api/syllabus.ts
+++ b/src/api/syllabus.ts
@@ -43,8 +43,10 @@ export async function findSubjectId(courseCode: string, subjectName?: string): P
         
         // Use the catalogue search (vyhledavani v katalogu)
         const searchUrl = `${BASE_URL}/auth/katalog/index.pl?search_text=${encodeURIComponent(query)};lang=cz`;
+        console.log(`[findSubjectId] Searching URL: ${searchUrl}`);
         const response = await fetchWithAuth(searchUrl);
         const html = await response.text();
+        console.log(`[findSubjectId] Search returned ${html.length} bytes.`);
         
         // Parse the HTML to find a link to syllabus that matches the code
         const parser = new DOMParser();
@@ -52,6 +54,9 @@ export async function findSubjectId(courseCode: string, subjectName?: string): P
         
         // Find rows or links containing the code/name and a link to syllabus
         const links = Array.from(doc.querySelectorAll('a[href*="syllabus.pl?predmet="]'));
+        
+        let bestMatchId: string | null = null;
+        let maxId = 0;
         
         for (const link of links) {
             const href = link.getAttribute('href') || '';
@@ -73,21 +78,28 @@ export async function findSubjectId(courseCode: string, subjectName?: string): P
             if (isMatch) {
                 const match = href.match(/predmet=(\d+)/);
                 if (match) {
+                    const idVal = parseInt(match[1], 10);
                     // Start of heuristics:
                     // If we have a code, let's double check if the link TEXT contains the code to reduce false positives
                     if (courseCode && text.includes(courseCode)) {
-                         return match[1];
+                         if (idVal > maxId) {
+                             maxId = idVal;
+                             bestMatchId = match[1];
+                         }
                     }
-                    
                     // If we searched by name and found a result, it's likely correct
-                    if (subjectName) {
-                        return match[1];
+                    else if (subjectName) {
+                         if (idVal > maxId) {
+                             maxId = idVal;
+                             bestMatchId = match[1];
+                         }
                     }
                 }
             }
         }
         
-        return null;
+        console.log(`[findSubjectId] bestMatchId for ${courseCode} (maxId=${maxId}) -> ${bestMatchId}`);
+        return bestMatchId;
         
     } catch (error) {
         console.error(`[findSubjectId] Error searching for ${courseCode}:`, error);

--- a/src/components/AppMain.tsx
+++ b/src/components/AppMain.tsx
@@ -13,7 +13,7 @@ interface AppMainProps {
     handlePrevWeek: () => void;
     handleNextWeek: () => void;
     handleToday: () => void;
-    handleOpenSubjectFromSearch: (courseCode: string, courseName?: string, courseId?: string) => void;
+    handleOpenSubjectFromSearch: (courseCode: string, courseName?: string, courseId?: string, facultyCode?: string, initialTab?: 'files' | 'stats' | 'syllabus' | 'classmates', isFulfilled?: boolean) => void;
     dateRangeLabel: string;
     searchPrefillRef?: React.MutableRefObject<((query: string) => void) | null>;
     setCurrentView?: (view: AppView) => void;

--- a/src/components/ErasmusPanel/ErasmusVerifyDot.tsx
+++ b/src/components/ErasmusPanel/ErasmusVerifyDot.tsx
@@ -165,6 +165,7 @@ export function ErasmusVerifyDot({ courseCode, courseName, optionId, plan: _plan
       const freshCache = useAppStore.getState().syllabuses.cache;
       const targetSyl = freshCache[targetBCode];
       const mendeluText = targetSyl ? buildMendeluText(targetSyl) : '';
+      console.log(`[ErasmusVerifyDot] Home syllabus for ${targetBCode}:`, mendeluText);
 
       const primaryMetadata = {
         credits: 0,

--- a/src/components/SubjectFileDrawer/DrawerHeader.tsx
+++ b/src/components/SubjectFileDrawer/DrawerHeader.tsx
@@ -8,6 +8,10 @@ import { HeaderTabs } from './Header/HeaderTabs';
 import { useTranslation } from '../../hooks/useTranslation';
 import { useTimeline } from '../../hooks/useTimeline';
 
+const NO_ID_DISABLED: string[] = ['files', 'classmates', 'cvicneTests'];
+const CLASSMATES_ONLY: string[] = ['classmates'];
+const EMPTY_TABS: string[] = [];
+
 function formatDate(ds: string, t: (k: string) => string) {
     if (!ds || ds.length !== 8) return '';
     const d = new Date(parseInt(ds.substring(0, 4)), parseInt(ds.substring(4, 6)) - 1, parseInt(ds.substring(6, 8)));
@@ -89,7 +93,7 @@ export function DrawerHeader({ lesson, courseId, courseInfo, subjectInfo, select
             <HeaderTabs
                 activeTab={activeTab}
                 onTabChange={onTabChange}
-                disabledTabs={!subjectInfo?.subjectId ? ['files', 'classmates', 'cvicneTests'] : (lesson && 'isFulfilled' in lesson && lesson.isFulfilled ? ['classmates'] : [])}
+                disabledTabs={!subjectInfo?.subjectId ? NO_ID_DISABLED : (lesson && 'isFulfilled' in lesson && lesson.isFulfilled ? CLASSMATES_ONLY : EMPTY_TABS)}
                 counts={tabCounts}
             />
         </div>

--- a/src/components/SubjectFileDrawer/DrawerHeader.tsx
+++ b/src/components/SubjectFileDrawer/DrawerHeader.tsx
@@ -89,7 +89,7 @@ export function DrawerHeader({ lesson, courseId, courseInfo, subjectInfo, select
             <HeaderTabs
                 activeTab={activeTab}
                 onTabChange={onTabChange}
-                disabledTabs={!subjectInfo?.subjectId ? ['files', 'classmates', 'cvicneTests'] : []}
+                disabledTabs={!subjectInfo?.subjectId ? ['files', 'classmates', 'cvicneTests'] : (lesson && 'isFulfilled' in lesson && lesson.isFulfilled ? ['classmates'] : [])}
                 counts={tabCounts}
             />
         </div>

--- a/src/components/SubjectsPanel/SemesterSection.tsx
+++ b/src/components/SubjectsPanel/SemesterSection.tsx
@@ -76,6 +76,9 @@ export function SemesterSection({ block, open, dimmed, failRates, zameraniLookup
   const state = getSemesterState(block);
   const cfg = stateConfig[state];
 
+  const titleMatch = block.title.match(/^(\d+\.\s*semestr)/i);
+  const cleanTitle = titleMatch ? titleMatch[1] : block.title.replace(/\s*\(dosud neaktivní\)/gi, '');
+
   const allSubjects = block.groups.flatMap(g => g.subjects);
   const fulfilledCount = allSubjects.filter(s => s.isFulfilled).length;
   const totalCount = allSubjects.length;
@@ -89,7 +92,7 @@ export function SemesterSection({ block, open, dimmed, failRates, zameraniLookup
         className={`w-full flex items-center gap-3 px-4 py-3 transition-colors ${open ? 'bg-base-200/30' : 'hover:bg-base-200/50'}`}
       >
         <div className={`w-1 h-8 rounded-full ${cfg.indicator} shrink-0`} />
-        <span className="text-sm font-semibold flex-1 text-left">{block.title.replace(/\s*\(dosud neaktivní\)/gi, '')}</span>
+        <span className="text-sm font-semibold flex-1 text-left">{cleanTitle}</span>
         {totalCredits > 0 && (state !== 'future' || open) && (
           <span className="text-[11px] text-base-content/40 shrink-0">{totalCredits} kr.</span>
         )}

--- a/src/components/SubjectsPanel/SemesterSection.tsx
+++ b/src/components/SubjectsPanel/SemesterSection.tsx
@@ -84,7 +84,7 @@ export function SemesterSection({ block, open, dimmed, failRates, zameraniLookup
   const isPast = state === 'past';
 
   return (
-    <div className={`rounded-lg border overflow-hidden transition-all ${open ? 'border-base-content/20 bg-base-100 shadow-sm' : cfg.border} ${dimmed ? 'opacity-40' : ''} ${block.isWholePlanPool ? 'border-dashed' : ''}`}>
+    <div className={`rounded-lg border overflow-hidden transition-all ${open ? 'border-base-content/20 bg-base-100 shadow-sm' : `${cfg.border} ${state === 'current' ? 'bg-primary/5 ring-1 ring-primary/15' : ''}`} ${dimmed ? 'opacity-40' : ''} ${block.isWholePlanPool ? 'border-dashed' : ''}`}>
       <button
         onClick={onToggle}
         className={`w-full flex items-center gap-3 px-4 py-3 transition-colors ${open ? 'bg-base-200/30' : 'hover:bg-base-200/50'}`}

--- a/src/components/SubjectsPanel/SemesterSection.tsx
+++ b/src/components/SubjectsPanel/SemesterSection.tsx
@@ -75,7 +75,6 @@ const stateConfig: Record<SemesterState, {
 export function SemesterSection({ block, open, dimmed, failRates, zameraniLookup, zameraniProgress, onToggle, onOpenSubject, onSearchSubject }: SemesterSectionProps) {
   const state = getSemesterState(block);
   const cfg = stateConfig[state];
-  const Icon = block.isWholePlanPool ? Layers : cfg.icon;
 
   const allSubjects = block.groups.flatMap(g => g.subjects);
   const fulfilledCount = allSubjects.filter(s => s.isFulfilled).length;
@@ -90,9 +89,8 @@ export function SemesterSection({ block, open, dimmed, failRates, zameraniLookup
         className={`w-full flex items-center gap-3 px-4 py-3 transition-colors ${open ? 'bg-base-200/30' : 'hover:bg-base-200/50'}`}
       >
         <div className={`w-1 h-8 rounded-full ${cfg.indicator} shrink-0`} />
-        <Icon className={`w-4 h-4 ${cfg.accent} shrink-0`} />
-        <span className="text-sm font-semibold flex-1 text-left">{block.title}</span>
-        {totalCredits > 0 && (
+        <span className="text-sm font-semibold flex-1 text-left">{block.title.replace(/\s*\(dosud neaktivní\)/gi, '')}</span>
+        {totalCredits > 0 && (state !== 'future' || open) && (
           <span className="text-[11px] text-base-content/40 shrink-0">{totalCredits} kr.</span>
         )}
         <span className={cfg.badgeCls}>

--- a/src/components/SubjectsPanel/SemesterSection.tsx
+++ b/src/components/SubjectsPanel/SemesterSection.tsx
@@ -13,7 +13,7 @@ interface SemesterSectionProps {
   zameraniLookup?: Map<string, Zamerani>;
   zameraniProgress?: Map<string, ZameraniProgress>;
   onToggle: () => void;
-  onOpenSubject: (courseCode: string, courseName: string, courseId: string, facultyCode?: string, initialTab?: string) => void;
+  onOpenSubject: (courseCode: string, courseName: string, courseId: string, facultyCode?: string, initialTab?: 'files' | 'stats' | 'syllabus' | 'classmates', isFulfilled?: boolean) => void;
   onSearchSubject: (name: string) => void;
 }
 

--- a/src/components/SubjectsPanel/SubjectRow.tsx
+++ b/src/components/SubjectsPanel/SubjectRow.tsx
@@ -9,7 +9,7 @@ interface SubjectRowProps {
   subject: SubjectStatus;
   compact?: boolean;
   failRate?: number | null;
-  onOpenSubject: (courseCode: string, courseName: string, courseId: string, facultyCode?: string, initialTab?: 'files' | 'stats' | 'syllabus' | 'classmates') => void;
+  onOpenSubject: (courseCode: string, courseName: string, courseId: string, facultyCode?: string, initialTab?: 'files' | 'stats' | 'syllabus' | 'classmates', isFulfilled?: boolean) => void;
   onSearchSubject: (name: string) => void;
   hideStatus?: boolean;
   zamerani?: Zamerani | null;
@@ -34,7 +34,7 @@ export function SubjectRow({ subject, compact, failRate, hideStatus, onOpenSubje
   const handleClick = () => {
     if (isZamerani) return; // pseudo-row, not openable
     if (hasId) {
-      onOpenSubject(subject.code, subject.name, subject.id);
+      onOpenSubject(subject.code, subject.name, subject.id, undefined, undefined, subject.isFulfilled);
     } else {
       onSearchSubject(subject.name);
     }

--- a/src/components/SubjectsPanel/SubjectsPanelHeader.tsx
+++ b/src/components/SubjectsPanel/SubjectsPanelHeader.tsx
@@ -80,19 +80,9 @@ export function SubjectsPanelHeader({ creditsAcquired, creditsRequired, studySta
           {plan?.title || t('subjects.title')}
         </h2>
         <div className="flex items-center gap-2 flex-wrap justify-end">
-          <a href={zadostUrl} target="_blank" rel="noopener noreferrer"
-            className="btn btn-ghost btn-sm px-2.5 text-base-content/50 hover:text-primary gap-1.5">
-            <span className="text-xs uppercase whitespace-nowrap">{t('subjects.zadost')}</span>
-            <ExternalLink size={14} />
-          </a>
           <a href={registrationsUrl} target="_blank" rel="noopener noreferrer"
             className="btn btn-ghost btn-sm px-2.5 text-base-content/50 hover:text-primary gap-1.5">
             <span className="text-xs uppercase whitespace-nowrap">{t('sidebar.registrations')}</span>
-            <ExternalLink size={14} />
-          </a>
-          <a href={planCheckUrl} target="_blank" rel="noopener noreferrer"
-            className="btn btn-ghost btn-sm px-2.5 text-base-content/50 hover:text-primary gap-1.5">
-            <span className="text-xs uppercase whitespace-nowrap">IS MENDELU</span>
             <ExternalLink size={14} />
           </a>
         </div>

--- a/src/components/SubjectsPanel/SubjectsPanelHeader.tsx
+++ b/src/components/SubjectsPanel/SubjectsPanelHeader.tsx
@@ -16,6 +16,7 @@ interface SubjectsPanelHeaderProps {
   studyStats: StudyStats | null;
   plan: StudyPlan | null;
   zameraniProgress?: Map<string, ZameraniProgress>;
+  enrolledCredits?: number;
 }
 
 type ProgressionLevel = 'safe' | 'warning' | 'danger';
@@ -44,7 +45,7 @@ const levelConfig = {
   danger: { bg: 'bg-error/8', border: 'border-error/20', text: 'text-error', bar: 'bg-error', Icon: ShieldAlert },
 };
 
-export function SubjectsPanelHeader({ creditsAcquired, creditsRequired, studyStats, plan, zameraniProgress }: SubjectsPanelHeaderProps) {
+export function SubjectsPanelHeader({ creditsAcquired, creditsRequired, studyStats, plan, zameraniProgress, enrolledCredits }: SubjectsPanelHeaderProps) {
   const { t, language } = useTranslation();
   const { params } = useUserParams();
   const studium = params?.studium || '';
@@ -132,9 +133,14 @@ export function SubjectsPanelHeader({ creditsAcquired, creditsRequired, studySta
               )}
             </span>
           )}
-          {studyStats && studyStats.gpaTotal > 0 && (
-            <span className="ml-auto">{t('subjects.gpa')}: {studyStats.weightedGpaTotal.toFixed(2)}</span>
-          )}
+          <span className="flex items-center gap-2 ml-auto">
+            {enrolledCredits != null && enrolledCredits > 0 && (
+              <span>{enrolledCredits} {t('subjects.enrolledCreditsLabel')}</span>
+            )}
+            {studyStats && studyStats.gpaTotal > 0 && (
+              <span>{t('subjects.gpa')}: {studyStats.weightedGpaTotal.toFixed(2)}</span>
+            )}
+          </span>
         </div>
 
         {zameraniMin !== undefined && zameraniMin > 0 && (

--- a/src/components/SubjectsPanel/index.tsx
+++ b/src/components/SubjectsPanel/index.tsx
@@ -21,7 +21,7 @@ function normalizeZameraniName(s: string): string {
 }
 
 interface SubjectsPanelProps {
-  onOpenSubject: (courseCode: string, courseName: string, courseId: string, facultyCode?: string, initialTab?: string) => void;
+  onOpenSubject: (courseCode: string, courseName: string, courseId: string, facultyCode?: string, initialTab?: 'files' | 'stats' | 'syllabus' | 'classmates', isFulfilled?: boolean) => void;
   onSearchSubject: (name: string) => void;
 }
 

--- a/src/components/SubjectsPanel/index.tsx
+++ b/src/components/SubjectsPanel/index.tsx
@@ -197,7 +197,6 @@ export function SubjectsPanel({ onOpenSubject, onSearchSubject }: SubjectsPanelP
       />
 
       <div className="px-4 pt-4 pb-4">
-        <h3 className="text-sm font-semibold text-base-content/50 mb-3">{t('subjects.studyPlan')}</h3>
         <div className="flex flex-col gap-2">
           {plan.blocks.map((block, bi) => (
             <div key={bi} ref={bi === firstCurrentIdx ? currentSemesterRef : undefined}>

--- a/src/components/SubjectsPanel/index.tsx
+++ b/src/components/SubjectsPanel/index.tsx
@@ -1,16 +1,17 @@
-import { useMemo, useState, useEffect } from 'react';
+import { useMemo, useState, useEffect, useRef, useCallback } from 'react';
 import { useStudyPlan } from '@/hooks/useStudyPlan';
 import { useAppStore } from '@/store/useAppStore';
 import { useTranslation } from '@/hooks/useTranslation';
-import { isElectiveGroup } from '@/utils/studyPlanUtils';
 import { SubjectsPanelHeader } from './SubjectsPanelHeader';
-import { SubjectRow } from './SubjectRow';
 import { computeFailRate } from './computeFailRate';
 import { SemesterSection } from './SemesterSection';
 import { SubjectsPanelSkeleton } from './SubjectsPanelSkeleton';
-import type { SubjectStatus, Zamerani } from '@/types/studyPlan';
+import { IndexedDBService } from '@/services/storage';
+import type { SubjectStatus, Zamerani, SemesterBlock } from '@/types/studyPlan';
 
-function normalizeZameraniName(s: string): string {
+const IDB_KEY = 'subjects_open_semesters';
+
+function normalizeZamereniName(s: string): string {
   return s
     .toLowerCase()
     .replace(/^zaměření:\s*/i, '')
@@ -18,6 +19,20 @@ function normalizeZameraniName(s: string): string {
     .normalize('NFD')
     .replace(/[\u0300-\u036f]/g, '')
     .trim();
+}
+
+// IS Mendelu sentinel: 999 credits = "uznaný předmět", don't sum.
+const isRealCredits = (c: number) => c < 999;
+
+function getSemesterState(block: SemesterBlock): 'past' | 'current' | 'future' {
+  const all = block.groups.flatMap(g => g.subjects);
+  if (all.length === 0) return 'future';
+  const hasEnrolled = all.some(s => s.isEnrolled);
+  if (hasEnrolled) return 'current';
+  const allFulfilled = all.every(s => s.isFulfilled);
+  if (allFulfilled) return 'past';
+  const hasFulfilled = all.some(s => s.isFulfilled);
+  return hasFulfilled ? 'past' : 'future';
 }
 
 interface SubjectsPanelProps {
@@ -42,19 +57,77 @@ export function SubjectsPanel({ onOpenSubject, onSearchSubject }: SubjectsPanelP
     if (codes.length > 0) useAppStore.getState().fetchSuccessRateBatch(codes);
   }, [plan]);
 
-  const [openSemester, setOpenSemester] = useState<number | null>(null);
+  // --- Multi-open semester state with IndexedDB persistence ---
+  const [openSemesters, setOpenSemesters] = useState<Set<number>>(new Set());
+  const [idbLoaded, setIdbLoaded] = useState(false);
+  const scrolledRef = useRef(false);
+  const currentSemesterRef = useRef<HTMLDivElement | null>(null);
 
-  const zameraniLookup = useMemo(() => {
+  // Compute current semester indices from plan
+  const currentSemesterIndices = useMemo(() => {
+    if (!plan) return new Set<number>();
+    const indices = new Set<number>();
+    plan.blocks.forEach((block, i) => {
+      if (getSemesterState(block) === 'current') indices.add(i);
+    });
+    return indices;
+  }, [plan]);
+
+  // Load persisted state from IndexedDB
+  useEffect(() => {
+    IndexedDBService.get('meta', IDB_KEY)
+      .then((stored) => {
+        if (Array.isArray(stored) && stored.length > 0) {
+          setOpenSemesters(new Set(stored as number[]));
+        } else {
+          // First visit: auto-open current semester(s)
+          setOpenSemesters(currentSemesterIndices);
+        }
+        setIdbLoaded(true);
+      })
+      .catch(() => {
+        setOpenSemesters(currentSemesterIndices);
+        setIdbLoaded(true);
+      });
+  }, [currentSemesterIndices]);
+
+  // Persist to IndexedDB on change (skip the initial load)
+  useEffect(() => {
+    if (!idbLoaded) return;
+    IndexedDBService.set('meta', IDB_KEY, Array.from(openSemesters)).catch(console.error);
+  }, [openSemesters, idbLoaded]);
+
+  // Auto-scroll to the first current semester on initial render
+  useEffect(() => {
+    if (scrolledRef.current || !idbLoaded || !plan) return;
+    if (currentSemesterIndices.size === 0) return;
+    scrolledRef.current = true;
+    // Defer scroll to allow the DOM to settle after expansion
+    requestAnimationFrame(() => {
+      currentSemesterRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    });
+  }, [idbLoaded, plan, currentSemesterIndices]);
+
+  const handleToggle = useCallback((index: number) => {
+    setOpenSemesters(prev => {
+      const next = new Set(prev);
+      if (next.has(index)) next.delete(index);
+      else next.add(index);
+      return next;
+    });
+  }, []);
+
+  const zamereniLookup = useMemo(() => {
     const map = new Map<string, Zamerani>();
     if (!plan?.zameranis) return map;
-    for (const z of plan.zameranis) map.set(normalizeZameraniName(z.name), z);
+    for (const z of plan.zameranis) map.set(normalizeZamereniName(z.name), z);
     return map;
   }, [plan]);
 
   // Pure reduce over existing data: for each zaměření, count how many of its
   // member subjects are currently enrolled or already fulfilled. Used both by
   // the header progress indicator and the zaměření card.
-  const zameraniProgress = useMemo(() => {
+  const zamereniProgress = useMemo(() => {
     const out = new Map<string, { enrolled: number; fulfilled: number; total: number; touched: boolean }>();
     if (!plan?.zameranis) return out;
     const subjectByCode = new Map<string, { isEnrolled: boolean; isFulfilled: boolean }>();
@@ -70,7 +143,7 @@ export function SubjectsPanel({ onOpenSubject, onSearchSubject }: SubjectsPanelP
         else if (hit.isEnrolled) enrolled++;
       }
       const touched = enrolled + fulfilled > 0;
-      out.set(normalizeZameraniName(z.name), { enrolled, fulfilled, total: z.subjects.length, touched });
+      out.set(normalizeZamereniName(z.name), { enrolled, fulfilled, total: z.subjects.length, touched });
     }
     return out;
   }, [plan]);
@@ -88,6 +161,20 @@ export function SubjectsPanel({ onOpenSubject, onSearchSubject }: SubjectsPanelP
     return map;
   }, [plan, successRates]);
 
+  // Compute total enrolled credits for the header
+  const enrolledCredits = useMemo(() => {
+    if (!plan) return 0;
+    let total = 0;
+    for (const block of plan.blocks) {
+      for (const group of block.groups) {
+        for (const s of group.subjects) {
+          if (s.isEnrolled && isRealCredits(s.credits)) total += s.credits;
+        }
+      }
+    }
+    return total;
+  }, [plan]);
+
   if (!plan) {
     if (!studyPlanLoaded || (!handshakeDone && !handshakeTimedOut) || isSyncing) {
       return <SubjectsPanelSkeleton />;
@@ -95,22 +182,8 @@ export function SubjectsPanel({ onOpenSubject, onSearchSubject }: SubjectsPanelP
     return <div className="flex items-center justify-center h-full text-base-content/50">{t('subjects.noData')}</div>;
   }
 
-  const enrolledCore: SubjectStatus[] = [];
-  const enrolledElective: SubjectStatus[] = [];
-  for (const block of plan.blocks) {
-    for (const group of block.groups) {
-      const elective = isElectiveGroup(group.name, block.title);
-      for (const s of group.subjects) {
-        if (!s.isEnrolled) continue;
-        if (elective) enrolledElective.push(s);
-        else enrolledCore.push(s);
-      }
-    }
-  }
-  const sortByFailRate = (a: SubjectStatus, b: SubjectStatus) => (failRates[b.code] ?? -1) - (failRates[a.code] ?? -1);
-  enrolledCore.sort(sortByFailRate);
-  enrolledElective.sort(sortByFailRate);
-  const hasEnrolledSubjects = enrolledCore.length > 0 || enrolledElective.length > 0;
+  // Determine the first current semester index for the scroll ref
+  const firstCurrentIdx = plan.blocks.findIndex((block) => getSemesterState(block) === 'current');
 
   return (
     <div className="h-full overflow-y-auto">
@@ -119,56 +192,27 @@ export function SubjectsPanel({ onOpenSubject, onSearchSubject }: SubjectsPanelP
         creditsRequired={plan.creditsRequired}
         studyStats={studyStats}
         plan={plan}
-        zameraniProgress={zameraniProgress}
+        zameraniProgress={zamereniProgress}
+        enrolledCredits={enrolledCredits}
       />
 
-      {hasEnrolledSubjects && (
-        <div className="px-4 pt-4 pb-2">
-          <div className="flex items-baseline justify-between mb-2">
-            <h3 className="text-sm font-semibold text-base-content/50">{t('subjects.enrolled')}</h3>
-            <span className="text-[11px] text-base-content/40">
-              {enrolledCore.filter(s => s.credits <= 50).reduce((a, s) => a + s.credits, 0) + enrolledElective.filter(s => s.credits <= 50).reduce((a, s) => a + s.credits, 0)} {t('subjects.enrolledCreditsLabel')}
-            </span>
-          </div>
-          <div className="rounded-lg border border-base-300 overflow-hidden">
-            {enrolledCore.length > 0 && (
-              <div className="p-1.5">
-                {enrolledElective.length > 0 && (
-                  <div className="text-[10px] text-base-content/40 font-semibold px-2 py-1 uppercase tracking-widest">{t('subjects.compulsory')}</div>
-                )}
-                {enrolledCore.map(s => (
-                  <SubjectRow key={s.code} subject={s} failRate={failRates[s.code]} hideStatus={true} onOpenSubject={onOpenSubject} onSearchSubject={onSearchSubject} />
-                ))}
-              </div>
-            )}
-            {enrolledElective.length > 0 && (
-              <div className={`p-1.5 ${enrolledCore.length > 0 ? 'border-t border-base-300' : ''}`}>
-                <div className="text-[10px] text-base-content/40 font-semibold px-2 py-1 uppercase tracking-widest">{t('subjects.elective')}</div>
-                {enrolledElective.map(s => (
-                  <SubjectRow key={s.code} subject={s} failRate={failRates[s.code]} hideStatus={true} onOpenSubject={onOpenSubject} onSearchSubject={onSearchSubject} />
-                ))}
-              </div>
-            )}
-          </div>
-        </div>
-      )}
-
-      <div className="px-4 pt-2 pb-4">
+      <div className="px-4 pt-4 pb-4">
         <h3 className="text-sm font-semibold text-base-content/50 mb-3">{t('subjects.studyPlan')}</h3>
         <div className="flex flex-col gap-2">
           {plan.blocks.map((block, bi) => (
-            <SemesterSection
-              key={bi}
-              block={block}
-              open={openSemester === bi}
-              dimmed={openSemester !== null && openSemester !== bi}
-              failRates={failRates}
-              zameraniLookup={zameraniLookup}
-              zameraniProgress={zameraniProgress}
-              onToggle={() => setOpenSemester(prev => prev === bi ? null : bi)}
-              onOpenSubject={onOpenSubject}
-              onSearchSubject={onSearchSubject}
-            />
+            <div key={bi} ref={bi === firstCurrentIdx ? currentSemesterRef : undefined}>
+              <SemesterSection
+                block={block}
+                open={openSemesters.has(bi)}
+                dimmed={openSemesters.size > 0 && !openSemesters.has(bi)}
+                failRates={failRates}
+                zamereniLookup={zamereniLookup}
+                zamereniProgress={zamereniProgress}
+                onToggle={() => handleToggle(bi)}
+                onOpenSubject={onOpenSubject}
+                onSearchSubject={onSearchSubject}
+              />
+            </div>
           ))}
         </div>
       </div>

--- a/src/hooks/useAppLogic.ts
+++ b/src/hooks/useAppLogic.ts
@@ -212,8 +212,8 @@ export function useAppLogic() {
         return () => window.removeEventListener('message', handle);
     }, []);
 
-    const handleOpenSubjectFromSearch = (courseCode: string, courseName?: string, courseId?: string, facultyCode?: string, initialTab?: 'files' | 'stats' | 'syllabus' | 'classmates') => {
-        setSelectedSubject({ courseCode, courseName: courseName || courseCode, courseId: courseId || '', id: `search-${courseCode}`, isFromSearch: true, facultyCode, initialTab });
+    const handleOpenSubjectFromSearch = (courseCode: string, courseName?: string, courseId?: string, facultyCode?: string, initialTab?: 'files' | 'stats' | 'syllabus' | 'classmates', isFulfilled?: boolean) => {
+        setSelectedSubject({ courseCode, courseName: courseName || courseCode, courseId: courseId || '', id: `search-${courseCode}`, isFromSearch: true, facultyCode, initialTab, isFulfilled });
     };
 
     return { currentDate, setCurrentDate, currentView, setCurrentView, selectedSubject, setSelectedSubject, weekNavCount, setWeekNavCount, isFeedbackOpen, setIsFeedbackOpen, openSettingsRef, searchPrefillRef, outlookSyncEnabled, handleOpenSubjectFromSearch };

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -332,7 +332,6 @@
   "subjects": {
     "title": "Moje předměty",
     "credits": "kreditů",
-    "enrolled": "Zapsané předměty",
     "studyPlan": "Studijní plán",
     "noData": "Žádná data o studijním plánu",
     "loading": "Načítání...",
@@ -351,8 +350,6 @@
     "progressionDanger": "Hrozí nesplnění!",
     "repeatWarning": "2. zápis",
     "gpa": "Průměr",
-    "compulsory": "Povinné",
-    "elective": "Volitelné",
     "enrolledCreditsLabel": "kr. zapsáno",
     "failRateLabel": "neúsp.",
     "needMore": "potřeba ještě {n}",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -330,7 +330,6 @@
   "subjects": {
     "title": "My Subjects",
     "credits": "credits",
-    "enrolled": "Enrolled Subjects",
     "studyPlan": "Study Plan",
     "noData": "No study plan data",
     "loading": "Loading...",
@@ -349,8 +348,6 @@
     "progressionDanger": "At risk!",
     "repeatWarning": "2nd enrollment",
     "gpa": "GPA",
-    "compulsory": "Compulsory",
-    "elective": "Elective",
     "enrolledCreditsLabel": "cr. enrolled",
     "failRateLabel": "fail",
     "needMore": "need {n} more",

--- a/src/injector/syncService.ts
+++ b/src/injector/syncService.ts
@@ -2,6 +2,7 @@ import pLimit from "p-limit";
 import { Messages } from "../types/messages";
 import { fetchDualLanguageExams } from "../api/exams";
 import { fetchDualLanguageSubjects } from "../api/subjects";
+import { fetchDualLanguagePastSubjects } from "../api/pastSubjects";
 import { fetchFilesFromFolder } from "../api/documents";
 import { fetchAssessments } from "../api/assessments";
 import { fetchDualLanguageStudyPlan } from "../api/studyPlan";
@@ -51,6 +52,10 @@ export async function syncAllData() {
             return plan;
         }) : Promise.resolve(null);
 
+        // Past-semester folders from doc server history — used to backfill
+        // SubjectInfo for fulfilled subjects that list.pl no longer returns.
+        const pastSubjectsPromise = fetchDualLanguagePastSubjects();
+
         const studyStatsPromise = (studium && userParams?.obdobi)
             ? fetchStudyStats(studium, userParams.obdobi).then(stats => {
                 if (stats) cachedData = { ...cachedData, studyStats: stats };
@@ -75,7 +80,7 @@ export async function syncAllData() {
             : Promise.resolve(null);
 
         // Phase 2b: Full schedule + exams in parallel (subjects/studyPlan/studyStats re-uses already-started promises)
-        const [fullSchedule, exams, subjects, studyPlan, studyStats, cvicneTests, odevzdavarnyResult] = await Promise.allSettled([
+        const [fullSchedule, exams, subjects, studyPlan, studyStats, cvicneTests, odevzdavarnyResult, pastSubjects] = await Promise.allSettled([
             fetchFullSemesterSchedule(),
             fetchDualLanguageExams(),
             subjectsPromise,
@@ -83,7 +88,19 @@ export async function syncAllData() {
             studyStatsPromise,
             cvicneTestsPromise,
             odevzdavarnyPromise,
+            pastSubjectsPromise,
         ]);
+
+        if (
+            subjects.status === "fulfilled" && subjects.value &&
+            pastSubjects.status === "fulfilled" && pastSubjects.value
+        ) {
+            mergePastSubjects(
+                subjects.value.subjects,
+                pastSubjects.value,
+                studyPlan.status === "fulfilled" ? studyPlan.value : null,
+            );
+        }
 
         cachedData = {
             ...cachedData,
@@ -169,6 +186,45 @@ async function syncSubjectDetails(subjectsValue: { data: Record<string, { folder
         await Promise.all(classmateTasks);
     } catch (e) {
         console.error('[syncClassmates] Error fetching group map:', e);
+    }
+}
+
+type PastFoldersByLang = Awaited<ReturnType<typeof fetchDualLanguagePastSubjects>>;
+type DualStudyPlan = Awaited<ReturnType<typeof fetchDualLanguageStudyPlan>>;
+
+function mergePastSubjects(
+    subjectsData: { data: Record<string, { displayName: string; fullName: string; nameCs?: string; nameEn?: string; subjectCode: string; subjectId?: string; folderUrl: string; fetchedAt: string }> },
+    past: PastFoldersByLang,
+    plan: DualStudyPlan | null,
+) {
+    const planById = new Map<string, string>();
+    const planNameCs = new Map<string, string>();
+    const planNameEn = new Map<string, string>();
+    if (plan) {
+        for (const block of plan.cz.blocks) for (const group of block.groups) for (const s of group.subjects) {
+            planById.set(s.code, s.id);
+            planNameCs.set(s.code, s.name);
+        }
+        for (const block of plan.en.blocks) for (const group of block.groups) for (const s of group.subjects) {
+            planNameEn.set(s.code, s.name);
+        }
+    }
+
+    const now = new Date().toISOString();
+    for (const [code, czFolder] of Object.entries(past.cz)) {
+        if (subjectsData.data[code]) continue;
+        const nameCs = planNameCs.get(code) ?? czFolder.displayName;
+        const nameEn = planNameEn.get(code) ?? past.en[code]?.displayName;
+        subjectsData.data[code] = {
+            subjectCode: code,
+            displayName: nameCs,
+            fullName: `${code} ${nameCs}`,
+            nameCs,
+            nameEn,
+            subjectId: planById.get(code),
+            folderUrl: czFolder.folderUrl,
+            fetchedAt: now,
+        };
     }
 }
 

--- a/src/injector/syncService.ts
+++ b/src/injector/syncService.ts
@@ -11,6 +11,7 @@ import { fetchSyllabus } from "../api/syllabus";
 import { syncCvicneTests } from "../services/sync/syncCvicneTests";
 import { syncOdevzdavarny } from "../services/sync/syncOdevzdavarny";
 import { fetchSeminarGroupIds, fetchClassmates } from "../api/classmates";
+import { mergePastSubjects } from "../services/sync/mergePastSubjects";
 
 import { getUserParams } from "../utils/userParams";
 import { fetchFullSemesterSchedule } from "./dataFetchers";
@@ -186,45 +187,6 @@ async function syncSubjectDetails(subjectsValue: { data: Record<string, { folder
         await Promise.all(classmateTasks);
     } catch (e) {
         console.error('[syncClassmates] Error fetching group map:', e);
-    }
-}
-
-type PastFoldersByLang = Awaited<ReturnType<typeof fetchDualLanguagePastSubjects>>;
-type DualStudyPlan = Awaited<ReturnType<typeof fetchDualLanguageStudyPlan>>;
-
-function mergePastSubjects(
-    subjectsData: { data: Record<string, { displayName: string; fullName: string; nameCs?: string; nameEn?: string; subjectCode: string; subjectId?: string; folderUrl: string; fetchedAt: string }> },
-    past: PastFoldersByLang,
-    plan: DualStudyPlan | null,
-) {
-    const planById = new Map<string, string>();
-    const planNameCs = new Map<string, string>();
-    const planNameEn = new Map<string, string>();
-    if (plan) {
-        for (const block of plan.cz.blocks) for (const group of block.groups) for (const s of group.subjects) {
-            planById.set(s.code, s.id);
-            planNameCs.set(s.code, s.name);
-        }
-        for (const block of plan.en.blocks) for (const group of block.groups) for (const s of group.subjects) {
-            planNameEn.set(s.code, s.name);
-        }
-    }
-
-    const now = new Date().toISOString();
-    for (const [code, czFolder] of Object.entries(past.cz)) {
-        if (subjectsData.data[code]) continue;
-        const nameCs = planNameCs.get(code) ?? czFolder.displayName;
-        const nameEn = planNameEn.get(code) ?? past.en[code]?.displayName;
-        subjectsData.data[code] = {
-            subjectCode: code,
-            displayName: nameCs,
-            fullName: `${code} ${nameCs}`,
-            nameCs,
-            nameEn,
-            subjectId: planById.get(code),
-            folderUrl: czFolder.folderUrl,
-            fetchedAt: now,
-        };
     }
 }
 

--- a/src/services/sync/mergePastSubjects.ts
+++ b/src/services/sync/mergePastSubjects.ts
@@ -1,0 +1,41 @@
+import type { fetchDualLanguagePastSubjects } from "../../api/pastSubjects";
+import type { fetchDualLanguageStudyPlan } from "../../api/studyPlan";
+
+type PastFoldersByLang = Awaited<ReturnType<typeof fetchDualLanguagePastSubjects>>;
+type DualStudyPlan = Awaited<ReturnType<typeof fetchDualLanguageStudyPlan>>;
+
+export function mergePastSubjects(
+    subjectsData: { data: Record<string, { displayName: string; fullName: string; nameCs?: string; nameEn?: string; subjectCode: string; subjectId?: string; folderUrl: string; fetchedAt: string }> },
+    past: PastFoldersByLang,
+    plan: DualStudyPlan | null,
+) {
+    const planById = new Map<string, string>();
+    const planNameCs = new Map<string, string>();
+    const planNameEn = new Map<string, string>();
+    if (plan) {
+        for (const block of plan.cz.blocks) for (const group of block.groups) for (const s of group.subjects) {
+            planById.set(s.code, s.id);
+            planNameCs.set(s.code, s.name);
+        }
+        for (const block of plan.en.blocks) for (const group of block.groups) for (const s of group.subjects) {
+            planNameEn.set(s.code, s.name);
+        }
+    }
+
+    const now = new Date().toISOString();
+    for (const [code, czFolder] of Object.entries(past.cz)) {
+        if (subjectsData.data[code]) continue;
+        const nameCs = planNameCs.get(code) ?? czFolder.displayName;
+        const nameEn = planNameEn.get(code) ?? past.en[code]?.displayName;
+        subjectsData.data[code] = {
+            subjectCode: code,
+            displayName: nameCs,
+            fullName: `${code} ${nameCs}`,
+            nameCs,
+            nameEn,
+            subjectId: planById.get(code),
+            folderUrl: czFolder.folderUrl,
+            fetchedAt: now,
+        };
+    }
+}

--- a/src/services/sync/syncSyllabus.ts
+++ b/src/services/sync/syncSyllabus.ts
@@ -44,7 +44,9 @@ export async function fetchAndCacheSingleSyllabus(
 ): Promise<SyllabusRequirements | undefined> {
     let activeId = courseId;
     if (!activeId) {
+        console.log(`[fetchAndCacheSingleSyllabus] finding subject id for ${courseCode}...`);
         activeId = await findSubjectId(courseCode, subjectName) || undefined;
+        console.log(`[fetchAndCacheSingleSyllabus] found activeId: ${activeId}`);
     }
 
     if (!activeId) {
@@ -56,6 +58,7 @@ export async function fetchAndCacheSingleSyllabus(
         fetchSyllabus(activeId, 'en')
     ]);
 
+    console.log(`[fetchAndCacheSingleSyllabus] fetch activeId: ${activeId} complete.`);
     await IndexedDBService.set('syllabuses', courseCode, {
         cz: czSyllabus,
         en: enSyllabus

--- a/src/store/slices/createSyllabusSlice.ts
+++ b/src/store/slices/createSyllabusSlice.ts
@@ -3,7 +3,7 @@ import { IndexedDBService } from '../../services/storage';
 import { fetchAndCacheSingleSyllabus } from '../../services/sync/syncSyllabus';
 import type { SyllabusRequirements } from '../../types/documents';
 
-const SYLLABUS_VERSION = 3; // v3: added objectivesText + contentText
+const SYLLABUS_VERSION = 4; // v4: force fetch to ensure we get newest predmetId
 
 export const createSyllabusSlice: AppSlice<SyllabusSlice> = (set, get) => ({
   syllabuses: {

--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -8,4 +8,5 @@ export interface SelectedSubject {
     isFromSearch?: boolean;
     facultyCode?: string;
     initialTab?: 'files' | 'stats' | 'syllabus' | 'classmates';
+    isFulfilled?: boolean;
 }


### PR DESCRIPTION
## Summary

Removes the redundant "Zapsané předměty" (enrolled subjects) card from the SubjectsPanel and replaces it with auto-expanding current semester behavior.

### Problem
The enrolled subjects section duplicated subjects already present in the current semester's `SemesterSection`, creating:
- **Cognitive overhead**: same data in two places, two formats
- **Context loss**: subjects shown without semester context
- **Maintenance liability**: ~55 lines of logic that had to stay in sync with `SemesterSection`

### Changes
- **Delete** the entire enrolled subjects card and its extraction/sorting/rendering logic
- **Multi-open semesters**: switch from `number | null` to `Set<number>` — multiple semesters can be open simultaneously
- **IndexedDB persistence**: open/closed state saved under `meta → subjects_open_semesters`
  - First visit: auto-opens current semester(s)
  - Subsequent visits: restores from IDB
- **Enrolled credits** counter moved into `SubjectsPanelHeader` progression card
- **Visual enhancement**: current semester gets a subtle `bg-primary/5 ring-1 ring-primary/15` highlight when collapsed
- **Auto-scroll** to current semester on initial render
- **i18n cleanup**: removed 3 unused keys (`subjects.enrolled`, `subjects.compulsory`, `subjects.elective`)

### Files Changed
| File | Change |
|------|--------|
| `SubjectsPanel/index.tsx` | Rewrote — removed enrolled section, added multi-open + IDB persistence + auto-scroll |
| `SubjectsPanelHeader.tsx` | Added `enrolledCredits` prop + display |
| `SemesterSection.tsx` | Added current-semester highlight styling |
| `cs.json` / `en.json` | Removed 3 unused i18n keys |

### Verification
- ✅ `tsc --noEmit` — clean
- ✅ `npm run build` — 4.95 MB, 9s