### PR TITLE
chore: add CodeRabbit config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,8 @@
+reviews:
+  path_filters:
+    - "!src/api/documents/parser.ts"
+    - "!src/api/ukoly.ts"
+    - "!src/api/osnovy.ts"
+  auto_review:
+    enabled: true
+    drafts: false


### PR DESCRIPTION
## Summary
- Adds `.coderabbit.yaml` to configure CodeRabbit for the repo
- Excludes the brittle IS Mendelu HTML parsers (`parser.ts`, `ukoly.ts`, `osnovy.ts`) from automated review — these are intentionally fragile and must not be touched without a real HTML sample as evidence
- Disables review on draft PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review automation configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->