### PR TITLE
fix/feat: study plan & file drawer improvements

### DIFF
--- a/src/api/subjects.ts
+++ b/src/api/subjects.ts
@@ -197,6 +197,7 @@ function parseSubjectFolders(htmlString: string): Record<string, SubjectLinkData
                         ? rawAutoHref
                         : new URL(rawAutoHref, `${BASE_URL}/auth/`).href;
                 } catch { autoHref = null; }
+                if (autoHref && !autoHref.startsWith('https://') && !autoHref.startsWith('http://')) autoHref = null;
             }
 
             subjectMap[subjectName] = {

--- a/src/components/SubjectFileDrawer/index.tsx
+++ b/src/components/SubjectFileDrawer/index.tsx
@@ -77,6 +77,16 @@ export function SubjectFileDrawer({ lesson, isOpen, onClose }: { lesson: BlockLe
     const groupedFiles = useMemo(() => {
         if (!state.files) return [];
         const otherFolder = t('course.footer.other');
+        const knownFolderKeys: Record<string, string> = {
+            'informace k výuce': 'fileCategories.informace_k_vyuce',
+            'studijní texty': 'fileCategories.studijni_texty',
+            'materiály z přednášek': 'fileCategories.materialy_z_prednasek',
+            'průvodce studiem předmětu': 'fileCategories.pruvodce_studiem',
+        };
+        const translateFolder = (name: string) => {
+            const i18nKey = knownFolderKeys[name.toLowerCase()];
+            return i18nKey ? (t(i18nKey) || name) : name;
+        };
         const groups = new Map<string, ParsedFile[]>();
         state.files.forEach(f => {
             const sub = f.subfolder?.trim() || otherFolder;
@@ -85,7 +95,8 @@ export function SubjectFileDrawer({ lesson, isOpen, onClose }: { lesson: BlockLe
         });
         return Array.from(groups.keys()).sort((a, b) => a === otherFolder ? 1 : b === otherFolder ? -1 : a.localeCompare(b, 'cs'))
             .map(key => ({
-                name: key, displayName: key === otherFolder ? otherFolder : cleanFolderName(key, lesson?.courseCode),
+                name: key,
+                displayName: key === otherFolder ? otherFolder : translateFolder(cleanFolderName(key, lesson?.courseCode)),
                 files: groups.get(key)!.sort((a, b) => (a.file_comment || a.file_name).localeCompare(b.file_comment || b.file_name, 'cs', { numeric: true }))
             }));
     }, [state.files, lesson, t]);

--- a/src/components/SubjectsPanel/SemesterSection.tsx
+++ b/src/components/SubjectsPanel/SemesterSection.tsx
@@ -11,6 +11,7 @@ interface SemesterSectionProps {
   failRates?: Record<string, number | null>;
   zameraniLookup?: Map<string, Zamerani>;
   zameraniProgress?: Map<string, ZameraniProgress>;
+  subjectSemesters?: Map<string, string[]>;
   onToggle: () => void;
   onOpenSubject: (courseCode: string, courseName: string, courseId: string, facultyCode?: string, initialTab?: 'files' | 'stats' | 'syllabus' | 'classmates', isFulfilled?: boolean) => void;
   onSearchSubject: (name: string) => void;
@@ -46,7 +47,7 @@ const stateConfig: Record<SemesterState, {
   },
 };
 
-export function SemesterSection({ block, open, dimmed, failRates, zameraniLookup, zameraniProgress, onToggle, onOpenSubject, onSearchSubject }: SemesterSectionProps) {
+export function SemesterSection({ block, open, dimmed, failRates, zameraniLookup, zameraniProgress, subjectSemesters, onToggle, onOpenSubject, onSearchSubject }: SemesterSectionProps) {
   const state = getSemesterState(block);
   const cfg = stateConfig[state];
 
@@ -115,6 +116,7 @@ export function SemesterSection({ block, open, dimmed, failRates, zameraniLookup
                     failRate={failRates?.[s.code]}
                     zamerani={zameraniLookup?.get(normalizeZameraniName(s.name)) ?? null}
                     zameraniProgress={zameraniProgress?.get(normalizeZameraniName(s.name)) ?? null}
+                    subjectSemesters={subjectSemesters}
                     onOpenSubject={onOpenSubject}
                     onSearchSubject={onSearchSubject}
                   />

--- a/src/components/SubjectsPanel/SubjectRow.tsx
+++ b/src/components/SubjectsPanel/SubjectRow.tsx
@@ -16,6 +16,7 @@ interface SubjectRowProps {
   hideStatus?: boolean;
   zamerani?: Zamerani | null;
   zameraniProgress?: ZameraniProgress | null;
+  subjectSemesters?: Map<string, string[]>;
 }
 
 // Zaměření pseudo-subjects in the plan table always carry these code prefixes.
@@ -24,7 +25,7 @@ const isZameraniCode = (code: string) => ZAMERANI_PREFIXES.some(p => code.starts
 // IS Mendelu uses 999 as a sentinel "credits unknown / pass-through" value.
 const isSentinelCredits = (credits: number) => credits >= 999;
 
-export function SubjectRow({ subject, compact, failRate, hideStatus, onOpenSubject, onSearchSubject, zamerani, zameraniProgress }: SubjectRowProps) {
+export function SubjectRow({ subject, compact, failRate, hideStatus, onOpenSubject, onSearchSubject, zamerani, zameraniProgress, subjectSemesters }: SubjectRowProps) {
   const { t } = useTranslation();
   const hasId = subject.id !== '';
   const displayName = useCourseName(subject.code, subject.name);
@@ -81,12 +82,26 @@ export function SubjectRow({ subject, compact, failRate, hideStatus, onOpenSubje
         {zamerani && zamerani.subjects.length > 0 && (
           <div className="pl-5 flex flex-col gap-0.5">
             <div className="text-[10px] uppercase tracking-wider text-base-content/40">{t('subjects.zameraniMembers')}</div>
-            {zamerani.subjects.map(s => (
-              <div key={s.code} className="text-[11px] text-base-content/60 truncate">
-                <span className="font-mono text-base-content/70">{s.code}</span>
-                {s.name !== s.code && <span> — {s.name}</span>}
-              </div>
-            ))}
+            {[...zamerani.subjects].sort((a, b) => {
+              const sa = subjectSemesters?.get(a.code)?.[0] ?? '999';
+              const sb = subjectSemesters?.get(b.code)?.[0] ?? '999';
+              return Number(sa) - Number(sb);
+            }).map(s => {
+              const sems = subjectSemesters?.get(s.code);
+              return (
+                <div key={s.code} className="text-[11px] text-base-content/60 flex items-center gap-1.5 min-w-0">
+                  <span className="font-mono text-base-content/70 shrink-0">{s.code}</span>
+                  {s.name !== s.code && <span className="truncate"> — {s.name}</span>}
+                  {sems && (
+                    <span className="flex gap-1 shrink-0 ml-auto">
+                      {sems.map(n => (
+                        <span key={n} className="text-[10px] text-base-content/40 font-medium whitespace-nowrap">{n}. {t('subjects.semesterShort')}</span>
+                      ))}
+                    </span>
+                  )}
+                </div>
+              );
+            })}
           </div>
         )}
       </div>

--- a/src/components/SubjectsPanel/index.tsx
+++ b/src/components/SubjectsPanel/index.tsx
@@ -101,6 +101,22 @@ export function SubjectsPanel({ onOpenSubject, onSearchSubject }: SubjectsPanelP
     return map;
   }, [plan]);
 
+  // Maps each subject code to the semester numbers it appears in (e.g. ["4", "5"]).
+  const subjectSemesters = useMemo(() => {
+    const map = new Map<string, string[]>();
+    if (!plan) return map;
+    for (const block of plan.blocks) {
+      const num = block.title.match(/^(\d+)/)?.[1];
+      if (!num) continue;
+      for (const g of block.groups) for (const s of g.subjects) {
+        const existing = map.get(s.code);
+        if (existing) existing.push(num);
+        else map.set(s.code, [num]);
+      }
+    }
+    return map;
+  }, [plan]);
+
   // Pure reduce over existing data: for each zaměření, count how many of its
   // member subjects are currently enrolled or already fulfilled. Used both by
   // the header progress indicator and the zaměření card.
@@ -186,6 +202,7 @@ export function SubjectsPanel({ onOpenSubject, onSearchSubject }: SubjectsPanelP
                   failRates={failRates}
                   zameraniLookup={zameraniLookup}
                   zameraniProgress={zameraniProgress}
+                  subjectSemesters={subjectSemesters}
                   onToggle={() => handleToggle(bi)}
                   onOpenSubject={onOpenSubject}
                   onSearchSubject={onSearchSubject}

--- a/src/components/SubjectsPanel/utils.ts
+++ b/src/components/SubjectsPanel/utils.ts
@@ -10,6 +10,8 @@ export function getSemesterState(block: SemesterBlock): SemesterState {
   if (all.length === 0) return 'future';
   const hasEnrolled = all.some(s => s.isEnrolled);
   if (hasEnrolled) return 'current';
+  const isNotActivated = /neaktiv/i.test(block.title) || /not been activated/i.test(block.title);
+  if (isNotActivated) return 'future';
   const allFulfilled = all.every(s => s.isFulfilled);
   if (allFulfilled) return 'past';
   const hasFulfilled = all.some(s => s.isFulfilled);

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -421,6 +421,7 @@
     "notEnoughEnrolled": "málo zapsáno",
     "zamerani": "zaměření",
     "zameraniMembers": "Obsahuje předměty",
+    "semesterShort": "sem.",
     "zameraniProgress": "Zaměření: plní se {touched}, nutno splnit {min}",
     "zadost": "Žádosti",
     "sourcesMismatch": "Rozdíl mezi zdroji: plán {plan} kr., statistiky {stats} kr."

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -419,6 +419,7 @@
     "notEnoughEnrolled": "not enough enrolled",
     "zamerani": "specialization",
     "zameraniMembers": "Includes courses",
+    "semesterShort": "sem.",
     "zameraniProgress": "Specializations: {touched} started, must complete {min}",
     "zadost": "Requests",
     "sourcesMismatch": "Source mismatch: plan {plan} cr., stats {stats} cr."


### PR DESCRIPTION
## Summary

- **fix:** Folder section names in the file drawer now translate with language preference (e.g. "Informace k výuce" → "Teaching Info") using existing `fileCategories` i18n keys
- **fix:** Semesters marked "dosud neaktivní" (not yet activated) no longer flip to `past` state when a recognized mobility course is already fulfilled
- **feat:** Zaměření (specialization) cards now show which semester each member subject is offered in, sorted by semester number ascending

## Test plan

- [ ] Switch language to EN — "Informace k výuce" / "Studijní texty" etc. should appear translated in the Files drawer
- [ ] Open a future semester that contains a recognized International Mobility Course — it should render with the future (non-compact) row UI, not the past/compact UI
- [ ] Open a zaměření card — each subject should show a "N. sem." label on the right, sorted by semester number

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Subjects now display semester numbers alongside their codes and names
  * Pseudo-subject members are sorted by their first semester occurrence
  * Folder category names are now properly translated to Czech

* **Bug Fixes**
  * Stricter URL validation for subject folder links (only HTTP/HTTPS protocols accepted)
  * Improved detection and labeling of inactive semesters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->