### PR TITLE
feat: past semester subjects + attendance via list.pl, grade history EN

### DIFF
--- a/src/api/gradeHistory.ts
+++ b/src/api/gradeHistory.ts
@@ -7,10 +7,25 @@ export async function fetchGradeHistory(
     obdobi: string
 ): Promise<GradeHistory | null> {
     try {
-        const url = `${BASE_URL}/auth/student/pruchod_studiem.pl?vyber=vsechna_obdobi;studium=${studium};obdobi=${obdobi};lang=cz`;
-        const response = await fetchWithAuth(url);
-        const html = await response.text();
-        return parseGradeHistory(html, studium);
+        const base = `${BASE_URL}/auth/student/pruchod_studiem.pl?vyber=vsechna_obdobi;studium=${studium};obdobi=${obdobi}`;
+        const [czRes, enRes] = await Promise.all([
+            fetchWithAuth(`${base};lang=cz`),
+            fetchWithAuth(`${base};lang=en`),
+        ]);
+        const czHtml = await czRes.text();
+        const enHtml = await enRes.text();
+
+        const result = parseGradeHistory(czHtml, studium);
+
+        // Build predmetId → EN course name map and merge in
+        const enGrades = parseGradeHistory(enHtml, studium).grades;
+        const enNameMap = new Map(enGrades.map(g => [g.predmetId, g.courseName]));
+        for (const grade of result.grades) {
+            const enName = enNameMap.get(grade.predmetId);
+            if (enName) grade.courseNameEn = enName;
+        }
+
+        return result;
     } catch (e) {
         console.warn('[gradeHistory] fetchGradeHistory failed:', e);
         return null;

--- a/src/api/subjects.ts
+++ b/src/api/subjects.ts
@@ -1,7 +1,7 @@
  
  
 import { fetchWithAuth, BASE_URL } from "./client";
-import type { SubjectInfo, SubjectsData, SubjectAttendance, AttendanceRecord, AttendanceStatus } from "../types/documents";
+import type { SubjectInfo, SubjectsData, SubjectAttendance, AttendanceRecord, AttendanceStatus, AvailablePeriod } from "../types/documents";
 import { SubjectsDataSchema } from "../schemas/subjectSchema";
 
 const STUDENT_LIST_URL = `${BASE_URL}/auth/student/list.pl`;
@@ -33,15 +33,70 @@ export async function fetchSubjects(lang: string = 'cz', studium?: string): Prom
 export interface SubjectsFetchResult {
     subjects: SubjectsData;
     attendance: Record<string, SubjectAttendance[]>;
+    availablePeriods: AvailablePeriod[];
+}
+
+function buildListUrl(lang: string, studium?: string, obdobi?: string): string {
+    const params = new URLSearchParams();
+    params.set('lang', lang);
+    if (studium) params.set('studium', studium);
+    if (obdobi) params.set('obdobi', obdobi);
+    return `${STUDENT_LIST_URL}?${params.toString().replace(/&/g, ';')}`;
+}
+
+export function parseAvailablePeriods(html: string): AvailablePeriod[] {
+    const doc = new DOMParser().parseFromString(html, 'text/html');
+    const select = doc.querySelector('select[name="obdobi"]');
+    if (!select) return [];
+    return Array.from(select.querySelectorAll('option')).map(opt => ({
+        id: opt.getAttribute('value') ?? '',
+        label: opt.textContent?.trim() ?? '',
+    })).filter(p => p.id);
+}
+
+/**
+ * Fetches subjects + attendance for a specific past semester (no periods list).
+ * Result is cached in IDB by the caller — this function is pure fetch+parse.
+ */
+export async function fetchPastSemesterData(studium: string, obdobi: string): Promise<SubjectsFetchResult | null> {
+    try {
+        const [czRes, enRes] = await Promise.all([
+            fetchWithAuth(buildListUrl('cz', studium, obdobi)),
+            fetchWithAuth(buildListUrl('en', studium, obdobi)),
+        ]);
+        const czHtml = await czRes.text();
+        const enHtml = await enRes.text();
+
+        const attendance = parseAttendance(czHtml);
+        const czMap = parseSubjectFolders(czHtml);
+        const enMap = parseSubjectFolders(enHtml);
+
+        const merged: Record<string, SubjectInfo> = {};
+        for (const [fullName, data] of Object.entries(czMap)) {
+            const code = extractSubjectCode(fullName);
+            const name = extractCleanName(fullName);
+            merged[code] = { displayName: name, fullName, nameCs: name, subjectCode: code, subjectId: data.subjectId, folderUrl: data.folderUrl, fetchedAt: new Date().toISOString() };
+        }
+        for (const [fullName] of Object.entries(enMap)) {
+            const code = extractSubjectCode(fullName);
+            if (merged[code]) merged[code].nameEn = extractCleanName(fullName);
+        }
+
+        const subjectsData: SubjectsData = { version: 1, lastUpdated: new Date().toISOString(), data: merged };
+        return { subjects: subjectsData, attendance, availablePeriods: [] };
+    } catch (e) {
+        console.warn('[subjects] fetchPastSemesterData failed:', e);
+        return null;
+    }
 }
 
 /**
  * Fetches subjects in both Czech and English and merges them.
  */
-export async function fetchDualLanguageSubjects(studium?: string): Promise<SubjectsFetchResult | null> {
+export async function fetchDualLanguageSubjects(studium?: string, obdobi?: string): Promise<SubjectsFetchResult | null> {
     try {
-        const czUrl = studium ? `${STUDENT_LIST_URL}?lang=cz;studium=${studium}` : `${STUDENT_LIST_URL}?lang=cz`;
-        const enUrl = studium ? `${STUDENT_LIST_URL}?lang=en;studium=${studium}` : `${STUDENT_LIST_URL}?lang=en`;
+        const czUrl = buildListUrl('cz', studium, obdobi);
+        const enUrl = buildListUrl('en', studium, obdobi);
 
         // Fetch both in parallel
         const [czRes, enRes] = await Promise.all([
@@ -89,7 +144,8 @@ export async function fetchDualLanguageSubjects(studium?: string): Promise<Subje
         };
 
         const result = SubjectsDataSchema.safeParse(subjectsData);
-        return { subjects: result.success ? result.data : subjectsData, attendance };
+        const availablePeriods = parseAvailablePeriods(czHtml);
+        return { subjects: result.success ? result.data : subjectsData, attendance, availablePeriods };
     } catch (e) {
         console.warn('[subjects] fetchDualLanguageSubjects failed:', e);
         return null;

--- a/src/api/terminyInfo.ts
+++ b/src/api/terminyInfo.ts
@@ -1,4 +1,4 @@
-import { BASE_URL } from './client';
+import { BASE_URL, fetchWithAuth } from './client';
 import type { Classmate } from '../types/classmates';
 
 export async function fetchExamClassmates(
@@ -8,8 +8,7 @@ export async function fetchExamClassmates(
 ): Promise<Classmate[] | null> {
     try {
         const url = `${BASE_URL}/auth/student/terminy_info.pl?termin=${terminId};spoluzaci=1;studium=${studiumId};obdobi=${obdobiId};lang=cz`;
-        const res = await fetch(url);
-        if (!res.ok) return null;
+        const res = await fetchWithAuth(url);
 
         const doc = new DOMParser().parseFromString(await res.text(), 'text/html');
         const tables = doc.getElementsByTagName('table');

--- a/src/components/SubjectFileDrawer/AttendanceSection.tsx
+++ b/src/components/SubjectFileDrawer/AttendanceSection.tsx
@@ -20,7 +20,7 @@ function shortDate(d: string): string {
 
 export function AttendanceSection({ courseCode }: { courseCode: string }) {
     const { t } = useTranslation();
-    const groups = useAppStore(state => state.attendance[courseCode]);
+    const groups = useAppStore(state => state.attendance[courseCode] ?? state.pastAttendance[courseCode]);
 
     if (!groups || groups.length === 0) return null;
 

--- a/src/hooks/useAppLogic.ts
+++ b/src/hooks/useAppLogic.ts
@@ -27,6 +27,7 @@ interface SyncedData {
     classmates?: Record<string, ClassmatesData>;
     assessments?: Record<string, Assessment[] | { cz: Assessment[]; en: Assessment[] }>;
     attendance?: Record<string, SubjectAttendance[]>;
+    pastAttendance?: Record<string, SubjectAttendance[]>;
     studyPlan?: DualLanguageStudyPlan;
     studyStats?: unknown;
     cvicneTests?: any[];
@@ -53,6 +54,26 @@ export function useAppLogic() {
         syncGradeHistory()
             .then(() => useAppStore.getState().loadStudyJamSuggestions())
             .catch(() => {});
+
+        // Hydrate past attendance from permanently-cached IDB entries
+        IndexedDBService.getAllWithKeys('meta').then(entries => {
+            const pastEntries = entries.filter(({ key }) => key.startsWith('past_semester_'));
+            const merged: Record<string, SubjectAttendance[]> = {};
+            for (const { value } of pastEntries) {
+                const att = (value as { attendance?: Record<string, SubjectAttendance[]> })?.attendance ?? {};
+                for (const [code, records] of Object.entries(att)) {
+                    if (merged[code]) {
+                        merged[code] = [...merged[code], ...records];
+                    } else {
+                        merged[code] = records;
+                    }
+                }
+            }
+            if (Object.keys(merged).length > 0) {
+                useAppStore.getState().setPastAttendance(merged);
+            }
+        }).catch(() => {});
+
         let unsub: (() => void) | undefined;
         initializeStore().then(unsubscribe => {
             unsub = unsubscribe;
@@ -140,6 +161,10 @@ export function useAppLogic() {
 
                 if (r.attendance) {
                     useAppStore.getState().setAttendance(r.attendance);
+                }
+
+                if (r.pastAttendance) {
+                    useAppStore.getState().setPastAttendance(r.pastAttendance);
                 }
 
                 if (r.files) {

--- a/src/injector/syncService.ts
+++ b/src/injector/syncService.ts
@@ -12,6 +12,7 @@ import { syncCvicneTests } from "../services/sync/syncCvicneTests";
 import { syncOdevzdavarny } from "../services/sync/syncOdevzdavarny";
 import { fetchSeminarGroupIds, fetchClassmates } from "../api/classmates";
 import { mergePastSubjects } from "../services/sync/mergePastSubjects";
+import { syncPastSemesters } from "../services/sync/syncPastSemesters";
 
 import { getUserParams } from "../utils/userParams";
 import { fetchFullSemesterSchedule } from "./dataFetchers";
@@ -36,8 +37,8 @@ export async function syncAllData() {
         const userParams = await getUserParams();
         const studium = userParams?.studium;
 
-        // Phase 2a: Start subjects early — fast fetch
-        const subjectsPromise = fetchDualLanguageSubjects(studium || undefined)
+        // Phase 2a: Start subjects early — fast fetch (explicit obdobi prevents session-state coupling)
+        const subjectsPromise = fetchDualLanguageSubjects(studium || undefined, userParams?.obdobi || undefined)
             .then(result => {
                 if (result) {
                     cachedData = { ...cachedData, subjects: result.subjects, attendance: result.attendance };
@@ -96,6 +97,23 @@ export async function syncAllData() {
             subjects.status === "fulfilled" && subjects.value &&
             pastSubjects.status === "fulfilled" && pastSubjects.value
         ) {
+            // Inject already-cached past semester subjects (richer data than dok_server)
+            // before mergePastSubjects so dok_server only fills truly old subjects.
+            if (studium && userParams?.obdobi && subjects.value.availablePeriods.length > 0) {
+                const pastPeriods = subjects.value.availablePeriods.filter(p => p.id !== userParams!.obdobi);
+                for (const period of pastPeriods) {
+                    const cached = await IndexedDBService.get('meta', `past_semester_${period.id}`) as
+                        { subjects: { data: typeof subjects.value.subjects.data }; attendance: unknown } | undefined;
+                    if (cached?.subjects?.data) {
+                        for (const [code, info] of Object.entries(cached.subjects.data)) {
+                            if (!subjects.value.subjects.data[code]) {
+                                subjects.value.subjects.data[code] = info;
+                            }
+                        }
+                    }
+                }
+            }
+
             mergePastSubjects(
                 subjects.value.subjects,
                 pastSubjects.value,
@@ -124,6 +142,11 @@ export async function syncAllData() {
         
         cachedData.lastSync = Date.now();
         sendToIframe(Messages.syncUpdate({ ...cachedData, isSyncing: false }));
+
+        // Fire-and-forget: fetch past semesters once, permanently cache in IDB
+        if (studium && userParams?.obdobi && subjects.status === "fulfilled" && subjects.value?.availablePeriods.length) {
+            syncPastSemesters(studium, userParams.obdobi, subjects.value.availablePeriods).catch(() => {});
+        }
     } catch (e) {
         sendToIframe(Messages.syncUpdate({ isSyncing: false, error: String(e), lastSync: cachedData.lastSync }));
     } finally { 

--- a/src/services/sync/syncPastSemesters.ts
+++ b/src/services/sync/syncPastSemesters.ts
@@ -1,0 +1,62 @@
+import { fetchPastSemesterData } from '../../api/subjects';
+import { IndexedDBService } from '../storage';
+import { sendToIframe } from '../../injector/iframeManager';
+import { Messages } from '../../types/messages';
+import type { AvailablePeriod, SubjectAttendance } from '../../types/documents';
+import type { SubjectsData } from '../../types/documents';
+import type { SyncedData } from '../../types/messages/base';
+
+const META_KEY_PREFIX = 'past_semester_';
+
+export async function syncPastSemesters(
+    studium: string,
+    currentObdobi: string,
+    allPeriods: AvailablePeriod[],
+): Promise<void> {
+    const pastPeriods = allPeriods.filter(p => p.id !== currentObdobi);
+    if (pastPeriods.length === 0) return;
+
+    const mergedPastAttendance: Record<string, SubjectAttendance[]> = {};
+    const mergedPastSubjects: Record<string, SubjectsData['data'][string]> = {};
+
+    for (const period of pastPeriods) {
+        const cacheKey = `${META_KEY_PREFIX}${period.id}`;
+
+        // Permanent cache — past semesters are immutable facts
+        const cached = await IndexedDBService.get('meta', cacheKey) as
+            { subjects: SubjectsData; attendance: Record<string, SubjectAttendance[]> } | undefined;
+
+        let subjects: SubjectsData | null = null;
+        let attendance: Record<string, SubjectAttendance[]> = {};
+
+        if (cached?.subjects && cached?.attendance) {
+            subjects = cached.subjects;
+            attendance = cached.attendance;
+        } else {
+            const result = await fetchPastSemesterData(studium, period.id);
+            if (result) {
+                subjects = result.subjects;
+                attendance = result.attendance;
+                await IndexedDBService.set('meta', cacheKey, { subjects, attendance });
+            }
+        }
+
+        if (subjects) {
+            Object.assign(mergedPastSubjects, subjects.data);
+        }
+        for (const [code, records] of Object.entries(attendance)) {
+            if (mergedPastAttendance[code]) {
+                mergedPastAttendance[code] = [...mergedPastAttendance[code], ...records];
+            } else {
+                mergedPastAttendance[code] = records;
+            }
+        }
+    }
+
+    const update: Partial<SyncedData> = {
+        pastAttendance: mergedPastAttendance,
+        lastSync: Date.now(),
+    };
+
+    sendToIframe(Messages.syncUpdate(update as SyncedData));
+}

--- a/src/services/sync/syncPastSemesters.ts
+++ b/src/services/sync/syncPastSemesters.ts
@@ -2,8 +2,7 @@ import { fetchPastSemesterData } from '../../api/subjects';
 import { IndexedDBService } from '../storage';
 import { sendToIframe } from '../../injector/iframeManager';
 import { Messages } from '../../types/messages';
-import type { AvailablePeriod, SubjectAttendance } from '../../types/documents';
-import type { SubjectsData } from '../../types/documents';
+import type { AvailablePeriod, SubjectAttendance, SubjectsData } from '../../types/documents';
 import type { SyncedData } from '../../types/messages/base';
 
 const META_KEY_PREFIX = 'past_semester_';
@@ -17,7 +16,6 @@ export async function syncPastSemesters(
     if (pastPeriods.length === 0) return;
 
     const mergedPastAttendance: Record<string, SubjectAttendance[]> = {};
-    const mergedPastSubjects: Record<string, SubjectsData['data'][string]> = {};
 
     for (const period of pastPeriods) {
         const cacheKey = `${META_KEY_PREFIX}${period.id}`;
@@ -41,9 +39,6 @@ export async function syncPastSemesters(
             }
         }
 
-        if (subjects) {
-            Object.assign(mergedPastSubjects, subjects.data);
-        }
         for (const [code, records] of Object.entries(attendance)) {
             if (mergedPastAttendance[code]) {
                 mergedPastAttendance[code] = [...mergedPastAttendance[code], ...records];

--- a/src/store/slices/createSubjectsSlice.ts
+++ b/src/store/slices/createSubjectsSlice.ts
@@ -7,6 +7,7 @@ export const createSubjectsSlice: AppSlice<SubjectsSlice> = (set, get) => ({
     courseNicknames: {},
     courseDeadlines: {},
     attendance: {},
+    pastAttendance: {},
     fetchSubjects: async () => {
         // Only show loading on the first call. Subsequent sync-driven refreshes
         // must not flip isLoaded and cause a UI flash while cached data is visible.
@@ -29,6 +30,15 @@ export const createSubjectsSlice: AppSlice<SubjectsSlice> = (set, get) => ({
         }
     },
     setAttendance: (data) => set({ attendance: data }),
+    setPastAttendance: (incoming) => set(s => {
+        const merged: Record<string, import('../../types/documents').SubjectAttendance[]> = { ...s.pastAttendance };
+        for (const [code, records] of Object.entries(incoming)) {
+            merged[code] = s.pastAttendance[code]
+                ? [...s.pastAttendance[code], ...records]
+                : records;
+        }
+        return { pastAttendance: merged };
+    }),
     setCourseNickname: (courseCode, nickname) => {
         const currentNicknames = get().courseNicknames;
         const newNicknames = { ...currentNicknames };

--- a/src/store/slices/createSubjectsSlice.ts
+++ b/src/store/slices/createSubjectsSlice.ts
@@ -30,15 +30,7 @@ export const createSubjectsSlice: AppSlice<SubjectsSlice> = (set, get) => ({
         }
     },
     setAttendance: (data) => set({ attendance: data }),
-    setPastAttendance: (incoming) => set(s => {
-        const merged: Record<string, import('../../types/documents').SubjectAttendance[]> = { ...s.pastAttendance };
-        for (const [code, records] of Object.entries(incoming)) {
-            merged[code] = s.pastAttendance[code]
-                ? [...s.pastAttendance[code], ...records]
-                : records;
-        }
-        return { pastAttendance: merged };
-    }),
+    setPastAttendance: (data) => set({ pastAttendance: data }),
     setCourseNickname: (courseCode, nickname) => {
         const currentNicknames = get().courseNicknames;
         const newNicknames = { ...currentNicknames };

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -84,8 +84,10 @@ export interface SubjectsSlice {
     courseNicknames: Record<string, string>;
     courseDeadlines: Record<string, CourseDeadline[]>;
     attendance: Record<string, SubjectAttendance[]>;
+    pastAttendance: Record<string, SubjectAttendance[]>;
     fetchSubjects: () => Promise<void>;
     setAttendance: (data: Record<string, SubjectAttendance[]>) => void;
+    setPastAttendance: (data: Record<string, SubjectAttendance[]>) => void;
     setCourseNickname: (courseCode: string, nickname: string | null) => void;
     setCourseDeadlines: (courseCode: string, deadlines: CourseDeadline[] | null) => void;
 }

--- a/src/types/documents.ts
+++ b/src/types/documents.ts
@@ -107,11 +107,17 @@ export interface Assessment {
     detailUrl?: string; // Relative URL for details
 }
 
+export interface AvailablePeriod {
+    id: string;    // e.g. "801"
+    label: string; // e.g. "ZS 2025/2026 - PEF"
+}
+
 export interface CourseGrade {
     period: string;        // "ZS 2025/2026 - PEF"
     predmetId: string;     // "159410"
     courseCode?: string;   // "DSND" — short code from second table cell
     courseName: string;    // "Algoritmizace"
+    courseNameEn?: string; // English name from EN parallel fetch
     examType: string;      // "zk" | "záp" | "zak"
     attempt: number | null;
     gradeText: string;     // "dobře plus (D)"

--- a/src/types/messages/base.ts
+++ b/src/types/messages/base.ts
@@ -4,7 +4,7 @@ import type { IskamData } from '../iskam';
 export type DataRequestType = 'schedule' | 'exams' | 'subjects' | 'files' | 'assessments' | 'all';
 export type ActionType = 'register_exam' | 'unregister_exam' | 'toggle_outlook_sync' | 'download_file' | 'trigger_sync' | 'open_url' | 'logout';
 
-export interface SyncedData { schedule?: unknown; exams?: unknown; subjects?: unknown; files?: unknown; assessments?: unknown; syllabuses?: unknown; cvicneTests?: unknown; odevzdavarny?: unknown; classmates?: Record<string, unknown>; attendance?: Record<string, unknown>; studyPlan?: DualLanguageStudyPlan; studyStats?: StudyStats; isSyncing?: boolean; lastSync: number; error?: string; }
+export interface SyncedData { schedule?: unknown; exams?: unknown; subjects?: unknown; files?: unknown; assessments?: unknown; syllabuses?: unknown; cvicneTests?: unknown; odevzdavarny?: unknown; classmates?: Record<string, unknown>; attendance?: Record<string, unknown>; pastAttendance?: Record<string, unknown>; studyPlan?: DualLanguageStudyPlan; studyStats?: StudyStats; isSyncing?: boolean; lastSync: number; error?: string; }
 
 
 export interface ReadyMessage { type: 'REIS_READY'; }


### PR DESCRIPTION
## What

Three fixes in one pipeline pass:

### 1. Session-state coupling eliminated
`fetchDualLanguageSubjects` now always passes explicit `?studium=X;obdobi=Y` to `list.pl`. Previously it omitted `obdobi`, making IS Mendelu return whichever semester its server session had last selected — a silent data corruption vector.

### 2. Past semester attendance via list.pl
New `syncPastSemesters` service fetches every past period shown in the `list.pl` dropdown via `fetchPastSemesterData(studium, obdobiId)`. Results are **permanently cached in IDB** (`meta:'past_semester_${id}'`) — past semesters are immutable facts, there is no reason to re-fetch them on every sync. On subsequent loads, cached data is loaded from IDB without a network request.

Past attendance is merged into a new `pastAttendance` store field and surfaced in `AttendanceSection` via `attendance[code] ?? pastAttendance[code]`. No other UI changes.

The `dok_server/strom_od.pl` approach (`mergePastSubjects`) is kept as fallback for subjects older than what IS shows in the dropdown. Since cached past subjects are injected into `subjects.data` before `mergePastSubjects` runs, the dok_server only fills truly historical subjects — natural complementarity, zero conflict.

### 3. Grade history dual-language
`fetchGradeHistory` now fetches CZ and EN in parallel, merges `courseNameEn` onto each `CourseGrade` by `predmetId`. One extra network request per grade history sync; zero store/IDB changes.

## Test plan
- [ ] Build passes (`npm run build`)
- [ ] All 45 test files pass (`npm run test:run`)
- [ ] Network tab: current semester subjects URL includes `?studium=...;obdobi=...`
- [ ] After first sync, `meta:'past_semester_801'` (or equivalent) exists in IDB
- [ ] After second sync, no network requests fire for past semester URLs
- [ ] Subject drawer for a past-semester subject shows attendance records

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Grade history now includes English course names alongside Czech titles.
  * Historical semester data is now accessible and cached, allowing you to view past attendance records and subject information.
  * App now supports retrieving and displaying data across multiple semester periods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->