### PR TITLE
fix: use fetchWithAuth in fetchExamClassmates for reliable cookie routing

### DIFF
--- a/src/api/terminyInfo.ts
+++ b/src/api/terminyInfo.ts
@@ -1,4 +1,4 @@
-import { BASE_URL } from './client';
+import { BASE_URL, fetchWithAuth } from './client';
 import type { Classmate } from '../types/classmates';
 
 export async function fetchExamClassmates(
@@ -8,8 +8,7 @@ export async function fetchExamClassmates(
 ): Promise<Classmate[] | null> {
     try {
         const url = `${BASE_URL}/auth/student/terminy_info.pl?termin=${terminId};spoluzaci=1;studium=${studiumId};obdobi=${obdobiId};lang=cz`;
-        const res = await fetch(url);
-        if (!res.ok) return null;
+        const res = await fetchWithAuth(url);
 
         const doc = new DOMParser().parseFromString(await res.text(), 'text/html');
         const tables = doc.getElementsByTagName('table');


### PR DESCRIPTION
## Problem

`fetchExamClassmates` was calling plain `fetch()` without authentication. Since `loadExamClassmates` runs in the store (iframe context, `chrome-extension://` origin), requests hit IS Mendelu without auth cookies.

IS Mendelu responds with a login-redirect HTML page, which:
- Sometimes contains a table with "Jméno" in a header → parser matches it, finds no classmate rows, returns `[]` → card shows **🧑 0**
- Sometimes no table matches → returns `null` → classmates button **never appears**

This is why the count was unreliable.

## Fix

Replace `fetch(url)` with `fetchWithAuth(url)` in `src/api/terminyInfo.ts`. `fetchWithAuth` automatically routes through the content-script proxy (which has real auth cookies) when called from the iframe context.

## Test plan
- [ ] Open ExamPanel with a registered exam term
- [ ] Classmates button (🧑 N) shows the correct count of classmates registered for the same term
- [ ] Count is consistent across page loads

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced authentication handling for an API endpoint by updating the request method to include proper authentication credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->