### PR TITLE
feat: menza spending statistics

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -3,6 +3,7 @@ reviews:
     - "!src/api/documents/parser.ts"
     - "!src/api/ukoly.ts"
     - "!src/api/osnovy.ts"
+    - "!src/utils/parsers/**/*.ts"
   auto_review:
     enabled: true
     drafts: false

--- a/src/api/iskam/__tests__/volneKapacity.test.ts
+++ b/src/api/iskam/__tests__/volneKapacity.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { academicYearDates } from '../volneKapacity';
+
+afterEach(() => { vi.useRealTimers(); });
+
+describe('academicYearDates', () => {
+    it('returns current academic year for January', () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date(2026, 0, 15));
+        const { od, doo } = academicYearDates();
+        expect(od).toBe('01.09.2025');
+        expect(doo).toBe('30.06.2026');
+    });
+
+    it('returns current academic year for August', () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date(2026, 7, 1));
+        const { od, doo } = academicYearDates();
+        expect(od).toBe('01.09.2025');
+        expect(doo).toBe('30.06.2026');
+    });
+
+    it('returns new academic year for September', () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date(2026, 8, 1));
+        const { od, doo } = academicYearDates();
+        expect(od).toBe('01.09.2026');
+        expect(doo).toBe('30.06.2027');
+    });
+
+    it('returns new academic year for December', () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date(2026, 11, 15));
+        const { od, doo } = academicYearDates();
+        expect(od).toBe('01.09.2026');
+        expect(doo).toBe('30.06.2027');
+    });
+});

--- a/src/api/iskam/__tests__/volneKapacity.test.ts
+++ b/src/api/iskam/__tests__/volneKapacity.test.ts
@@ -4,35 +4,35 @@ import { academicYearDates } from '../volneKapacity';
 afterEach(() => { vi.useRealTimers(); });
 
 describe('academicYearDates', () => {
-    it('returns current academic year for January', () => {
+    it('returns next academic year for January', () => {
         vi.useFakeTimers();
         vi.setSystemTime(new Date(2026, 0, 15));
         const { od, doo } = academicYearDates();
-        expect(od).toBe('01.09.2025');
-        expect(doo).toBe('30.06.2026');
+        expect(od).toBe('01.09.2026');
+        expect(doo).toBe('30.06.2027');
     });
 
-    it('returns current academic year for August', () => {
+    it('returns next academic year for August', () => {
         vi.useFakeTimers();
         vi.setSystemTime(new Date(2026, 7, 1));
         const { od, doo } = academicYearDates();
-        expect(od).toBe('01.09.2025');
-        expect(doo).toBe('30.06.2026');
+        expect(od).toBe('01.09.2026');
+        expect(doo).toBe('30.06.2027');
     });
 
-    it('returns new academic year for September', () => {
+    it('returns next academic year for September', () => {
         vi.useFakeTimers();
         vi.setSystemTime(new Date(2026, 8, 1));
         const { od, doo } = academicYearDates();
-        expect(od).toBe('01.09.2026');
-        expect(doo).toBe('30.06.2027');
+        expect(od).toBe('01.09.2027');
+        expect(doo).toBe('30.06.2028');
     });
 
-    it('returns new academic year for December', () => {
+    it('returns next academic year for December', () => {
         vi.useFakeTimers();
         vi.setSystemTime(new Date(2026, 11, 15));
         const { od, doo } = academicYearDates();
-        expect(od).toBe('01.09.2026');
-        expect(doo).toBe('30.06.2027');
+        expect(od).toBe('01.09.2027');
+        expect(doo).toBe('30.06.2028');
     });
 });

--- a/src/api/iskam/index.ts
+++ b/src/api/iskam/index.ts
@@ -2,6 +2,7 @@ import { fetchKonta } from './konta';
 import { fetchUbytovani } from './ubytovani';
 import { fetchProfileAndPayments } from './profile';
 import { fetchReservations } from './reservations';
+import { fetchKontaTransactions } from './kontaTransactions';
 import type { IskamData, KontoRow } from '../../types/iskam';
 
 function mergeKontaLanguages(cz: KontoRow[], en: KontoRow[]): KontoRow[] {
@@ -19,15 +20,21 @@ export async function fetchDualLanguageIskam(): Promise<IskamData> {
     const { profile, pendingPayments } = await fetchProfileAndPayments();
     const reservations = await fetchReservations();
 
+    const stravKonto = czKonta.find(k => /stravov/i.test(k.name));
+    const stravovaniTransactions = stravKonto?.transactionsHref
+        ? await fetchKontaTransactions(stravKonto.transactionsHref).catch(() => [])
+        : [];
+
     return {
         konta: enKonta.length === czKonta.length ? mergeKontaLanguages(czKonta, enKonta) : czKonta,
         ubytovani,
         profile: profile ?? undefined,
         reservations,
         pendingPayments,
+        stravovaniTransactions,
         syncedAt: Date.now(),
     };
 }
 
-export { fetchKonta, fetchUbytovani, fetchProfileAndPayments, fetchReservations };
+export { fetchKonta, fetchUbytovani, fetchProfileAndPayments, fetchReservations, fetchKontaTransactions };
 export { IskamAuthError } from './errors';

--- a/src/api/iskam/index.ts
+++ b/src/api/iskam/index.ts
@@ -3,7 +3,13 @@ import { fetchUbytovani } from './ubytovani';
 import { fetchProfileAndPayments } from './profile';
 import { fetchReservations } from './reservations';
 import { fetchKontaTransactions } from './kontaTransactions';
-import type { IskamData, KontoRow } from '../../types/iskam';
+import type { IskamData, KontaTransaction, KontoRow } from '../../types/iskam';
+
+const NON_FOOD_RE = [/^Ubytování/i, /^Tisky/i];
+
+function isFoodTx(tx: KontaTransaction): boolean {
+    return tx.type === 'Úhrada' && !NON_FOOD_RE.some(re => re.test(tx.description));
+}
 
 function mergeKontaLanguages(cz: KontoRow[], en: KontoRow[]): KontoRow[] {
     return cz.map((row, idx) => ({
@@ -20,10 +26,20 @@ export async function fetchDualLanguageIskam(): Promise<IskamData> {
     const { profile, pendingPayments } = await fetchProfileAndPayments();
     const reservations = await fetchReservations();
 
+    const mainKonto = czKonta.find(k => /hlavní|main/i.test(k.name));
     const stravKonto = czKonta.find(k => /stravov/i.test(k.name));
-    const stravovaniTransactions = stravKonto?.transactionsHref
+
+    const mainTxs = mainKonto?.transactionsHref
+        ? await fetchKontaTransactions(mainKonto.transactionsHref).catch(() => [])
+        : [];
+    const stravTxs = stravKonto?.transactionsHref
         ? await fetchKontaTransactions(stravKonto.transactionsHref).catch(() => [])
         : [];
+
+    // HLA needs non-food filtered out; STRAVOVACÍ is food-only but filter anyway for consistency.
+    // Sort merged result newest-first by datetime string (ISO-ish, same locale so lexicographic works after parsing).
+    const foodTransactions = [...mainTxs.filter(isFoodTx), ...stravTxs.filter(isFoodTx)]
+        .sort((a, b) => b.datetime.localeCompare(a.datetime));
 
     return {
         konta: enKonta.length === czKonta.length ? mergeKontaLanguages(czKonta, enKonta) : czKonta,
@@ -31,7 +47,7 @@ export async function fetchDualLanguageIskam(): Promise<IskamData> {
         profile: profile ?? undefined,
         reservations,
         pendingPayments,
-        stravovaniTransactions,
+        foodTransactions,
         syncedAt: Date.now(),
     };
 }

--- a/src/api/iskam/index.ts
+++ b/src/api/iskam/index.ts
@@ -7,6 +7,12 @@ import type { IskamData, KontaTransaction, KontoRow } from '../../types/iskam';
 
 const NON_FOOD_RE = [/^Ubytování/i, /^Tisky/i];
 
+function czDatetimeToMs(dt: string): number {
+    const [datePart, timePart = '00:00:00'] = dt.split(' ');
+    const [d, m, y] = datePart.split('.');
+    return new Date(`${y}-${m.padStart(2, '0')}-${d.padStart(2, '0')}T${timePart}`).getTime();
+}
+
 function isFoodTx(tx: KontaTransaction): boolean {
     return tx.type === 'Úhrada' && !NON_FOOD_RE.some(re => re.test(tx.description));
 }
@@ -29,17 +35,19 @@ export async function fetchDualLanguageIskam(): Promise<IskamData> {
     const mainKonto = czKonta.find(k => /hlavní|main/i.test(k.name));
     const stravKonto = czKonta.find(k => /stravov/i.test(k.name));
 
-    const mainTxs = mainKonto?.transactionsHref
-        ? await fetchKontaTransactions(mainKonto.transactionsHref).catch(() => [])
-        : [];
-    const stravTxs = stravKonto?.transactionsHref
-        ? await fetchKontaTransactions(stravKonto.transactionsHref).catch(() => [])
-        : [];
+    const [mainTxs, stravTxs] = await Promise.all([
+        mainKonto?.transactionsHref
+            ? fetchKontaTransactions(mainKonto.transactionsHref).catch(() => [])
+            : Promise.resolve([]),
+        stravKonto?.transactionsHref
+            ? fetchKontaTransactions(stravKonto.transactionsHref).catch(() => [])
+            : Promise.resolve([]),
+    ]);
 
     // HLA needs non-food filtered out; STRAVOVACÍ is food-only but filter anyway for consistency.
-    // Sort merged result newest-first by datetime string (ISO-ish, same locale so lexicographic works after parsing).
+    // datetime is Czech format "27.4.2026 12:48:02" — not lexicographically sortable, parse to ms.
     const foodTransactions = [...mainTxs.filter(isFoodTx), ...stravTxs.filter(isFoodTx)]
-        .sort((a, b) => b.datetime.localeCompare(a.datetime));
+        .sort((a, b) => czDatetimeToMs(b.datetime) - czDatetimeToMs(a.datetime));
 
     return {
         konta: enKonta.length === czKonta.length ? mergeKontaLanguages(czKonta, enKonta) : czKonta,

--- a/src/api/iskam/kontaTransactions.ts
+++ b/src/api/iskam/kontaTransactions.ts
@@ -1,0 +1,8 @@
+import { parseKontaTransactions } from '../../utils/parsers/iskam/kontaTransactions';
+import type { KontaTransaction } from '../../types/iskam';
+import { fetchIskam } from './client';
+
+export async function fetchKontaTransactions(href: string): Promise<KontaTransaction[]> {
+    const html = await fetchIskam(href, 'cz');
+    return parseKontaTransactions(html);
+}

--- a/src/api/iskam/profile.ts
+++ b/src/api/iskam/profile.ts
@@ -4,11 +4,19 @@ import { parsePendingPayments } from '../../utils/parsers/iskam/pendingPayments'
 import type { IskamProfile, PendingPayment } from '../../types/iskam';
 
 export async function fetchProfileAndPayments(): Promise<{ profile: IskamProfile | null; pendingPayments: PendingPayment[] }> {
+    let html: string;
     try {
-        const html = await requestIskam('/InformaceOKlientovi');
-        return { profile: parseProfile(html), pendingPayments: parsePendingPayments(html) };
+        html = await requestIskam('/InformaceOKlientovi');
     } catch (e) {
-        console.warn('[reIS:iskam] fetchProfile failed', e);
+        console.warn('[reIS:iskam] fetchProfileAndPayments network failed', e);
         return { profile: null, pendingPayments: [] };
     }
+
+    let profile: IskamProfile | null = null;
+    try { profile = parseProfile(html); } catch { /* non-critical */ }
+
+    let pendingPayments: PendingPayment[] = [];
+    try { pendingPayments = parsePendingPayments(html); } catch { /* non-critical */ }
+
+    return { profile, pendingPayments };
 }

--- a/src/api/iskam/profile.ts
+++ b/src/api/iskam/profile.ts
@@ -13,10 +13,10 @@ export async function fetchProfileAndPayments(): Promise<{ profile: IskamProfile
     }
 
     let profile: IskamProfile | null = null;
-    try { profile = parseProfile(html); } catch { /* non-critical */ }
+    try { profile = parseProfile(html); } catch (e) { console.warn('[reIS:iskam] parseProfile failed', e); }
 
     let pendingPayments: PendingPayment[] = [];
-    try { pendingPayments = parsePendingPayments(html); } catch { /* non-critical */ }
+    try { pendingPayments = parsePendingPayments(html); } catch (e) { console.warn('[reIS:iskam] parsePendingPayments failed', e); }
 
     return { profile, pendingPayments };
 }

--- a/src/api/iskam/volneKapacity.ts
+++ b/src/api/iskam/volneKapacity.ts
@@ -16,7 +16,7 @@ export const ISKAM_CAMPUSES: IskamCampus[] = [
 
 export function academicYearDates(): { od: string; doo: string } {
     const now = new Date();
-    const startYear = now.getMonth() < 8 ? now.getFullYear() - 1 : now.getFullYear();
+    const startYear = now.getMonth() < 8 ? now.getFullYear() : now.getFullYear() + 1;
     return { od: `01.09.${startYear}`, doo: `30.06.${startYear + 1}` };
 }
 

--- a/src/api/iskam/volneKapacity.ts
+++ b/src/api/iskam/volneKapacity.ts
@@ -16,19 +16,12 @@ export const ISKAM_CAMPUSES: IskamCampus[] = [
 
 export function academicYearDates(): { od: string; doo: string } {
     const now = new Date();
-    const y = now.getMonth() < 8 ? now.getFullYear() : now.getFullYear() + 1;
-    return { od: `01.09.${y}`, doo: `30.06.${y + 1}` };
+    const startYear = now.getMonth() < 8 ? now.getFullYear() - 1 : now.getFullYear();
+    return { od: `01.09.${startYear}`, doo: `30.06.${startYear + 1}` };
 }
 
-
 export async function fetchVolneKapacityBlock(blockId: string, od: string, doo: string): Promise<VolneKapacityRoom[]> {
-    console.log('[reIS:iskam] fetchVolneKapacityBlock', { blockId, od, doo });
-
     const body = new URLSearchParams({ datumOd: od, datumDo: doo, selBlok: blockId, buttSeek: 'Zobrazit' });
     const html = await postIskam('/VolneKapacity', body);
-    const rooms = parseVolneKapacity(html);
-    console.log('[reIS:iskam] fetchVolneKapacityBlock parsed blockId=' + blockId + ' rooms=' + rooms.length);
-    const tableStart = html.indexOf('<table');
-    console.log('[reIS:iskam] table html:', tableStart >= 0 ? html.slice(tableStart, tableStart + 800) : 'NO TABLE FOUND');
-    return rooms;
+    return parseVolneKapacity(html);
 }

--- a/src/components/IskamPanel/IskamPanel.tsx
+++ b/src/components/IskamPanel/IskamPanel.tsx
@@ -46,7 +46,9 @@ export function IskamPanel() {
         k.name.toLowerCase().includes('main')
     );
 
-    const sortedContracts = [...data.ubytovani].sort((a, b) => contractOrder(a) - contractOrder(b));
+    const sortedContracts = [...data.ubytovani]
+        .filter(row => contractOrder(row) !== 2)
+        .sort((a, b) => contractOrder(a) - contractOrder(b));
 
     const todayMidnight = new Date();
     todayMidnight.setHours(0, 0, 0, 0);

--- a/src/components/IskamPanel/IskamPanel.tsx
+++ b/src/components/IskamPanel/IskamPanel.tsx
@@ -86,7 +86,7 @@ export function IskamPanel() {
             )}
 
             {/* 2. MENZA SPENDING */}
-            {data.foodTransactions.length > 0 && (
+            {data.konta.some(k => /stravov/i.test(k.name)) && (
                 <MenzaSpendingSection transactions={data.foodTransactions} language={language} />
             )}
 

--- a/src/components/IskamPanel/IskamPanel.tsx
+++ b/src/components/IskamPanel/IskamPanel.tsx
@@ -85,8 +85,8 @@ export function IskamPanel() {
             )}
 
             {/* 2. MENZA SPENDING */}
-            {data.stravovaniTransactions.length > 0 && (
-                <MenzaSpendingSection transactions={data.stravovaniTransactions} language={language} />
+            {data.foodTransactions.length > 0 && (
+                <MenzaSpendingSection transactions={data.foodTransactions} language={language} />
             )}
 
             {/* 3. PENDING PAYMENTS */}

--- a/src/components/IskamPanel/IskamPanel.tsx
+++ b/src/components/IskamPanel/IskamPanel.tsx
@@ -47,6 +47,7 @@ export function IskamPanel() {
         k.name.toLowerCase().includes('main')
     );
 
+    // contractOrder returns 2 for expired or date-unparseable contracts — hide them.
     const sortedContracts = [...data.ubytovani]
         .filter(row => contractOrder(row) !== 2)
         .sort((a, b) => contractOrder(a) - contractOrder(b));

--- a/src/components/IskamPanel/IskamPanel.tsx
+++ b/src/components/IskamPanel/IskamPanel.tsx
@@ -10,6 +10,7 @@ import { isStale, parseCzechDate, daysUntil } from './freshness';
 import { ISKAM_BASE } from '../../api/iskam/client';
 import { VolneKapacitySection } from './VolneKapacitySection';
 import { PendingPaymentsSection } from './PendingPaymentsSection';
+import { MenzaSpendingSection } from './MenzaSpendingSection';
 import type { UbytovaniRow } from '../../types/iskam';
 
 function contractOrder(row: UbytovaniRow): number {
@@ -83,10 +84,15 @@ export function IskamPanel() {
                 </div>
             )}
 
-            {/* 2. PENDING PAYMENTS */}
+            {/* 2. MENZA SPENDING */}
+            {data.stravovaniTransactions.length > 0 && (
+                <MenzaSpendingSection transactions={data.stravovaniTransactions} language={language} />
+            )}
+
+            {/* 3. PENDING PAYMENTS */}
             <PendingPaymentsSection payments={data.pendingPayments ?? []} language={language} />
 
-            {/* 3. CONTRACTS */}
+            {/* 4. CONTRACTS */}
             {sortedContracts.length > 0 && (
                 <section className="flex flex-col gap-2">
                     <h3 className="text-xs font-semibold text-base-content/50 uppercase tracking-widest px-1">
@@ -112,7 +118,7 @@ export function IskamPanel() {
                 </section>
             )}
 
-            {/* 4. FREE ROOMS */}
+            {/* 5. FREE ROOMS */}
             <VolneKapacitySection language={language} />
         </div>
     );

--- a/src/components/IskamPanel/KontoCard.tsx
+++ b/src/components/IskamPanel/KontoCard.tsx
@@ -25,7 +25,6 @@ export function KontoCard({ row, language, dimmed, variant = 'default' }: KontoC
 
     if (variant === 'hero') {
         const topUpUrl = row.topUpHref ? `${ISKAM_BASE}${row.topUpHref}` : null;
-        const roundedBalance = `${Math.round(row.balance).toLocaleString('cs-CZ')} Kč`;
 
         return (
             <div className={`card bg-base-100 shadow-sm border border-primary/20 ${dimmed ? 'opacity-60' : ''}`}>
@@ -33,7 +32,7 @@ export function KontoCard({ row, language, dimmed, variant = 'default' }: KontoC
                     <Wallet size={18} className="text-primary shrink-0" />
                     <div className="flex flex-col min-w-0">
                         <span className="text-xs font-medium uppercase tracking-wide text-base-content/50">{displayName}</span>
-                        <span className="text-2xl font-bold text-base-content leading-tight">{roundedBalance}</span>
+                        <span className="text-2xl font-bold text-base-content leading-tight">{row.balanceText}</span>
                     </div>
                     {topUpUrl && (
                         <a

--- a/src/components/IskamPanel/MenzaSpendingSection.tsx
+++ b/src/components/IskamPanel/MenzaSpendingSection.tsx
@@ -25,15 +25,18 @@ function isInCurrentWeek(d: Date): boolean {
     return d >= monday && d <= sunday;
 }
 
+function isInCurrentMonth(d: Date, today: Date): boolean {
+    return d.getFullYear() === today.getFullYear() && d.getMonth() === today.getMonth();
+}
+
 function filterByPeriod(transactions: KontaTransaction[], period: Period): KontaTransaction[] {
     const today = new Date();
     return transactions.filter(tx => {
-        if (tx.type !== 'Úhrada') return false;
         const d = parseSettledDate(tx.settledDate);
         if (!d) return false;
         if (period === 'day') return isSameDay(d, today);
         if (period === 'week') return isInCurrentWeek(d);
-        return true;
+        return isInCurrentMonth(d, today);
     });
 }
 
@@ -95,6 +98,7 @@ export function MenzaSpendingSection({ transactions, language }: Props) {
     const today = new Date();
     const elapsedDays = today.getDate();
     const daysInMonth = new Date(today.getFullYear(), today.getMonth() + 1, 0).getDate();
+    const visitDays = groups.length;
     const avgPerDay = elapsedDays > 0 ? Math.round(total / elapsedDays) : 0;
     const monthProgress = Math.round((elapsedDays / daysInMonth) * 100);
 
@@ -116,7 +120,7 @@ export function MenzaSpendingSection({ transactions, language }: Props) {
                         {periods.map(p => (
                             <button
                                 key={p}
-                                className={`btn btn-sm join-item flex-1 ${period === p ? 'btn-primary' : 'btn-ghost'}`}
+                                className={`btn btn-sm join-item flex-1 border-none ${period === p ? 'btn-primary' : 'btn-ghost'}`}
                                 onClick={() => setPeriod(p)}
                             >
                                 {periodLabels[p]}
@@ -133,9 +137,8 @@ export function MenzaSpendingSection({ transactions, language }: Props) {
                         <>
                             <progress className="progress progress-primary w-full h-1.5" value={monthProgress} max={100} />
                             <span className="text-xs text-base-content/40 -mt-2">
-                                {t('iskam.spending.days', { n: elapsedDays })}
-                                {' · '}
-                                {t('iskam.spending.avgPerDay', { amount: avgPerDay })}
+                                {t('iskam.spending.visits', { n: visitDays })}
+                                {visitDays > 0 && <>{' · '}{t('iskam.spending.avgPerVisit', { amount: avgPerDay })}</>}
                             </span>
                         </>
                     )}

--- a/src/components/IskamPanel/MenzaSpendingSection.tsx
+++ b/src/components/IskamPanel/MenzaSpendingSection.tsx
@@ -5,9 +5,12 @@ import { createIskamT, type IskamLanguage } from '../../i18n/iskamTranslate';
 type Period = 'day' | 'week' | 'month';
 
 function parseSettledDate(s: string): Date | null {
-    const [d, m, y] = s.split('.');
-    const date = new Date(Number(y), Number(m) - 1, Number(d));
-    return isNaN(date.getTime()) ? null : date;
+    const parts = s.split('.');
+    if (parts.length !== 3) return null;
+    const [d, m, y] = parts.map(Number);
+    const date = new Date(y, m - 1, d);
+    if (date.getFullYear() !== y || date.getMonth() !== m - 1 || date.getDate() !== d) return null;
+    return date;
 }
 
 function isSameDay(a: Date, b: Date): boolean {
@@ -32,6 +35,7 @@ function isInCurrentMonth(d: Date, today: Date): boolean {
 function filterByPeriod(transactions: KontaTransaction[], period: Period): KontaTransaction[] {
     const today = new Date();
     return transactions.filter(tx => {
+        if (tx.payment === null) return false;
         const d = parseSettledDate(tx.settledDate);
         if (!d) return false;
         if (period === 'day') return isSameDay(d, today);

--- a/src/components/IskamPanel/MenzaSpendingSection.tsx
+++ b/src/components/IskamPanel/MenzaSpendingSection.tsx
@@ -100,12 +100,8 @@ export function MenzaSpendingSection({ transactions, language }: Props) {
 
     const monthStats = useMemo(() => {
         if (period !== 'month') return null;
-        const today = new Date();
-        const elapsedDays = today.getDate();
-        const daysInMonth = new Date(today.getFullYear(), today.getMonth() + 1, 0).getDate();
         const visitDays = groups.length;
         return {
-            progress: Math.round((elapsedDays / daysInMonth) * 100),
             visitDays,
             avgPerVisit: visitDays > 0 ? Math.round(total / visitDays) : 0,
         };
@@ -143,13 +139,10 @@ export function MenzaSpendingSection({ transactions, language }: Props) {
                     </div>
 
                     {monthStats && (
-                        <>
-                            <progress className="progress progress-primary w-full h-1.5" value={monthStats.progress} max={100} />
-                            <span className="text-xs text-base-content/40 -mt-2">
-                                {t('iskam.spending.visits', { n: monthStats.visitDays })}
-                                {monthStats.visitDays > 0 && <>{' · '}{t('iskam.spending.avgPerVisit', { amount: monthStats.avgPerVisit })}</>}
-                            </span>
-                        </>
+                        <span className="text-xs text-base-content/40">
+                            {t('iskam.spending.visits', { n: monthStats.visitDays })}
+                            {monthStats.visitDays > 0 && <>{' · '}{t('iskam.spending.avgPerVisit', { amount: monthStats.avgPerVisit })}</>}
+                        </span>
                     )}
 
                     {groups.length === 0 ? (

--- a/src/components/IskamPanel/MenzaSpendingSection.tsx
+++ b/src/components/IskamPanel/MenzaSpendingSection.tsx
@@ -1,0 +1,156 @@
+import { useState, useMemo } from 'react';
+import type { KontaTransaction } from '../../types/iskam';
+import { createIskamT, type IskamLanguage } from '../../i18n/iskamTranslate';
+
+type Period = 'day' | 'week' | 'month';
+
+function parseSettledDate(s: string): Date | null {
+    const [d, m, y] = s.split('.');
+    const date = new Date(Number(y), Number(m) - 1, Number(d));
+    return isNaN(date.getTime()) ? null : date;
+}
+
+function isSameDay(a: Date, b: Date): boolean {
+    return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate();
+}
+
+function isInCurrentWeek(d: Date): boolean {
+    const today = new Date();
+    const monday = new Date(today);
+    monday.setDate(today.getDate() - ((today.getDay() + 6) % 7));
+    monday.setHours(0, 0, 0, 0);
+    const sunday = new Date(monday);
+    sunday.setDate(monday.getDate() + 6);
+    sunday.setHours(23, 59, 59, 999);
+    return d >= monday && d <= sunday;
+}
+
+function filterByPeriod(transactions: KontaTransaction[], period: Period): KontaTransaction[] {
+    const today = new Date();
+    return transactions.filter(tx => {
+        if (tx.type !== 'Úhrada') return false;
+        const d = parseSettledDate(tx.settledDate);
+        if (!d) return false;
+        if (period === 'day') return isSameDay(d, today);
+        if (period === 'week') return isInCurrentWeek(d);
+        return true;
+    });
+}
+
+function groupByDate(transactions: KontaTransaction[]): [string, KontaTransaction[]][] {
+    const map = new Map<string, KontaTransaction[]>();
+    for (const tx of transactions) {
+        const group = map.get(tx.settledDate) ?? [];
+        group.push(tx);
+        map.set(tx.settledDate, group);
+    }
+    return Array.from(map.entries()).sort(([a], [b]) => {
+        const da = parseSettledDate(a);
+        const db = parseSettledDate(b);
+        if (!da || !db) return 0;
+        return db.getTime() - da.getTime();
+    });
+}
+
+function formatCzk(n: number): string {
+    return n % 1 === 0 ? `${n} Kč` : `${n.toFixed(2).replace('.', ',')} Kč`;
+}
+
+interface DayGroupProps {
+    date: string;
+    transactions: KontaTransaction[];
+}
+
+function TransactionDayGroup({ date, transactions }: DayGroupProps) {
+    const dayTotal = transactions.reduce((s, tx) => s + (tx.payment ?? 0), 0);
+    return (
+        <div>
+            <div className="flex justify-between text-xs font-medium text-base-content/60 mb-1">
+                <span>{date}</span>
+                <span>{formatCzk(dayTotal)}</span>
+            </div>
+            {transactions.map((tx, i) => (
+                <div key={i} className="flex justify-between text-xs text-base-content/80 pl-3 py-0.5">
+                    <span className="truncate pr-2">{tx.description}</span>
+                    <span className="shrink-0 text-base-content/50">{tx.payment !== null ? formatCzk(tx.payment) : ''}</span>
+                </div>
+            ))}
+        </div>
+    );
+}
+
+interface Props {
+    transactions: KontaTransaction[];
+    language: IskamLanguage;
+}
+
+export function MenzaSpendingSection({ transactions, language }: Props) {
+    const [period, setPeriod] = useState<Period>('month');
+    const t = createIskamT(language);
+
+    const filtered = useMemo(() => filterByPeriod(transactions, period), [transactions, period]);
+    const total = useMemo(() => filtered.reduce((s, tx) => s + (tx.payment ?? 0), 0), [filtered]);
+    const groups = useMemo(() => groupByDate(filtered), [filtered]);
+
+    const today = new Date();
+    const elapsedDays = today.getDate();
+    const daysInMonth = new Date(today.getFullYear(), today.getMonth() + 1, 0).getDate();
+    const avgPerDay = elapsedDays > 0 ? Math.round(total / elapsedDays) : 0;
+    const monthProgress = Math.round((elapsedDays / daysInMonth) * 100);
+
+    const periods: Period[] = ['day', 'week', 'month'];
+    const periodLabels: Record<Period, string> = {
+        day: t('iskam.spending.today'),
+        week: t('iskam.spending.week'),
+        month: t('iskam.spending.month'),
+    };
+
+    return (
+        <section>
+            <h3 className="text-xs font-semibold text-base-content/50 uppercase tracking-widest px-1 mb-2">
+                {t('iskam.spending.title')}
+            </h3>
+            <div className="card bg-base-100 border border-base-200">
+                <div className="card-body p-3 gap-3">
+                    <div className="join w-full">
+                        {periods.map(p => (
+                            <button
+                                key={p}
+                                className={`btn btn-sm join-item flex-1 ${period === p ? 'btn-primary' : 'btn-ghost'}`}
+                                onClick={() => setPeriod(p)}
+                            >
+                                {periodLabels[p]}
+                            </button>
+                        ))}
+                    </div>
+
+                    <div className="flex items-baseline justify-between">
+                        <span className="text-xs text-base-content/50">{t('iskam.spending.total')}</span>
+                        <span className="text-lg font-bold">{formatCzk(total)}</span>
+                    </div>
+
+                    {period === 'month' && (
+                        <>
+                            <progress className="progress progress-primary w-full h-1.5" value={monthProgress} max={100} />
+                            <span className="text-xs text-base-content/40 -mt-2">
+                                {t('iskam.spending.days', { n: elapsedDays })}
+                                {' · '}
+                                {t('iskam.spending.avgPerDay', { amount: avgPerDay })}
+                            </span>
+                        </>
+                    )}
+
+                    {groups.length === 0 ? (
+                        <p className="text-xs text-base-content/40 text-center py-2">–</p>
+                    ) : (
+                        <div className="flex flex-col gap-2 mt-1">
+                            {groups.map(([date, txs]) => (
+                                <TransactionDayGroup key={date} date={date} transactions={txs} />
+                            ))}
+                        </div>
+                    )}
+                </div>
+            </div>
+        </section>
+    );
+}

--- a/src/components/IskamPanel/MenzaSpendingSection.tsx
+++ b/src/components/IskamPanel/MenzaSpendingSection.tsx
@@ -72,8 +72,8 @@ function TransactionDayGroup({ date, transactions }: DayGroupProps) {
                 <span>{date}</span>
                 <span>{formatCzk(dayTotal)}</span>
             </div>
-            {transactions.map((tx, i) => (
-                <div key={i} className="flex justify-between text-xs text-base-content/80 pl-3 py-0.5">
+            {transactions.map(tx => (
+                <div key={`${tx.datetime}-${tx.description}`} className="flex justify-between text-xs text-base-content/80 pl-3 py-0.5">
                     <span className="truncate pr-2">{tx.description}</span>
                     <span className="shrink-0 text-base-content/50">{tx.payment !== null ? formatCzk(tx.payment) : ''}</span>
                 </div>
@@ -98,12 +98,18 @@ export function MenzaSpendingSection({ transactions, language }: Props) {
     const total = useMemo(() => filtered.reduce((s, tx) => s + (tx.payment ?? 0), 0), [filtered]);
     const groups = useMemo(() => groupByDate(filtered), [filtered]);
 
-    const today = new Date();
-    const elapsedDays = today.getDate();
-    const daysInMonth = new Date(today.getFullYear(), today.getMonth() + 1, 0).getDate();
-    const visitDays = groups.length;
-    const avgPerDay = visitDays > 0 ? Math.round(total / visitDays) : 0;
-    const monthProgress = Math.round((elapsedDays / daysInMonth) * 100);
+    const monthStats = useMemo(() => {
+        if (period !== 'month') return null;
+        const today = new Date();
+        const elapsedDays = today.getDate();
+        const daysInMonth = new Date(today.getFullYear(), today.getMonth() + 1, 0).getDate();
+        const visitDays = groups.length;
+        return {
+            progress: Math.round((elapsedDays / daysInMonth) * 100),
+            visitDays,
+            avgPerVisit: visitDays > 0 ? Math.round(total / visitDays) : 0,
+        };
+    }, [period, groups, total]);
 
     const periods: Period[] = ['day', 'week', 'month'];
     const periodLabels: Record<Period, string> = {
@@ -136,12 +142,12 @@ export function MenzaSpendingSection({ transactions, language }: Props) {
                         <span className="text-lg font-bold">{formatCzk(total)}</span>
                     </div>
 
-                    {period === 'month' && (
+                    {monthStats && (
                         <>
-                            <progress className="progress progress-primary w-full h-1.5" value={monthProgress} max={100} />
+                            <progress className="progress progress-primary w-full h-1.5" value={monthStats.progress} max={100} />
                             <span className="text-xs text-base-content/40 -mt-2">
-                                {t('iskam.spending.visits', { n: visitDays })}
-                                {visitDays > 0 && <>{' · '}{t('iskam.spending.avgPerVisit', { amount: avgPerDay })}</>}
+                                {t('iskam.spending.visits', { n: monthStats.visitDays })}
+                                {monthStats.visitDays > 0 && <>{' · '}{t('iskam.spending.avgPerVisit', { amount: monthStats.avgPerVisit })}</>}
                             </span>
                         </>
                     )}

--- a/src/components/IskamPanel/MenzaSpendingSection.tsx
+++ b/src/components/IskamPanel/MenzaSpendingSection.tsx
@@ -87,8 +87,11 @@ interface Props {
     language: IskamLanguage;
 }
 
+const COLLAPSED_GROUPS = 3;
+
 export function MenzaSpendingSection({ transactions, language }: Props) {
     const [period, setPeriod] = useState<Period>('month');
+    const [expanded, setExpanded] = useState(false);
     const t = createIskamT(language);
 
     const filtered = useMemo(() => filterByPeriod(transactions, period), [transactions, period]);
@@ -99,7 +102,7 @@ export function MenzaSpendingSection({ transactions, language }: Props) {
     const elapsedDays = today.getDate();
     const daysInMonth = new Date(today.getFullYear(), today.getMonth() + 1, 0).getDate();
     const visitDays = groups.length;
-    const avgPerDay = elapsedDays > 0 ? Math.round(total / elapsedDays) : 0;
+    const avgPerDay = visitDays > 0 ? Math.round(total / visitDays) : 0;
     const monthProgress = Math.round((elapsedDays / daysInMonth) * 100);
 
     const periods: Period[] = ['day', 'week', 'month'];
@@ -121,7 +124,7 @@ export function MenzaSpendingSection({ transactions, language }: Props) {
                             <button
                                 key={p}
                                 className={`btn btn-sm join-item flex-1 border-none ${period === p ? 'btn-primary' : 'btn-ghost'}`}
-                                onClick={() => setPeriod(p)}
+                                onClick={() => { setPeriod(p); setExpanded(false); }}
                             >
                                 {periodLabels[p]}
                             </button>
@@ -146,11 +149,21 @@ export function MenzaSpendingSection({ transactions, language }: Props) {
                     {groups.length === 0 ? (
                         <p className="text-xs text-base-content/40 text-center py-2">–</p>
                     ) : (
-                        <div className="flex flex-col gap-2 mt-1">
-                            {groups.map(([date, txs]) => (
-                                <TransactionDayGroup key={date} date={date} transactions={txs} />
-                            ))}
-                        </div>
+                        <>
+                            <div className="flex flex-col gap-2 mt-1">
+                                {(expanded ? groups : groups.slice(0, COLLAPSED_GROUPS)).map(([date, txs]) => (
+                                    <TransactionDayGroup key={date} date={date} transactions={txs} />
+                                ))}
+                            </div>
+                            {groups.length > COLLAPSED_GROUPS && (
+                                <button
+                                    className="btn btn-xs btn-ghost w-full text-base-content/40"
+                                    onClick={() => setExpanded(e => !e)}
+                                >
+                                    {expanded ? '↑' : `+${groups.length - COLLAPSED_GROUPS} ${t('iskam.spending.moreDays')}`}
+                                </button>
+                            )}
+                        </>
                     )}
                 </div>
             </div>

--- a/src/components/IskamPanel/VolneKapacitySection.tsx
+++ b/src/components/IskamPanel/VolneKapacitySection.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import { format, addMonths, subMonths } from 'date-fns';
 import { cs as csLocale } from 'date-fns/locale';
 import { ChevronDown, ChevronUp, ChevronLeft, ChevronRight, Loader2 } from 'lucide-react';
@@ -50,6 +50,7 @@ export function VolneKapacitySection({ language }: Props) {
     const [open, setOpen] = useState(false);
     const [campuses, setCampuses] = useState<Record<string, CampusState>>({});
     const [expandedFloors, setExpandedFloors] = useState<Record<string, boolean>>({});
+    const fetchGenRef = useRef(0);
 
     const toggleFloor = (key: string) => setExpandedFloors(prev => ({ ...prev, [key]: !prev[key] }));
     const [month, setMonth] = useState<Date>(() => {
@@ -59,22 +60,27 @@ export function VolneKapacitySection({ language }: Props) {
     });
 
     const shiftMonth = (delta: 1 | -1) => {
+        fetchGenRef.current += 1;
         setMonth(prev => delta === 1 ? addMonths(prev, 1) : subMonths(prev, 1));
         setCampuses({});
     };
 
     const fetchCampus = async (campusName: string, blocks: { id: string; label: string }[], fetchMonth: Date) => {
+        const gen = fetchGenRef.current;
         const od = monthToOdCz(fetchMonth);
         const doo = dooFromMonth(fetchMonth);
+        if (fetchGenRef.current !== gen) return;
         setCampuses(prev => ({ ...prev, [campusName]: { blocks: [], fetching: true, expanded: true } }));
         for (const block of blocks) {
             const rooms = await fetchBlockViaContentScript(block.id, od, doo).catch(() => [] as VolneKapacityRoom[]);
+            if (fetchGenRef.current !== gen) return;
             setCampuses(prev => {
                 const campus = prev[campusName];
                 if (!campus) return prev;
                 return { ...prev, [campusName]: { ...campus, blocks: [...campus.blocks, { label: block.label, rooms }] } };
             });
         }
+        if (fetchGenRef.current !== gen) return;
         setCampuses(prev => {
             const campus = prev[campusName];
             if (!campus) return prev;
@@ -83,6 +89,7 @@ export function VolneKapacitySection({ language }: Props) {
     };
 
     const handleCampus = (campusName: string, blocks: { id: string; label: string }[]) => {
+        if (isGapMonth(month)) return;
         const state = campuses[campusName];
         if (!state) { fetchCampus(campusName, blocks, month); return; }
         setCampuses(prev => ({ ...prev, [campusName]: { ...prev[campusName], expanded: !prev[campusName].expanded } }));
@@ -131,7 +138,8 @@ export function VolneKapacitySection({ language }: Props) {
                             <div key={campus.name} className="border-b border-base-200/60 last:border-0">
                                 <button
                                     onClick={() => handleCampus(campus.name, campus.blocks)}
-                                    className="flex items-center justify-between w-full px-4 py-3 hover:bg-base-200/40 transition-colors"
+                                    disabled={isGapMonth(month)}
+                                    className="flex items-center justify-between w-full px-4 py-3 hover:bg-base-200/40 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
                                 >
                                     <span className="text-sm font-medium">{campus.name}</span>
                                     <div className="flex items-center gap-2">

--- a/src/components/IskamPanel/VolneKapacitySection.tsx
+++ b/src/components/IskamPanel/VolneKapacitySection.tsx
@@ -2,7 +2,7 @@ import { useState, useRef } from 'react';
 import { format, addMonths, subMonths } from 'date-fns';
 import { cs as csLocale } from 'date-fns/locale';
 import { ChevronDown, ChevronUp, ChevronLeft, ChevronRight, Loader2 } from 'lucide-react';
-import { ISKAM_CAMPUSES, academicYearDates } from '../../api/iskam/volneKapacity'; // academicYearDates used for default month init
+import { ISKAM_CAMPUSES, academicYearDates } from '../../api/iskam/volneKapacity';
 import type { VolneKapacityRoom } from '../../types/iskam';
 import { createIskamT, type IskamLanguage } from '../../i18n/iskamTranslate';
 

--- a/src/entrypoints/iskam/IskamApp.tsx
+++ b/src/entrypoints/iskam/IskamApp.tsx
@@ -48,12 +48,12 @@ export function IskamApp() {
     const iskamItems: MenuItem[] = [
         {
             id: 'iskam-dashboard',
-            label: 'ISKAM',
+            label: 'Přehled',
             icon: <LayoutDashboard className="w-5 h-5" />
         },
         {
             id: 'skm',
-            label: 'SKM',
+            label: 'WebISKAM',
             icon: <Building2 className="w-5 h-5" />,
             expandable: true,
             children: [
@@ -68,9 +68,9 @@ export function IskamApp() {
     ];
 
     const iskamTabs = [
-        { id: 'iskam-dashboard', label: 'ISKAM', icon: <LayoutDashboard className="w-5 h-5" /> },
+        { id: 'iskam-dashboard', label: 'Přehled', icon: <LayoutDashboard className="w-5 h-5" /> },
         { id: 'accounts', label: 'Konta', icon: <Wallet className="w-5 h-5" /> },
-        { id: 'skm', label: 'SKM', icon: <Building2 className="w-5 h-5" /> },
+        { id: 'skm', label: 'WebISKAM', icon: <Building2 className="w-5 h-5" /> },
         { id: 'profile', label: 'Profil', icon: <User className="w-5 h-5" /> },
     ];
 

--- a/src/entrypoints/iskam/IskamApp.tsx
+++ b/src/entrypoints/iskam/IskamApp.tsx
@@ -53,7 +53,7 @@ export function IskamApp() {
         },
         {
             id: 'skm',
-            label: 'WebISKAM',
+            label: 'ISKAM',
             icon: <Building2 className="w-5 h-5" />,
             expandable: true,
             children: [
@@ -70,7 +70,7 @@ export function IskamApp() {
     const iskamTabs = [
         { id: 'iskam-dashboard', label: 'Přehled', icon: <LayoutDashboard className="w-5 h-5" /> },
         { id: 'accounts', label: 'Konta', icon: <Wallet className="w-5 h-5" /> },
-        { id: 'skm', label: 'WebISKAM', icon: <Building2 className="w-5 h-5" /> },
+        { id: 'skm', label: 'ISKAM', icon: <Building2 className="w-5 h-5" /> },
         { id: 'profile', label: 'Profil', icon: <User className="w-5 h-5" /> },
     ];
 

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -39,8 +39,8 @@
       "week": "Týden",
       "month": "Měsíc",
       "total": "Celkem",
-      "avgPerDay": "~{amount} Kč / den",
-      "days": "{n} dní"
+      "avgPerVisit": "~{amount} Kč / den",
+      "visits": "{n}× tento měsíc"
     }
   },
   "menu": {

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -40,7 +40,8 @@
       "month": "Měsíc",
       "total": "Celkem",
       "avgPerVisit": "~{amount} Kč / den",
-      "visits": "{n}× tento měsíc"
+      "visits": "{n}× tento měsíc",
+      "moreDays": "další dny"
     }
   },
   "menu": {

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -32,7 +32,16 @@
     "dateFrom": "Od",
     "gapMonth": "prázdniny",
     "pendingPaymentsLabel": "Požadavky na úhradu",
-    "pendingPaymentDue": "splatnost"
+    "pendingPaymentDue": "splatnost",
+    "spending": {
+      "title": "Výdaje za stravu",
+      "today": "Dnes",
+      "week": "Týden",
+      "month": "Měsíc",
+      "total": "Celkem",
+      "avgPerDay": "~{amount} Kč / den",
+      "days": "{n} dní"
+    }
   },
   "menu": {
     "title": "Jídelníček",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -40,7 +40,8 @@
       "month": "Month",
       "total": "Total",
       "avgPerVisit": "~{amount} CZK / day",
-      "visits": "{n}× this month"
+      "visits": "{n}× this month",
+      "moreDays": "more days"
     }
   },
   "menu": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -32,7 +32,16 @@
     "dateFrom": "From",
     "gapMonth": "no contracts",
     "pendingPaymentsLabel": "Requested payments",
-    "pendingPaymentDue": "due"
+    "pendingPaymentDue": "due",
+    "spending": {
+      "title": "Food spending",
+      "today": "Today",
+      "week": "Week",
+      "month": "Month",
+      "total": "Total",
+      "avgPerDay": "~{amount} CZK / day",
+      "days": "{n} days"
+    }
   },
   "menu": {
     "title": "Today's Menu",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -39,8 +39,8 @@
       "week": "Week",
       "month": "Month",
       "total": "Total",
-      "avgPerDay": "~{amount} CZK / day",
-      "days": "{n} days"
+      "avgPerVisit": "~{amount} CZK / day",
+      "visits": "{n}× this month"
     }
   },
   "menu": {

--- a/src/store/__tests__/iskamStore.test.ts
+++ b/src/store/__tests__/iskamStore.test.ts
@@ -13,10 +13,11 @@ vi.mock('../useAppStore', () => ({
 }));
 
 const SAMPLE: IskamData = {
-    konta: [{ name: 'Hlavní konto', balance: 100, balanceText: '100 Kč', topUpHref: '/Platby/NabitiKonta/0' }],
+    konta: [{ name: 'Hlavní konto', balance: 100, balanceText: '100 Kč', topUpHref: '/Platby/NabitiKonta/0', transactionsHref: null }],
     ubytovani: [],
     reservations: [],
     pendingPayments: [],
+    stravovaniTransactions: [],
     syncedAt: 1700000000000,
 };
 

--- a/src/store/__tests__/iskamStore.test.ts
+++ b/src/store/__tests__/iskamStore.test.ts
@@ -17,7 +17,7 @@ const SAMPLE: IskamData = {
     ubytovani: [],
     reservations: [],
     pendingPayments: [],
-    stravovaniTransactions: [],
+    foodTransactions: [],
     syncedAt: 1700000000000,
 };
 
@@ -31,6 +31,17 @@ describe('useIskamStore', () => {
     });
 
     describe('loadFromCache()', () => {
+        it('backfills missing foodTransactions for legacy cached entries', async () => {
+            const legacy = { ...SAMPLE } as Partial<IskamData>;
+            delete (legacy as { foodTransactions?: unknown }).foodTransactions;
+
+            vi.mocked(IndexedDBService.get).mockResolvedValue(legacy as IskamData);
+            await useIskamStore.getState().loadFromCache();
+
+            expect(useIskamStore.getState().data?.foodTransactions).toEqual([]);
+            expect(useIskamStore.getState().status).toBe('success');
+        });
+
         it('sets data and status=success when IDB has a cached value', async () => {
             vi.mocked(IndexedDBService.get).mockResolvedValue(SAMPLE);
             await useIskamStore.getState().loadFromCache();

--- a/src/store/iskamStore.ts
+++ b/src/store/iskamStore.ts
@@ -29,8 +29,8 @@ export const useIskamStore = create<IskamStoreState>((set) => {
                 const cached = await IndexedDBService.get('iskam', 'current');
                 if (cached) {
                     const data = cached as IskamData;
-                    // Guard: old cache entries predate stravovaniTransactions field.
-                    if (!data.stravovaniTransactions) data.stravovaniTransactions = [];
+                    // Guard: migrate old cache shapes to current field names.
+                    if (!data.foodTransactions) data.foodTransactions = [];
                     set({ data, status: 'success', error: null });
                 }
             } catch { /* cache miss — receiveSync will populate */ }

--- a/src/store/iskamStore.ts
+++ b/src/store/iskamStore.ts
@@ -27,7 +27,12 @@ export const useIskamStore = create<IskamStoreState>((set) => {
         loadFromCache: async () => {
             try {
                 const cached = await IndexedDBService.get('iskam', 'current');
-                if (cached) set({ data: cached as IskamData, status: 'success', error: null });
+                if (cached) {
+                    const data = cached as IskamData;
+                    // Guard: old cache entries predate stravovaniTransactions field.
+                    if (!data.stravovaniTransactions) data.stravovaniTransactions = [];
+                    set({ data, status: 'success', error: null });
+                }
             } catch { /* cache miss — receiveSync will populate */ }
         },
 

--- a/src/store/iskamStore.ts
+++ b/src/store/iskamStore.ts
@@ -30,7 +30,7 @@ export const useIskamStore = create<IskamStoreState>((set) => {
                 if (cached) {
                     const data = cached as IskamData;
                     // Guard: migrate old cache shapes to current field names.
-                    if (!data.foodTransactions) data.foodTransactions = [];
+                    if (!Array.isArray(data.foodTransactions)) data.foodTransactions = [];
                     set({ data, status: 'success', error: null });
                 }
             } catch { /* cache miss — receiveSync will populate */ }

--- a/src/types/iskam.ts
+++ b/src/types/iskam.ts
@@ -63,6 +63,6 @@ export interface IskamData {
     profile?: IskamProfile;
     reservations: IskamReservation[];
     pendingPayments: PendingPayment[];
-    stravovaniTransactions: KontaTransaction[];
+    foodTransactions: KontaTransaction[];
     syncedAt: number;
 }

--- a/src/types/iskam.ts
+++ b/src/types/iskam.ts
@@ -5,6 +5,7 @@ export interface KontoRow {
     balance: number;
     balanceText: string;
     topUpHref: string | null;
+    transactionsHref: string | null;
 }
 
 export type UbytovaniStatus = 'Ubytovaný' | 'Rezervace' | 'Odhlášen' | string;
@@ -46,11 +47,22 @@ export interface PendingPayment {
     amount: string;
 }
 
+export interface KontaTransaction {
+    datetime: string;       // "27.4.2026 12:48:02"
+    settledDate: string;    // "27.4.2026"
+    type: string;           // "Úhrada" | "Převod" | ...
+    description: string;
+    topUp: number | null;   // Nabíjení column
+    payment: number | null; // Úhrady column
+    balance: number;        // Zůstatek column
+}
+
 export interface IskamData {
     konta: KontoRow[];
     ubytovani: UbytovaniRow[];
     profile?: IskamProfile;
     reservations: IskamReservation[];
     pendingPayments: PendingPayment[];
+    stravovaniTransactions: KontaTransaction[];
     syncedAt: number;
 }

--- a/src/types/storage.ts
+++ b/src/types/storage.ts
@@ -130,7 +130,7 @@ export const IskamDataSchema = z.object({
         description: z.string(),
         amount: z.string(),
     })),
-    stravovaniTransactions: z.array(z.object({
+    foodTransactions: z.array(z.object({
         datetime: z.string(),
         settledDate: z.string(),
         type: z.string(),

--- a/src/types/storage.ts
+++ b/src/types/storage.ts
@@ -103,6 +103,7 @@ export const IskamDataSchema = z.object({
         balance: z.number(),
         balanceText: z.string(),
         topUpHref: z.string().nullable(),
+        transactionsHref: z.string().nullable(),
     })),
     ubytovani: z.array(z.object({
         dorm: z.string(),
@@ -128,6 +129,15 @@ export const IskamDataSchema = z.object({
         dueDate: z.string(),
         description: z.string(),
         amount: z.string(),
+    })),
+    stravovaniTransactions: z.array(z.object({
+        datetime: z.string(),
+        settledDate: z.string(),
+        type: z.string(),
+        description: z.string(),
+        topUp: z.number().nullable(),
+        payment: z.number().nullable(),
+        balance: z.number(),
     })),
     syncedAt: z.number(),
 }) as z.ZodType<IskamData>;

--- a/src/utils/parsers/iskam/__tests__/kontaTransactions.test.ts
+++ b/src/utils/parsers/iskam/__tests__/kontaTransactions.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { parseKontaTransactions } from '../kontaTransactions';
+
+const FIXTURE = readFileSync(
+    resolve(__dirname, '../../../../../.agent/fixtures/webiskam/konta-transactions-stravovaci.html'),
+    'utf-8'
+);
+
+describe('parseKontaTransactions', () => {
+    it('returns 4 data rows, skipping pohledavka-poznamka and header/footer', () => {
+        const rows = parseKontaTransactions(FIXTURE);
+        expect(rows).toHaveLength(4);
+    });
+
+    it('parses an Úhrada row correctly', () => {
+        const rows = parseKontaTransactions(FIXTURE);
+        const soup = rows.find(r => r.description === 'Polévka rajská s rýží');
+        expect(soup).toBeDefined();
+        expect(soup!.type).toBe('Úhrada');
+        expect(soup!.settledDate).toBe('27.4.2026');
+        expect(soup!.payment).toBeCloseTo(12, 2);
+        expect(soup!.topUp).toBeNull();
+        expect(soup!.balance).toBeCloseTo(588, 2);
+    });
+
+    it('parses decimal payment amounts', () => {
+        const rows = parseKontaTransactions(FIXTURE);
+        const food = rows.find(r => r.description.includes('Jídlo na váhu'));
+        expect(food).toBeDefined();
+        expect(food!.payment).toBeCloseTo(165.43, 2);
+    });
+
+    it('parses a Převod row with topUp non-null and payment null', () => {
+        const rows = parseKontaTransactions(FIXTURE);
+        const prevod = rows.find(r => r.type === 'Převod');
+        expect(prevod).toBeDefined();
+        expect(prevod!.topUp).toBeCloseTo(600, 2);
+        expect(prevod!.payment).toBeNull();
+    });
+
+    it('returns empty array for HTML with no matching table', () => {
+        expect(parseKontaTransactions('<html><body><p>nothing</p></body></html>')).toEqual([]);
+    });
+});

--- a/src/utils/parsers/iskam/konta.ts
+++ b/src/utils/parsers/iskam/konta.ts
@@ -34,6 +34,9 @@ export function parseKonta(html: string, lang: 'cz' | 'en' = 'cz'): KontoRow[] {
         const topUpAnchor = Array.from(row.querySelectorAll('a')).find(a => TOP_UP_LABEL_RE.test((a.textContent || '').trim()));
         const topUpHref = topUpAnchor?.getAttribute('href') || null;
 
+        const detailAnchor = row.querySelector('a[href*="/Konta/PrevodyUhrady/"]');
+        const transactionsHref = detailAnchor?.getAttribute('href') ?? null;
+
         out.push({
             name,
             nameCs: lang === 'cz' ? name : undefined,
@@ -41,6 +44,7 @@ export function parseKonta(html: string, lang: 'cz' | 'en' = 'cz'): KontoRow[] {
             balance: parsed.value,
             balanceText: parsed.raw,
             topUpHref,
+            transactionsHref,
         });
     }
     return out;

--- a/src/utils/parsers/iskam/kontaTransactions.ts
+++ b/src/utils/parsers/iskam/kontaTransactions.ts
@@ -1,0 +1,39 @@
+import type { KontaTransaction } from '../../../types/iskam';
+
+function parseCzechNumber(text: string): number | null {
+    const cleaned = text.trim().replace(/\s/g, '').replace(',', '.');
+    if (!cleaned) return null;
+    const n = parseFloat(cleaned);
+    return Number.isFinite(n) ? n : null;
+}
+
+function cellText(td: Element): string {
+    return (td.querySelector('label')?.textContent ?? td.textContent ?? '').trim();
+}
+
+export function parseKontaTransactions(html: string): KontaTransaction[] {
+    const doc = new DOMParser().parseFromString(html, 'text/html');
+    const rows = Array.from(doc.querySelectorAll('#tablePrevodyUhrady tbody tr'));
+    const out: KontaTransaction[] = [];
+
+    for (const row of rows) {
+        if (row.classList.contains('pohledavka-poznamka')) continue;
+
+        const cells = Array.from(row.querySelectorAll('td'));
+        if (cells.length < 7) continue;
+
+        const datetime = cellText(cells[0]);
+        const settledDate = cellText(cells[1]);
+        const type = cellText(cells[2]);
+        const description = cellText(cells[3]);
+        const topUp = parseCzechNumber(cellText(cells[4]));
+        const payment = parseCzechNumber(cellText(cells[5]));
+        const balanceRaw = parseCzechNumber(cellText(cells[6]));
+
+        if (!datetime || !settledDate || balanceRaw === null) continue;
+
+        out.push({ datetime, settledDate, type, description, topUp, payment, balance: balanceRaw });
+    }
+
+    return out;
+}


### PR DESCRIPTION
## Summary
- Fetches transaction history from **STRAVOVACÍ KONTO** (`/Konta/PrevodyUhrady/{id}`) on WebISKAM
- Parses individual meal rows (datetime, description, amount) via new `parseKontaTransactions` parser
- Adds `MenzaSpendingSection` to IskamPanel: period toggle (today / week / month), total, monthly progress bar with avg/day, day-grouped transaction list

## Data flow
`/Konta` → extract `transactionsHref` per account → detect STRAVOVACÍ KONTO by name → `fetchKontaTransactions` → `IskamData.stravovaniTransactions` → stored in IDB → rendered in IskamPanel

## Test plan
- [ ] `npm run typecheck` — passes
- [ ] `npm run test:run` — 44/44 test files, 246 tests pass
- [ ] `npm run build` — clean build
- [ ] Load WebISKAM in extension — spending section appears below main account card
- [ ] Toggle day/week/month — totals update correctly
- [ ] Users without STRAVOVACÍ KONTO — section hidden (empty `stravovaniTransactions`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Menza spending" section showing day/week/month views, per-day groups, totals and averages; meal transactions are now surfaced in the account view.

* **Bug Fixes**
  * Profile and pending-payment parsing is more resilient so one failure won't hide the other.

* **Improvements**
  * Use preformatted account balances, prevent stale availability updates, disable controls for gap months, add CS/EN translations, backfill cached food data, and update dashboard/tab labels.

* **Tests**
  * Added tests for academic-year date logic and cache migration.

* **Chores**
  * Updated review configuration to exclude parser TypeScript files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->