### PR TITLE
fix: clear IndexedDB on ISKAM logout, remove duplicate clear on IS logout

### DIFF
--- a/src/injector/iskamMessageHandler.ts
+++ b/src/injector/iskamMessageHandler.ts
@@ -1,5 +1,6 @@
 import { isIframeMessage } from '../types/messages';
 import { iskamIframeElement, markIskamIframeReady } from './iskamInjector';
+import { IndexedDBService } from '../services/storage/IndexedDBService';
 import { fetchVolneKapacityBlock } from '../api/iskam/volneKapacity';
 
 const IFRAME_ORIGIN = chrome.runtime.getURL('').replace(/\/$/, '');
@@ -31,6 +32,11 @@ export async function handleIskamMessage(event: MessageEvent): Promise<void> {
     }
 
     if (data.type === 'REIS_ACTION' && data.action === 'logout') {
+        try {
+            await IndexedDBService.clearAll();
+        } catch {
+            // Best-effort clear
+        }
         try {
             const form = document.createElement('form');
             form.method = 'POST';

--- a/src/injector/iskamMessageHandler.ts
+++ b/src/injector/iskamMessageHandler.ts
@@ -34,8 +34,8 @@ export async function handleIskamMessage(event: MessageEvent): Promise<void> {
     if (data.type === 'REIS_ACTION' && data.action === 'logout') {
         try {
             await IndexedDBService.clearAll();
-        } catch {
-            // Best-effort clear
+        } catch (error) {
+            console.warn('[reIS:iskam] IndexedDB clear failed during logout', error);
         }
         try {
             const form = document.createElement('form');

--- a/src/injector/messageHandler.ts
+++ b/src/injector/messageHandler.ts
@@ -5,7 +5,6 @@ import { fetchFullSemesterSchedule } from "./dataFetchers";
 import { fetchExamData, registerExam, unregisterExam } from "../api/exams";
 import { fetchSubjects } from "../api/subjects";
 import type { DataRequestType } from "../types/messages";
-import { IndexedDBService } from "../services/storage/IndexedDBService";
 import { scrapedNavMenu } from "./sniper";
 
 let topUpPopupRef: Window | null = null;
@@ -112,12 +111,6 @@ async function handleAction(id: string, action: string, payload: unknown) {
                     console.warn("Not in an authenticated session. No need to log out.");
                     result = { success: false, reason: 'not_authenticated' };
                     break;
-                }
-
-                try {
-                    await IndexedDBService.clearAll();
-                } catch (e) {
-                    console.error("Failed to clear injector IndexedDB during logout", e);
                 }
 
                 const existingForm = document.querySelector('form[action="/auth/system/logout.pl"]') as HTMLFormElement;


### PR DESCRIPTION
## Summary

- **ISKAM logout now clears IndexedDB** — financial/personal data (balance, transactions, food history, room profile) was surviving in `reis_db` after WebISKAM logout. Added `IndexedDBService.clearAll()` before the logout form POST in `iskamMessageHandler.ts`.
- **Removed duplicate `clearAll()` from IS Mendelu content script** — `proxyClient.ts` already calls `clearAll()` in the iframe before sending the `logout` action. The second call in `messageHandler.ts` was redundant; removed along with the unused import.

## Test plan

- [ ] Log into WebISKAM, open DevTools → Application → IndexedDB → `reis_db`, click logout — confirm all stores are empty after redirect
- [ ] Log into IS Mendelu, same DevTools check — confirm stores are empty after logout
- [ ] `npm run typecheck` passes
- [ ] `npm run build` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced logout process to clear locally stored session data before signing out
  * Data clearing uses best-effort approach; logout completes successfully regardless of any clearing failures
  * Warnings logged if data clearing encounters issues
<!-- end of auto-generated comment: release notes by coderabbit.ai -->