### PR TITLE
fix(telemetry): sanitize hardening, logError consolidation, full coverage sweep

### DIFF
--- a/src/api/cvicneTests.ts
+++ b/src/api/cvicneTests.ts
@@ -1,3 +1,5 @@
+import { logError } from '../utils/reportError';
+
 export interface CvicnyTest {
     courseId: string;
     courseNameCs: string;
@@ -66,7 +68,7 @@ async function fetchLang(studium: string, lang: 'cz' | 'en'): Promise<RawTest[] 
 
         return tests;
     } catch (error) {
-        console.error("Error fetching cvicne testy:", error);
+        logError('Api.fetchCvicneTests', error);
         return null;
     }
 }

--- a/src/api/documents/service.ts
+++ b/src/api/documents/service.ts
@@ -3,6 +3,7 @@ import { requestQueue, processWithDelay } from "../../utils/requestQueue";
 import { parseServerFiles } from "./parser";
 import { fetchSubjects } from "../subjects";
 import { validateUrl } from "../../utils/validation/index";
+import { logError } from "../../utils/reportError";
 import type { ParsedFile, FileAttachment } from "../../types/documents";
 
 export async function fetchDocumentsForSubject(subjectCode: string): Promise<FileAttachment[]> {
@@ -47,12 +48,12 @@ export async function fetchFilesFromFolder(
                 const { files: pageFiles } = parseServerFiles(pageText);
                 
                 if (pageFiles.length === 0) {
-                    console.warn(`[fetchFilesFromFolder] Pagination page ${pageUrl} returned 0 files, possibly non-standard grouping.`);
+                    logError('Documents.paginationEmpty', new Error('pagination page returned 0 files'));
                 }
-                
+
                 return pageFiles;
             } catch (err) {
-                console.warn(`[fetchFilesFromFolder] Paged ${pageUrl} failed, skipping:`, err);
+                logError('Documents.paginationFetch', err);
                 return [];
             }
         });
@@ -67,7 +68,10 @@ export async function fetchFilesFromFolder(
         }, 0);
 
         if (totalRecords !== undefined && baseFilesCount < totalRecords) {
-            console.warn(`[fetchFilesFromFolder] Integrity warning for ${folderUrl}: Expected ${totalRecords} items, but parsed ${baseFilesCount}. IS may group multiple files in one row.`);
+            logError(
+                'Documents.integrityMismatch',
+                new Error(`expected ${totalRecords} items, parsed ${baseFilesCount}`),
+            );
         }
 
         if (recursive && currentDepth < maxDepth) {
@@ -87,7 +91,7 @@ export async function fetchFilesFromFolder(
                     results.forEach(r => r.subfolder = f.name);
                     return results;
                 } catch (err) {
-                    console.error(`[fetchFilesFromFolder] Subfolder ${f.name} failed (recurse depth ${currentDepth}):`, err);
+                    logError('Documents.subfolderFetch', err, { depth: currentDepth });
                     return []; // Resilience: return empty array instead of failing the whole fetch
                 }
             }, 200);
@@ -114,7 +118,7 @@ export async function fetchFilesFromFolder(
 
         return finalResults;
     } catch (e) {
-        console.error(`[fetchFilesFromFolder] Failed to fetch folder ${folderUrl}:`, e);
+        logError('Documents.fetchFilesFromFolder', e);
         throw e;
     }
 }

--- a/src/api/exams.ts
+++ b/src/api/exams.ts
@@ -4,6 +4,7 @@ import { parseExamData } from "../utils/parsers/exams";
 import type { ExamSubject } from "../types/exams";
 import { fetchWithAuth } from "./client";
 import { getUserParams } from "../utils/userParams";
+import { logError } from "../utils/reportError";
 
 /**
  * Result of exam registration/unregistration.
@@ -52,7 +53,7 @@ export async function fetchExamData(lang: string = 'cz'): Promise<ExamSubject[]>
         const data = parseExamData(html, lang);
         return data;
     } catch (error) {
-        console.error("Error fetching exam data:", error);
+        logError('Api.fetchExamData', error, { lang });
         return [];
     }
 }
@@ -117,7 +118,7 @@ export async function fetchDualLanguageExams(): Promise<ExamSubject[]> {
 
         return merged;
     } catch (error) {
-        console.error('[exams] Error fetching dual language exams:', error);
+        logError('Api.fetchDualLanguageExams', error);
         return fetchExamData('cz'); // Fallback to CZ
     }
 }
@@ -150,7 +151,7 @@ export async function registerExam(termId: string): Promise<ExamActionResult> {
         return { success: false, error: 'Registrace se nepodařila ověřit. Zkontrolujte v IS.' };
         
     } catch (error) {
-        console.error("Error registering for exam:", error);
+        logError('Api.registerExam', error);
         return { success: false, error: 'Chyba připojení. Zkuste to znovu.' };
     }
 }
@@ -169,7 +170,7 @@ export async function unregisterExam(termId: string): Promise<ExamActionResult> 
         return { success: true };
         
     } catch (error) {
-        console.error("Error unregistering from exam:", error);
+        logError('Api.unregisterExam', error);
         return { success: false, error: 'Chyba připojení. Zkuste to znovu.' };
     }
 }

--- a/src/api/gradeHistory.ts
+++ b/src/api/gradeHistory.ts
@@ -1,6 +1,7 @@
 import { fetchWithAuth, BASE_URL } from './client';
 import { parseOptionalInt } from '../utils/parsers/parserGuards';
 import type { GradeHistory, CourseGrade } from '../types/documents';
+import { logError } from '../utils/reportError';
 
 export async function fetchGradeHistory(
     studium: string,
@@ -27,7 +28,7 @@ export async function fetchGradeHistory(
 
         return result;
     } catch (e) {
-        console.warn('[gradeHistory] fetchGradeHistory failed:', e);
+        logError('Api.fetchGradeHistory', e);
         return null;
     }
 }

--- a/src/api/iskam/profile.ts
+++ b/src/api/iskam/profile.ts
@@ -2,21 +2,22 @@ import { requestIskam } from './client';
 import { parseProfile } from '../../utils/parsers/iskam/profile';
 import { parsePendingPayments } from '../../utils/parsers/iskam/pendingPayments';
 import type { IskamProfile, PendingPayment } from '../../types/iskam';
+import { logError } from '../../utils/reportError';
 
 export async function fetchProfileAndPayments(): Promise<{ profile: IskamProfile | null; pendingPayments: PendingPayment[] }> {
     let html: string;
     try {
         html = await requestIskam('/InformaceOKlientovi');
     } catch (e) {
-        console.warn('[reIS:iskam] fetchProfileAndPayments network failed', e);
+        logError('Iskam.fetchProfileAndPayments:network', e);
         return { profile: null, pendingPayments: [] };
     }
 
     let profile: IskamProfile | null = null;
-    try { profile = parseProfile(html); } catch (e) { console.warn('[reIS:iskam] parseProfile failed', e); }
+    try { profile = parseProfile(html); } catch (e) { logError('Iskam.parseProfile', e); }
 
     let pendingPayments: PendingPayment[] = [];
-    try { pendingPayments = parsePendingPayments(html); } catch (e) { console.warn('[reIS:iskam] parsePendingPayments failed', e); }
+    try { pendingPayments = parsePendingPayments(html); } catch (e) { logError('Iskam.parsePendingPayments', e); }
 
     return { profile, pendingPayments };
 }

--- a/src/api/iskam/reservations.ts
+++ b/src/api/iskam/reservations.ts
@@ -1,13 +1,14 @@
 import { requestIskam } from './client';
 import { parseReservations } from '../../utils/parsers/iskam/reservations';
 import type { IskamReservation } from '../../types/iskam';
+import { logError } from '../../utils/reportError';
 
 export async function fetchReservations(): Promise<IskamReservation[]> {
     try {
         const html = await requestIskam('/Rezervace');
         return parseReservations(html);
     } catch (e) {
-        console.warn('[reIS:iskam] fetchReservations failed', e);
+        logError('Iskam.fetchReservations', e);
         return [];
     }
 }

--- a/src/api/kontrola.ts
+++ b/src/api/kontrola.ts
@@ -1,3 +1,5 @@
+import { logError } from '../utils/reportError';
+
 export interface KontrolaData {
     datumNarozeni: string; // ISO date: "YYYY-MM-DD"
 }
@@ -33,7 +35,7 @@ export async function fetchKontrolaData(): Promise<KontrolaData | null> {
         }
         return null;
     } catch (e) {
-        console.error('[kontrola] fetch error:', e);
+        logError('Api.fetchKontrolaData', e);
         return null;
     }
 }

--- a/src/api/odevzdavarny.ts
+++ b/src/api/odevzdavarny.ts
@@ -1,3 +1,5 @@
+import { logError } from '../utils/reportError';
+
 export interface Odevzdavarna {
     courseId: string;
     courseNameCs: string;
@@ -101,7 +103,7 @@ async function fetchLang(studium: string, obdobi: string, lang: 'cz' | 'en'): Pr
 
         return assignments;
     } catch (error) {
-        console.error("Error fetching odevzdavarny:", error);
+        logError('Api.fetchOdevzdavarnyLang', error);
         return null;
     }
 }

--- a/src/api/pastSubjects.ts
+++ b/src/api/pastSubjects.ts
@@ -1,4 +1,5 @@
 import { fetchWithAuth, BASE_URL } from "./client";
+import { logError } from "../utils/reportError";
 
 const PAST_SUBJECTS_TREE_URL = `${BASE_URL}/auth/dok_server/strom_od.pl?id=6`;
 
@@ -15,7 +16,7 @@ export async function fetchPastSubjectFolders(lang: string = 'cz'): Promise<Reco
         const html = await response.text();
         return parsePastSubjectTree(html);
     } catch (e) {
-        console.warn('[pastSubjects] fetchPastSubjectFolders failed:', e);
+        logError('Api.fetchPastSubjectFolders', e, { lang });
         return {};
     }
 }

--- a/src/api/proxyClient.ts
+++ b/src/api/proxyClient.ts
@@ -6,6 +6,7 @@ import { pendingFetches, pendingActions, REQUEST_TIMEOUT } from './proxy/pending
 import { initProxyListener } from './proxy/messageListener';
 import { IndexedDBService } from '../services/storage/IndexedDBService';
 import { clearUserParamsCache } from '../utils/userParams';
+import { logError } from '../utils/reportError';
 
 export async function fetchViaProxy(url: string, opts?: MsgTypes.FetchRequestMessage['options']): Promise<string> {
     initProxyListener();
@@ -39,7 +40,7 @@ export async function logout(): Promise<void> {
     try {
         await IndexedDBService.clearAll();
     } catch (e) {
-        console.warn('Failed to clear local IndexedDB during logout', e);
+        logError('ProxyClient.logout:clearAll', e);
     }
     return executeAction('logout', {});
 }

--- a/src/api/schedule.ts
+++ b/src/api/schedule.ts
@@ -2,6 +2,7 @@ import { fetchWithAuth, BASE_URL } from "./client";
 import { getUserId } from "./user";
 import { getScheduleFormat } from "../utils/date";
 import { getUserParams } from "../utils/userParams";
+import { logError } from "../utils/reportError";
 import type { BlockLesson, ScheduleData } from "../types/schedule";
 
 const SCHEDULE_URL = `${BASE_URL}/auth/katalog/rozvrhy_view.pl`;
@@ -70,11 +71,11 @@ export async function fetchWeekSchedule(specific?: { start: Date, end: Date }, l
             const data: ScheduleData = JSON.parse(text);
             return data.blockLessons || [];
         } catch (e) {
-            console.warn('[schedule] JSON parse failed:', e);
+            logError('Api.fetchWeekSchedule:jsonParse', e);
             return null;
         }
     } catch (error) {
-        console.error("[fetchWeekSchedule] Error fetching schedule:", error);
+        logError('Api.fetchWeekSchedule', error, { lang });
         return null;
     }
 }
@@ -119,7 +120,7 @@ export async function fetchDualLanguageSchedule(dateRange: { start: Date, end: D
 
         return merged;
     } catch (error) {
-        console.error('[fetchDualLanguageSchedule] Error:', error);
+        logError('Api.fetchDualLanguageSchedule', error);
         return null;
     }
 }

--- a/src/api/studyPlan.ts
+++ b/src/api/studyPlan.ts
@@ -74,7 +74,7 @@ export async function fetchDualLanguageStudyPlan(studium: string): Promise<DualL
 
         return { cz: czPlan, en: enPlan };
     } catch (e) {
-        console.error('[Study Plan API] Failed to fetch or parse:', e);
+        logError('Api.fetchDualLanguageStudyPlan', e);
         return null;
     }
 }

--- a/src/api/studyStats.ts
+++ b/src/api/studyStats.ts
@@ -1,5 +1,6 @@
 import { fetchWithAuth, BASE_URL } from "./client";
 import type { StudyStats, SemesterStats } from "../types/studyPlan";
+import { logError } from "../utils/reportError";
 
 const STATS_URL = `${BASE_URL}/auth/student/pruchod_studiem.pl`;
 
@@ -10,7 +11,7 @@ export async function fetchStudyStats(studium: string, obdobi: string): Promise<
         const doc = new DOMParser().parseFromString(html, 'text/html');
         return parseStudyStats(doc);
     } catch (e) {
-        console.error('[Study Stats API] Failed to fetch:', e);
+        logError('Api.fetchStudyStats', e);
         return null;
     }
 }

--- a/src/api/subjects.ts
+++ b/src/api/subjects.ts
@@ -3,6 +3,7 @@
 import { fetchWithAuth, BASE_URL } from "./client";
 import type { SubjectInfo, SubjectsData, SubjectAttendance, AttendanceRecord, AttendanceStatus, AvailablePeriod } from "../types/documents";
 import { SubjectsDataSchema } from "../schemas/subjectSchema";
+import { logError } from "../utils/reportError";
 
 const STUDENT_LIST_URL = `${BASE_URL}/auth/student/list.pl`;
 
@@ -25,7 +26,7 @@ export async function fetchSubjects(lang: string = 'cz', studium?: string): Prom
             return subjectsData;
         }
     } catch (e) {
-        console.warn('[subjects] fetchSubjects failed:', e);
+        logError('Api.fetchSubjects', e, { lang });
         return null;
     }
 }
@@ -85,7 +86,7 @@ export async function fetchPastSemesterData(studium: string, obdobi: string): Pr
         const subjectsData: SubjectsData = { version: 1, lastUpdated: new Date().toISOString(), data: merged };
         return { subjects: subjectsData, attendance, availablePeriods: [] };
     } catch (e) {
-        console.warn('[subjects] fetchPastSemesterData failed:', e);
+        logError('Api.fetchPastSemesterData', e);
         return null;
     }
 }
@@ -150,7 +151,7 @@ export async function fetchDualLanguageSubjects(studium?: string, obdobi?: strin
         const availablePeriods = parseAvailablePeriods(czHtml);
         return { subjects: result.success ? result.data : subjectsData, attendance, availablePeriods };
     } catch (e) {
-        console.warn('[subjects] fetchDualLanguageSubjects failed:', e);
+        logError('Api.fetchDualLanguageSubjects', e);
         return null;
     }
 }

--- a/src/api/syllabus.ts
+++ b/src/api/syllabus.ts
@@ -3,6 +3,7 @@
 import { fetchWithAuth, BASE_URL } from "./client";
 import { parseSyllabusOffline } from "../utils/parsers/syllabusParser";
 import type { SyllabusRequirements } from "../types/documents";
+import { logError } from "../utils/reportError";
 
 /**
  * Fetch syllabus requirements for a specific subject.
@@ -21,7 +22,7 @@ export async function fetchSyllabus(predmetId: string, lang: string = 'cz'): Pro
 
         return parsed;
     } catch (error) {
-        console.error(`[fetchSyllabus] Failed for predmetId ${predmetId}:`, error);
+        logError('Api.fetchSyllabus', error, { predmetId, lang });
         
         // Return empty structure on error (graceful degradation)
         return {
@@ -99,7 +100,7 @@ export async function findSubjectId(courseCode: string, subjectName?: string): P
         return bestMatchId;
         
     } catch (error) {
-        console.error(`[findSubjectId] Error searching for ${courseCode}:`, error);
+        logError('Api.findSubjectId', error, { courseCode });
         return null;
     }
 }

--- a/src/api/teachingWeek.ts
+++ b/src/api/teachingWeek.ts
@@ -1,5 +1,6 @@
 import { fetchWithAuth } from './client';
 import { getStudium } from '../utils/userParams';
+import { logError } from '../utils/reportError';
 
 const PREHLED_URL = 'https://is.mendelu.cz/auth/ca/prehled_tydnu.pl';
 
@@ -73,7 +74,7 @@ export async function fetchTeachingWeeks(): Promise<TeachingWeekData | null> {
         const html = await res.text();
         return parseTeachingWeeks(html);
     } catch (e) {
-        console.warn('[teachingWeek] fetchTeachingWeeks failed:', e);
+        logError('Api.fetchTeachingWeeks', e);
         return null;
     }
 }

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -2,6 +2,7 @@
  
 import { fetchWithAuth, BASE_URL } from "./client";
 import { IndexedDBService } from "../services/storage";
+import { logError } from "../utils/reportError";
 
 const ID_URL = `${BASE_URL}/auth/student/studium.pl`;
 
@@ -24,7 +25,7 @@ export async function fetchUserId(): Promise<string | null> {
         }
         return null;
     } catch (error) {
-        console.error("Failed to fetch user ID:", error);
+        logError('Api.fetchUserId', error);
         return null;
     }
 }
@@ -40,7 +41,7 @@ export async function getUserId(): Promise<string | null> {
             return fetchedId;
         }
     } catch (err) {
-        console.error("[api/user] Failed to get user ID:", err);
+        logError('Api.getUserId', err);
     }
 
     return null;

--- a/src/components/Feedback/FeedbackModal.tsx
+++ b/src/components/Feedback/FeedbackModal.tsx
@@ -4,6 +4,7 @@ import { X, Send, Loader2, CheckCircle2 } from 'lucide-react';
 import { DISCORD_WEBHOOK_URL } from '../../constants/config';
 import { toast } from 'sonner';
 import { useTranslation } from '../../hooks/useTranslation';
+import { logError } from '../../utils/reportError';
 
 interface FeedbackModalProps {
   isOpen: boolean;
@@ -53,7 +54,7 @@ export function FeedbackModal({ isOpen, onClose }: FeedbackModalProps) {
         throw new Error('Failed to send');
       }
     } catch (error) {
-      console.error('Feedback error:', error);
+      logError('FeedbackModal.send', error);
       toast.error(t('feedback.toastError'));
     } finally {
       setIsSending(false);

--- a/src/components/Onboarding/WelcomeModal.tsx
+++ b/src/components/Onboarding/WelcomeModal.tsx
@@ -6,6 +6,7 @@ import { IndexedDBService } from '../../services/storage';
 import { useTranslation } from '../../hooks/useTranslation';
 import { useOutlookSync } from '../../hooks/data/useOutlookSync';
 import { useAppStore } from '../../store/useAppStore';
+import { logError } from '../../utils/reportError';
 
 export function WelcomeModal() {
     const [isVisible, setIsVisible] = useState(false);
@@ -23,7 +24,7 @@ export function WelcomeModal() {
                     return () => clearTimeout(timer);
                 }
             } catch (err) {
-                console.error('[WelcomeModal] Failed to check status:', err);
+                logError('WelcomeModal.checkStatus', err);
             }
         }
         checkWelcome();
@@ -39,7 +40,7 @@ export function WelcomeModal() {
 
     const handleDismiss = () => {
         setIsVisible(false);
-        IndexedDBService.set('meta', 'welcome_dismissed', true).catch(console.error);
+        IndexedDBService.set('meta', 'welcome_dismissed', true).catch(e => logError('WelcomeModal.dismiss', e));
     };
 
 

--- a/src/components/Sidebar/NavItem.tsx
+++ b/src/components/Sidebar/NavItem.tsx
@@ -7,6 +7,7 @@ import { useAppStore } from '../../store/useAppStore';
 import { useTranslation } from '../../hooks/useTranslation';
 import { PagePinnerModal } from './PagePinnerModal';
 import { IndexedDBService } from '../../services/storage';
+import { logError } from '../../utils/reportError';
 
 interface NavItemProps {
   item: MenuItem;
@@ -30,7 +31,7 @@ export function NavItem({ item, isActive, isHovered, onMouseEnter, onMouseLeave,
     if (item.id === 'is' && isHovered && pinnedPages.length === 0) {
       IndexedDBService.get('meta', 'pin_hint_dismissed').then(dismissed => {
         if (!dismissed) setShowPinHint(true);
-      }).catch(console.error);
+      }).catch(e => logError('NavItem.checkPinHint', e));
     }
   }, [item.id, isHovered, pinnedPages.length]);
 
@@ -167,7 +168,7 @@ export function NavItem({ item, isActive, isHovered, onMouseEnter, onMouseLeave,
                     setPinnerOpen(true); 
                     if (showPinHint) {
                       setShowPinHint(false);
-                      IndexedDBService.set('meta', 'pin_hint_dismissed', true).catch(console.error);
+                      IndexedDBService.set('meta', 'pin_hint_dismissed', true).catch(e => logError('NavItem.dismissPinHint', e));
                     }
                   }}
                   className="flex items-center gap-2 w-full px-3 py-2 rounded-lg text-sm text-base-content/40 hover:bg-base-200 hover:text-primary transition-colors relative"

--- a/src/components/SubjectsPanel/index.tsx
+++ b/src/components/SubjectsPanel/index.tsx
@@ -7,6 +7,7 @@ import { computeFailRate } from './computeFailRate';
 import { SemesterSection } from './SemesterSection';
 import { SubjectsPanelSkeleton } from './SubjectsPanelSkeleton';
 import { IndexedDBService } from '@/services/storage';
+import { logError } from '@/utils/reportError';
 import type { Zamerani } from '@/types/studyPlan';
 import { getSemesterState, isRealCredits, normalizeZameraniName, buildSubjectSemesters } from './utils';
 
@@ -71,7 +72,7 @@ export function SubjectsPanel({ onOpenSubject, onSearchSubject }: SubjectsPanelP
   // Persist to IndexedDB on change (skip the initial load)
   useEffect(() => {
     if (!idbLoaded) return;
-    IndexedDBService.set('meta', IDB_KEY, Array.from(openSemesters)).catch(console.error);
+    IndexedDBService.set('meta', IDB_KEY, Array.from(openSemesters)).catch(e => logError('SubjectsPanel.persistOpenSemesters', e));
   }, [openSemesters, idbLoaded]);
 
   // Auto-scroll to the first current semester on initial render

--- a/src/hooks/data/useDocumentNote.ts
+++ b/src/hooks/data/useDocumentNote.ts
@@ -7,6 +7,7 @@
 
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { IndexedDBService } from '../../services/storage/IndexedDBService';
+import { logError } from '../../utils/reportError';
 import type { DocumentNote } from '../../types/documents';
 
 const MAX_NOTE_LENGTH = 500;
@@ -33,7 +34,7 @@ export function useDocumentNote(courseCode: string, fileLink: string | undefined
             : IndexedDBService.delete('document_notes', key);
 
         op.then(() => { hasChangesRef.current = false; })
-            .catch((error) => { console.warn('[useDocumentNote] Failed to save:', error); });
+            .catch((error) => { logError('useDocumentNote.save', error); });
     }, []);
 
     useEffect(() => {
@@ -62,7 +63,7 @@ export function useDocumentNote(courseCode: string, fileLink: string | undefined
                 setIsLoading(false);
             })
             .catch((error) => {
-                console.warn('[useDocumentNote] Failed to load:', error);
+                logError('useDocumentNote.load', error);
                 if (currentKeyRef.current !== key) return;
                 setNoteState('');
                 noteRef.current = '';

--- a/src/hooks/data/useDocumentNoteKeys.ts
+++ b/src/hooks/data/useDocumentNoteKeys.ts
@@ -7,6 +7,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { IndexedDBService } from '../../services/storage/IndexedDBService';
+import { logError } from '../../utils/reportError';
 
 export function useDocumentNoteKeys(courseCode: string) {
     const [noteKeys, setNoteKeys] = useState<Set<string>>(new Set());
@@ -26,7 +27,7 @@ export function useDocumentNoteKeys(courseCode: string) {
                 setNoteKeys(links);
             })
             .catch((error) => {
-                console.warn('[useDocumentNoteKeys] Failed to load:', error);
+                logError('useDocumentNoteKeys.load', error);
             });
     }, [courseCode]);
 

--- a/src/hooks/ui/useFileDownload.ts
+++ b/src/hooks/ui/useFileDownload.ts
@@ -2,6 +2,7 @@ import { useState, useCallback } from 'react';
 import JSZip from 'jszip';
 import { saveAs } from 'file-saver';
 import { resolveFinalFileUrl } from './useFileDownload/urlResolver';
+import { logError } from '../../utils/reportError';
 
 export interface FileInfo { url: string; name: string; subfolder?: string; }
 export interface UseFileDownloadOptions { onRefreshUrls?: () => Promise<FileInfo[] | null>; onDownloadStart?: () => void; onDownloadComplete?: () => void; onError?: (error: Error) => void; }
@@ -47,7 +48,7 @@ export function useFileDownload(options: UseFileDownloadOptions = {}) {
                     let name = m?.[1] || f.name;
                     if (f.subfolder) name = `${f.subfolder.replace(/^\/|\/$/g, '').replace(/\//g, '_')}_${name}`;
                     zip.file(name, await r.blob());
-                } catch (e) { console.warn(e); }
+                } catch (e) { logError('useFileDownload.zipEntry', e); }
             }));
             saveAs(await zip.generateAsync({ type: 'blob' }), `${zipName}.zip`);
             onDownloadComplete?.();

--- a/src/hooks/ui/useFileDownload/urlResolver.ts
+++ b/src/hooks/ui/useFileDownload/urlResolver.ts
@@ -1,3 +1,5 @@
+import { logError } from '../../../utils/reportError';
+
 export async function resolveFinalFileUrl(link: string): Promise<string> {
     link = link.replace(/\?;/g, '?').replace(/;/g, '&');
     const auth = "https://is.mendelu.cz/auth", root = "https://is.mendelu.cz";
@@ -21,7 +23,7 @@ export async function resolveFinalFileUrl(link: string): Promise<string> {
                     else full = `${auth}/dok_server/${h}`;
                 }
             }
-        } catch (e) { console.warn(e); }
+        } catch (e) { logError('urlResolver.resolveFinalFileUrl', e); }
     }
     return full;
 }

--- a/src/hooks/useEventsFacultySettings.ts
+++ b/src/hooks/useEventsFacultySettings.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { IndexedDBService } from '../services/storage';
 import { getUserParams } from '../utils/userParams';
+import { logError } from '../utils/reportError';
 import type { FacultyKey } from '../types/events';
 import { FACULTY_LABEL_TO_KEY } from '../types/events';
 
@@ -28,7 +29,7 @@ export function useEventsFacultySettings() {
 
       setSubscribedFaculties(saved);
     } catch (err) {
-      console.warn('[useEventsFacultySettings] Failed to load:', err);
+      logError('useEventsFacultySettings.load', err);
     } finally {
       setIsLoading(false);
     }
@@ -51,7 +52,7 @@ export function useEventsFacultySettings() {
       await IndexedDBService.set('meta', STORAGE_KEY, next);
       window.dispatchEvent(new Event(CHANGE_EVENT));
     } catch (err) {
-      console.warn('[useEventsFacultySettings] Failed to save:', err);
+      logError('useEventsFacultySettings.save', err);
     }
   };
 

--- a/src/hooks/useEventsFeed.ts
+++ b/src/hooks/useEventsFeed.ts
@@ -3,6 +3,7 @@ import { fetchEvents } from '../api/events';
 import { useEventsFacultySettings } from './useEventsFacultySettings';
 import { useAppStore } from '../store/useAppStore';
 import { IndexedDBService } from '../services/storage';
+import { logError } from '../utils/reportError';
 import type { MendeluEvent } from '../types/events';
 
 const CACHE_PREFIX = 'reis_events_cache_';
@@ -30,7 +31,7 @@ export function useEventsFeed() {
       setAllEvents(events);
       IndexedDBService.set('meta', cacheKey, events);
     } catch (e) {
-      console.warn('[useEventsFeed] Fetch failed:', e);
+      logError('useEventsFeed.load', e);
     } finally {
       setLoading(false);
     }

--- a/src/hooks/useExamDrawerLogic.ts
+++ b/src/hooks/useExamDrawerLogic.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import { registerExam, unregisterExam } from '../api/exams';
 import { useExams } from '../hooks/data';
 import { useAppStore } from '../store/useAppStore';
+import { logError } from '../utils/reportError';
 import type { ExamSection, ExamTerm } from '../types/exams';
 
 export function useExamDrawerLogic(isOpen: boolean) {
@@ -24,7 +25,7 @@ export function useExamDrawerLogic(isOpen: boolean) {
             }
             if (await registerExam(termId)) { await fetchExams(); setPopupSection(null); }
             else alert("Reg failed");
-        } catch (e) { console.error(e); } finally { setProcessingId(null); }
+        } catch (e) { logError('useExamDrawerLogic.register', e); } finally { setProcessingId(null); }
     }, [fetchExams]);
 
     useEffect(() => {

--- a/src/hooks/useSpolkySettings.ts
+++ b/src/hooks/useSpolkySettings.ts
@@ -1,7 +1,8 @@
 import { useState, useEffect, useCallback } from 'react';
-import { IndexedDBService } from '../services/storage'; 
+import { IndexedDBService } from '../services/storage';
 import { FACULTY_TO_ASSOCIATION } from '../services/spolky/config';
 import { getUserParams } from '../utils/userParams';
+import { logError } from '../utils/reportError';
 
 // New key for full list
 const STORAGE_KEY = 'reis_subscribed_associations';
@@ -55,7 +56,7 @@ export function useSpolkySettings() {
               }
           }
       } catch (err) {
-          console.error('[useSpolkySettings] Failed to load settings:', err);
+          logError('useSpolkySettings.load', err);
       } finally {
           setIsLoading(false);
       }
@@ -90,7 +91,7 @@ export function useSpolkySettings() {
         // Dispatch event for other hooks in the same tab
         window.dispatchEvent(new Event('reis-spolky-settings-changed'));
     } catch (err) {
-        console.error('[useSpolkySettings] Failed to save setting:', err);
+        logError('useSpolkySettings.save', err);
     }
   };
 

--- a/src/hooks/useUserParams.ts
+++ b/src/hooks/useUserParams.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { logError } from '../utils/reportError';
 import { getUserParams } from '../utils/userParams';
 import type { UserParams } from '../utils/userParams';
 
@@ -16,7 +17,7 @@ export function useUserParams() {
                     setParams(data);
                 }
             } catch (error) {
-                console.error("Error in useUserParams:", error);
+                logError('useUserParams', error);
             } finally {
                 if (mounted) {
                     setLoading(false);

--- a/src/injector/iskamMessageHandler.ts
+++ b/src/injector/iskamMessageHandler.ts
@@ -1,5 +1,5 @@
-import { isIframeMessage } from '../types/messages';
-import { iskamIframeElement, markIskamIframeReady } from './iskamInjector';
+import { isIframeMessage, Messages } from '../types/messages';
+import { iskamIframeElement, markIskamIframeReady, sendToIskamIframe } from './iskamInjector';
 import { IndexedDBService } from '../services/storage/IndexedDBService';
 import { fetchVolneKapacityBlock } from '../api/iskam/volneKapacity';
 
@@ -25,7 +25,7 @@ export async function handleIskamMessage(event: MessageEvent): Promise<void> {
                 iskamIframeElement?.contentWindow?.postMessage({ type: 'ISKAM_BLOCK_RESULT', id, rooms }, IFRAME_ORIGIN);
             })
             .catch(err => {
-                console.error('[reIS:iskam] ISKAM_FETCH_BLOCK error, blockId:', blockId, err);
+                sendToIskamIframe(Messages.telemetryError('IskamMessageHandler.fetchBlock', err));
                 iskamIframeElement?.contentWindow?.postMessage({ type: 'ISKAM_BLOCK_RESULT', id, rooms: [] }, IFRAME_ORIGIN);
             });
         return;
@@ -35,7 +35,7 @@ export async function handleIskamMessage(event: MessageEvent): Promise<void> {
         try {
             await IndexedDBService.clearAll();
         } catch (error) {
-            console.warn('[reIS:iskam] IndexedDB clear failed during logout', error);
+            sendToIskamIframe(Messages.telemetryError('IskamMessageHandler.logout:clearAll', error));
         }
         try {
             const form = document.createElement('form');

--- a/src/injector/iskamSyncService.ts
+++ b/src/injector/iskamSyncService.ts
@@ -23,7 +23,6 @@ export async function syncIskamData(): Promise<void> {
             window.location.href = `${ISKAM_BASE}/ObjednavkyStravovani`;
             return;
         }
-        console.error('[reIS:iskam] sync error', err);
         sendToIskamIframe(Messages.telemetryError('IskamSyncService.syncIskamData', err));
         sendToIskamIframe(IskamMessages.iskamSyncUpdate(cachedIskamData, false, 'network'));
     } finally {

--- a/src/injector/syncService.ts
+++ b/src/injector/syncService.ts
@@ -197,14 +197,12 @@ async function syncSubjectDetails(subjectsValue: { data: Record<string, { folder
                     // Persist skupinaId for use in the UI if needed
                     subjectsValue.data[courseCode].skupinaId = skupinaId;
                 } catch (e) {
-                    console.error(`[syncClassmates] Error for ${courseCode}:`, e);
                     sendToIframe(Messages.telemetryError('SyncService.syncClassmates', e));
                 }
             }));
 
         await Promise.all(classmateTasks);
     } catch (e) {
-        console.error('[syncClassmates] Error fetching group map:', e);
         sendToIframe(Messages.telemetryError('SyncService.syncClassmates:groupMap', e));
     }
 }

--- a/src/services/errorReporter/__tests__/reporter.test.ts
+++ b/src/services/errorReporter/__tests__/reporter.test.ts
@@ -109,6 +109,22 @@ describe('installErrorReporter', () => {
         expect(supabase.rpc).not.toHaveBeenCalled();
     });
 
+    it('does not stringify non-Error rejection reasons (privacy)', async () => {
+        cleanup = installErrorReporter(() => true);
+        const ev = new Event('unhandledrejection') as PromiseRejectionEvent;
+        const reason = { studentName: 'Jan Novák', grade: 'A', courseCode: 'ALG' };
+        Object.defineProperty(ev, 'reason', { value: reason, configurable: true });
+        window.dispatchEvent(ev);
+        await flush();
+        expect(supabase.rpc).toHaveBeenCalledTimes(1);
+        const [, args] = (supabase.rpc as ReturnType<typeof vi.fn>).mock.calls[0];
+        expect(args.p_error_message).not.toContain('Jan');
+        expect(args.p_error_message).not.toContain('Novák');
+        expect(args.p_error_message).not.toContain('ALG');
+        expect(args.p_error_message).toContain('non-error rejection');
+        expect(args.p_error_message).toContain('object');
+    });
+
     it('handles unhandledrejection events', async () => {
         cleanup = installErrorReporter(() => true);
         const reason = new Error('promise blew up');

--- a/src/services/errorReporter/__tests__/sanitize.test.ts
+++ b/src/services/errorReporter/__tests__/sanitize.test.ts
@@ -112,6 +112,17 @@ describe('sanitizeFilePath', () => {
         const out = sanitizeFilePath(long);
         expect(out.length).toBeLessThanOrEqual(500);
     });
+
+    it('scrubs mendelu.cz URLs in non-extension paths', () => {
+        const out = sanitizeFilePath('https://intranet.mendelu.cz/scripts/main.js');
+        expect(out).not.toContain('mendelu.cz');
+        expect(out).not.toContain('intranet');
+    });
+
+    it('scrubs email addresses in non-extension paths', () => {
+        const out = sanitizeFilePath('/app/student@mendelu.cz/bundle.js');
+        expect(out).not.toContain('@');
+    });
 });
 
 describe('getBrowserInfo', () => {

--- a/src/services/errorReporter/__tests__/sanitize.test.ts
+++ b/src/services/errorReporter/__tests__/sanitize.test.ts
@@ -18,6 +18,17 @@ describe('sanitizeMessage', () => {
         expect(out).not.toContain('mendelu.cz');
     });
 
+    it('strips non-MENDELU email addresses', () => {
+        const out = sanitizeMessage('Erasmus contact alice.smith@uni-foo.de bounced');
+        expect(out).not.toContain('alice.smith@uni-foo.de');
+    });
+
+    it('strips arbitrary mendelu.cz subdomains', () => {
+        const out = sanitizeMessage('fetch https://intranet.mendelu.cz/x?id=123 failed');
+        expect(out).not.toContain('intranet.mendelu.cz');
+        expect(out).not.toContain('id=123');
+    });
+
     it('strips Bearer tokens', () => {
         const out = sanitizeMessage('401 with Bearer eyJhbGciOiJIUzI1NiJ9.foo');
         expect(out).not.toContain('eyJhbGciOiJIUzI1NiJ9.foo');

--- a/src/services/errorReporter/reporter.ts
+++ b/src/services/errorReporter/reporter.ts
@@ -59,7 +59,10 @@ function normalizeFromRejection(ev: PromiseRejectionEvent): NormalizedError | nu
     } else if (typeof reason === 'string') {
         rawMessage = reason;
     } else {
-        try { rawMessage = JSON.stringify(reason); } catch { rawMessage = String(reason); }
+        // Never JSON.stringify the reason: arbitrary objects (parsed payloads,
+        // Response bodies) can contain student data the regex set won't redact.
+        // The type tag is enough to identify the rejection class.
+        rawMessage = `<non-error rejection: ${typeof reason}>`;
     }
     const message = sanitizeMessage(rawMessage);
     if (!message) return null;

--- a/src/services/errorReporter/sanitize.ts
+++ b/src/services/errorReporter/sanitize.ts
@@ -15,10 +15,11 @@ const PATTERNS: RegExp[] = [
     /\b(?:Bearer|Basic|Token)\s+[A-Za-z0-9._\-+/=]+/gi,
     // Cookie / Set-Cookie payloads
     /(?:Cookie|Set-Cookie)\s*[:=]\s*[^\s;]+/gi,
-    // MENDELU email addresses (covers @mendelu.cz, @node.mendelu.cz, etc.)
-    /[\w.+-]+@(?:[\w-]+\.)*mendelu\.cz/gi,
-    // is.mendelu.cz / webiskam.mendelu.cz URLs (with or without query)
-    /https?:\/\/(?:is|webiskam|node)\.mendelu\.cz[^\s)]*/gi,
+    // Any email address — a non-MENDELU address (Erasmus contacts, gmail in
+    // user-typed text) is still PII once paired with anything else.
+    /[\w.+-]+@[\w-]+(?:\.[\w-]+)+/g,
+    // Any *.mendelu.cz URL (with or without query)
+    /https?:\/\/(?:[\w-]+\.)*mendelu\.cz[^\s)]*/gi,
     // 6-to-7-digit student/staff IDs — negative look-around avoids matching
     // longer numbers (timestamps, counts) while catching UIDs embedded in strings.
     /(?<!\d)\d{6,7}(?!\d)/g,
@@ -45,6 +46,8 @@ export function sanitizeFilePath(input: unknown): string {
         const slash = out.lastIndexOf('/');
         if (slash !== -1) out = out.slice(slash + 1);
     }
+    // Defensive: if a non-extension path slips through, still scrub PII patterns.
+    for (const re of PATTERNS) out = out.replace(re, REDACT);
     if (out.length > MAX_PATH_LEN) out = out.slice(0, MAX_PATH_LEN);
     return out;
 }

--- a/src/services/spolky/spolkyService.ts
+++ b/src/services/spolky/spolkyService.ts
@@ -1,6 +1,7 @@
 import type { SpolekNotification, AssociationProfile } from './types';
 import { FACULTY_TO_ASSOCIATION, ASSOCIATION_PROFILES } from './config';
 import { supabase } from './supabaseClient';
+import { logError } from '../../utils/reportError';
 
 // ... rest of imports
 
@@ -20,8 +21,7 @@ export async function trackNotificationsViewed(notificationIds: string[]): Promi
       )
     );
   } catch (error) {
-    // Fail silently but log error
-    console.error(error);
+    logError('Spolky.trackNotificationsViewed', error);
   }
 }
 
@@ -33,11 +33,9 @@ export async function trackNotificationClick(notificationId: string): Promise<vo
   if (!notificationId) return;
 
   try {
-    // Call Supabase RPC to increment click count
     await supabase.rpc('increment_notification_click', { row_id: notificationId });
   } catch (error) {
-    // Fail silently
-    console.error(error);
+    logError('Spolky.trackNotificationClick', error);
   }
 }
 

--- a/src/services/sync/syncFiles.ts
+++ b/src/services/sync/syncFiles.ts
@@ -4,6 +4,7 @@
 
 import { IndexedDBService } from '../storage';
 import { fetchFilesFromFolder } from '../../api/documents';
+import { logError } from '../../utils/reportError';
 
 function getIdFromUrl(url: string): string | null {
     const match = url.match(/[?&;]id=(\d+)/);
@@ -40,7 +41,7 @@ export async function syncFiles(): Promise<void> {
                 en: Array.isArray(enFiles) ? enFiles : []
             });
         } catch (e) {
-            console.error(`[syncFiles] Failed for ${courseCode}:`, e);
+            logError('Sync.syncFiles', e, { courseCode });
         }
     }
 

--- a/src/services/sync/syncSyllabus.ts
+++ b/src/services/sync/syncSyllabus.ts
@@ -5,6 +5,7 @@
 import { IndexedDBService } from '../storage';
 import { fetchSyllabus, findSubjectId } from '../../api/syllabus';
 import type { SyllabusRequirements } from '../../types/documents';
+import { logError } from '../../utils/reportError';
 
 export async function syncSyllabus(): Promise<void> {
     const subjectsData = await IndexedDBService.get('subjects', 'current');
@@ -27,7 +28,7 @@ export async function syncSyllabus(): Promise<void> {
                 en: enSyllabus
             });
         } catch (e) {
-            console.error(`[syncSyllabus] Failed for ${courseCode}:`, e);
+            logError('Sync.syncSyllabus', e, { courseCode });
         }
     }
 }

--- a/src/store/slices/createClassmatesSlice.ts
+++ b/src/store/slices/createClassmatesSlice.ts
@@ -1,5 +1,6 @@
 import type { ClassmatesSlice, AppSlice } from '../types';
 import { IndexedDBService } from '../../services/storage';
+import { logError } from '../../utils/reportError';
 
 /**
  * Classmates slice — IDB-read-only pattern (mirrors files slice).
@@ -25,7 +26,7 @@ export const createClassmatesSlice: AppSlice<ClassmatesSlice> = (set, get) => ({
                 classmatesLoading: { ...s.classmatesLoading, [courseCode]: false },
             }));
         } catch (error) {
-            console.error(`[ClassmatesSlice] Error loading from IDB for ${courseCode}:`, error);
+            logError('ClassmatesSlice.fetchClassmates', error, { courseCode });
             set((s) => ({
                 classmates: { ...s.classmates, [courseCode]: [] },
                 classmatesLoading: { ...s.classmatesLoading, [courseCode]: false },

--- a/src/store/slices/createContextSlice.ts
+++ b/src/store/slices/createContextSlice.ts
@@ -1,6 +1,6 @@
 import type { ContextSlice, AppSlice } from '../types';
 import { getUserParams } from '../../utils/userParams';
-import { sendTelemetry } from '../../services/errorReporter/telemetry';
+import { logError } from '../../utils/reportError';
 
 export const createContextSlice: AppSlice<ContextSlice> = (set) => ({
     studiumId: null,
@@ -27,8 +27,7 @@ export const createContextSlice: AppSlice<ContextSlice> = (set) => ({
                 });
             }
         } catch (err) {
-            console.error("Failed to load user context", err);
-            sendTelemetry('ContextSlice.loadContext', err);
+            logError('ContextSlice.loadContext', err);
         }
     },
 });

--- a/src/store/slices/createCustomEventsSlice.ts
+++ b/src/store/slices/createCustomEventsSlice.ts
@@ -1,7 +1,7 @@
 import type { CalendarCustomEventsSlice, AppSlice } from '../types';
 import { IndexedDBService } from '../../services/storage';
 import type { CalendarCustomEvent } from '../../types/calendarTypes';
-import { sendTelemetry } from '../../services/errorReporter/telemetry';
+import { logError } from '../../utils/reportError';
 
 export const createCustomEventsSlice: AppSlice<CalendarCustomEventsSlice> = (set, get) => ({
   customEvents: [],
@@ -13,8 +13,7 @@ export const createCustomEventsSlice: AppSlice<CalendarCustomEventsSlice> = (set
         set({ customEvents: data.map(item => item.value as CalendarCustomEvent) });
       }
     } catch (error) {
-      console.error('Failed to load custom events:', error);
-      sendTelemetry('CustomEventsSlice.loadCalendarCustomEvents', error);
+      logError('CustomEventsSlice.loadCalendarCustomEvents', error);
     }
   },
 

--- a/src/store/slices/createCvicneTestsSlice.ts
+++ b/src/store/slices/createCvicneTestsSlice.ts
@@ -1,7 +1,7 @@
 import type { CvicneTestsSlice, AppSlice } from '../types';
 import { IndexedDBService } from '../../services/storage';
 import { getUserParams } from '../../utils/userParams';
-import { sendTelemetry } from '../../services/errorReporter/telemetry';
+import { logError } from '../../utils/reportError';
 
 export const createCvicneTestsSlice: AppSlice<CvicneTestsSlice> = (set, get) => ({
   cvicneTests: [],
@@ -25,8 +25,7 @@ export const createCvicneTestsSlice: AppSlice<CvicneTestsSlice> = (set, get) => 
         set({ cvicneTestsStatus: 'success', cvicneTests: [] });
       }
     } catch (e) {
-      console.warn('[CvicneTestsSlice] fetchCvicneTests failed:', e);
-      sendTelemetry('CvicneTestsSlice.fetchCvicneTests', e);
+      logError('CvicneTestsSlice.fetchCvicneTests', e);
       set({ cvicneTestsStatus: 'error' });
     }
   },
@@ -56,7 +55,7 @@ export const createCvicneTestsSlice: AppSlice<CvicneTestsSlice> = (set, get) => 
         set({ odevzdavarnyStatus: 'success', odevzdavarny: [] });
       }
     } catch (e) {
-      console.warn('[CvicneTestsSlice] fetchOdevzdavarny failed:', e);
+      logError('CvicneTestsSlice.fetchOdevzdavarny', e);
       set({ odevzdavarnyStatus: 'error' });
     }
   },

--- a/src/store/slices/createErasmusSlice.ts
+++ b/src/store/slices/createErasmusSlice.ts
@@ -5,7 +5,6 @@ import { fetchJsonViaProxy } from '../../api/proxyClient';
 import { IndexedDBService } from '../../services/storage';
 import { loggers } from '../../utils/logger';
 import { logError } from '../../utils/reportError';
-import { sendTelemetry } from '../../services/errorReporter/telemetry';
 import type { AIComparisonResult } from '../../api/gemini';
 
 const TABLE_A_COURSES_KEY = 'erasmus_table_a_courses'; // Legacy
@@ -75,8 +74,7 @@ export const createErasmusSlice: AppSlice<ErasmusSlice> = (set, get) => ({
       set({ universities: { ...get().universities, [alpha2]: parsed } });
       await IndexedDBService.set('meta', `${UNIVERSITIES_KEY_PREFIX}:${alpha2}`, parsed);
     } catch (err) {
-      loggers.ui.error('[ErasmusSlice] fetchUniversities failed:', err);
-      console.error('[fetchUniversities] raw error:', err);
+      logError('ErasmusSlice.fetchUniversities', err);
     } finally {
       set({ universitiesLoading: { ...get().universitiesLoading, [alpha2]: false } });
     }
@@ -327,7 +325,6 @@ export const createErasmusSlice: AppSlice<ErasmusSlice> = (set, get) => ({
       }
     } catch (e) {
       logError('ErasmusSlice.loadErasmusState', e);
-      sendTelemetry('ErasmusSlice.loadErasmusState', e);
     }
   },
 });

--- a/src/store/slices/createErasmusSlice.ts
+++ b/src/store/slices/createErasmusSlice.ts
@@ -106,7 +106,7 @@ export const createErasmusSlice: AppSlice<ErasmusSlice> = (set, get) => ({
       const data = await fetchErasmusReports(file);
       if (data) set({ erasmusData: data });
     } catch (err) {
-      loggers.ui.error('[ErasmusSlice] Fetch failed:', err);
+      logError('ErasmusSlice.setErasmusCountry', err);
     } finally {
       set({ erasmusLoading: false });
     }
@@ -116,7 +116,7 @@ export const createErasmusSlice: AppSlice<ErasmusSlice> = (set, get) => ({
       const data = await fetchErasmusConfigApi();
       if (data) set({ erasmusConfig: data });
     } catch (err) {
-      loggers.ui.error('[ErasmusSlice] Config fetch failed:', err);
+      logError('ErasmusSlice.fetchErasmusConfig', err);
     }
   },
   fetchErasmusReports: async () => {
@@ -130,7 +130,7 @@ export const createErasmusSlice: AppSlice<ErasmusSlice> = (set, get) => ({
       const data = await fetchErasmusReports(file);
       if (data) set({ erasmusData: data });
     } catch (err) {
-      loggers.ui.error('[ErasmusSlice] Fetch failed:', err);
+      logError('ErasmusSlice.fetchErasmusReports', err);
     } finally {
       set({ erasmusLoading: false });
     }

--- a/src/store/slices/createFilesSlice.ts
+++ b/src/store/slices/createFilesSlice.ts
@@ -1,7 +1,6 @@
 import type { FilesSlice, AppSlice } from '../types';
 import { IndexedDBService } from '../../services/storage';
 import { logError } from '../../utils/reportError';
-import { sendTelemetry } from '../../services/errorReporter/telemetry';
 import type { ParsedFile } from '../../types/documents';
 
 export const createFilesSlice: AppSlice<FilesSlice> = (set, get) => ({
@@ -112,7 +111,6 @@ export const createFilesSlice: AppSlice<FilesSlice> = (set, get) => ({
             }));
         } catch (e) {
             logError('FilesSlice.fetchFilesPriority', e, { courseCode });
-            sendTelemetry('FilesSlice.fetchFilesPriority', e);
             set((state) => ({
                 files: { ...state.files, [courseCode]: [] },
                 filesLoading: { ...state.filesLoading, [courseCode]: false },
@@ -176,7 +174,6 @@ export const createFilesSlice: AppSlice<FilesSlice> = (set, get) => ({
             }));
         } catch (e) {
             logError('FilesSlice.refreshFiles', e, { courseCode });
-            sendTelemetry('FilesSlice.refreshFiles', e);
             set((state) => ({
                 files: { ...state.files, [courseCode]: state.files[courseCode] ?? [] },
                 filesLoading: { ...state.filesLoading, [courseCode]: false }
@@ -212,6 +209,6 @@ export const createFilesSlice: AppSlice<FilesSlice> = (set, get) => ({
                 }
             }
             set({ files: filesMap });
-        } catch (e) { logError('FilesSlice.fetchAllFiles', e); sendTelemetry('FilesSlice.fetchAllFiles', e); }
+        } catch (e) { logError('FilesSlice.fetchAllFiles', e); }
     },
 });

--- a/src/store/slices/createHiddenItemsSlice.ts
+++ b/src/store/slices/createHiddenItemsSlice.ts
@@ -1,6 +1,6 @@
 import type { HiddenItemsSlice, AppSlice } from '../types';
 import { IndexedDBService } from '../../services/storage';
-import { sendTelemetry } from '../../services/errorReporter/telemetry';
+import { logError } from '../../utils/reportError';
 
 export const createHiddenItemsSlice: AppSlice<HiddenItemsSlice> = (set, get) => ({
   hiddenItems: {
@@ -15,8 +15,7 @@ export const createHiddenItemsSlice: AppSlice<HiddenItemsSlice> = (set, get) => 
         set({ hiddenItems: data });
       }
     } catch (error) {
-      console.error('Failed to load hidden items:', error);
-      sendTelemetry('HiddenItemsSlice.loadHiddenItems', error);
+      logError('HiddenItemsSlice.loadHiddenItems', error);
     }
   },
 

--- a/src/store/slices/createScheduleSlice.ts
+++ b/src/store/slices/createScheduleSlice.ts
@@ -1,6 +1,6 @@
 import type { ScheduleSlice, AppSlice } from '../types';
 import { IndexedDBService } from '../../services/storage';
-import { sendTelemetry } from '../../services/errorReporter/telemetry';
+import { logError } from '../../utils/reportError';
 
 export const createScheduleSlice: AppSlice<ScheduleSlice> = (set, get) => ({
   schedule: {
@@ -27,8 +27,7 @@ export const createScheduleSlice: AppSlice<ScheduleSlice> = (set, get) => ({
       }));
 
     } catch (e) {
-      console.warn('[ScheduleSlice] fetchSchedule failed:', e);
-      sendTelemetry('ScheduleSlice.fetchSchedule', e);
+      logError('ScheduleSlice.fetchSchedule', e);
       set((state) => ({ schedule: { ...state.schedule, status: 'error' } }));
     }
   },

--- a/src/store/slices/createSubjectsSlice.ts
+++ b/src/store/slices/createSubjectsSlice.ts
@@ -1,7 +1,7 @@
 import type { SubjectsSlice, AppSlice, CourseDeadline } from '../types';
 import type { SubjectAttendance } from '../../types/documents';
 import { IndexedDBService } from '../../services/storage';
-import { sendTelemetry } from '../../services/errorReporter/telemetry';
+import { logError } from '../../utils/reportError';
 
 export const createSubjectsSlice: AppSlice<SubjectsSlice> = (set, get) => ({
     subjects: null,
@@ -29,8 +29,7 @@ export const createSubjectsSlice: AppSlice<SubjectsSlice> = (set, get) => ({
                 subjectsLoading: false,
             });
         } catch (e) {
-            console.warn('[SubjectsSlice] fetchSubjects failed:', e);
-            sendTelemetry('SubjectsSlice.fetchSubjects', e);
+            logError('SubjectsSlice.fetchSubjects', e);
             set({ subjectsLoading: false });
         }
     },
@@ -50,7 +49,7 @@ export const createSubjectsSlice: AppSlice<SubjectsSlice> = (set, get) => ({
         }
 
         set({ courseNicknames: newNicknames });
-        IndexedDBService.set('meta', 'course_nicknames', newNicknames).catch(console.error);
+        IndexedDBService.set('meta', 'course_nicknames', newNicknames).catch(e => logError('SubjectsSlice.setCourseNickname', e));
     },
     setCourseDeadlines: (courseCode, deadlines) => {
         const currentDeadlines = get().courseDeadlines;
@@ -63,6 +62,6 @@ export const createSubjectsSlice: AppSlice<SubjectsSlice> = (set, get) => ({
         }
 
         set({ courseDeadlines: newDeadlines });
-        IndexedDBService.set('meta', 'course_deadlines', newDeadlines).catch(console.error);
+        IndexedDBService.set('meta', 'course_deadlines', newDeadlines).catch(e => logError('SubjectsSlice.setCourseDeadlines', e));
     }
 });

--- a/src/store/slices/createSyllabusSlice.ts
+++ b/src/store/slices/createSyllabusSlice.ts
@@ -2,7 +2,7 @@ import type { SyllabusSlice, AppSlice } from '../types';
 import { IndexedDBService } from '../../services/storage';
 import { fetchAndCacheSingleSyllabus } from '../../services/sync/syncSyllabus';
 import type { SyllabusRequirements } from '../../types/documents';
-import { sendTelemetry } from '../../services/errorReporter/telemetry';
+import { logError } from '../../utils/reportError';
 
 const SYLLABUS_VERSION = 4; // v4: force fetch to ensure we get newest predmetId
 
@@ -62,8 +62,7 @@ export const createSyllabusSlice: AppSlice<SyllabusSlice> = (set, get) => ({
         },
       }));
     } catch (e) {
-      console.warn('[SyllabusSlice] fetchSyllabus failed:', e);
-      sendTelemetry('SyllabusSlice.fetchSyllabus', e);
+      logError('SyllabusSlice.fetchSyllabus', e);
       set((state) => ({
         syllabuses: {
           ...state.syllabuses,

--- a/src/utils/reportError.ts
+++ b/src/utils/reportError.ts
@@ -1,5 +1,9 @@
-// Console logger for non-fatal errors. Use sendTelemetry() to also forward
-// to Supabase — logError() is console-only and never transmits data.
+// Single entry point for non-fatal errors.
+// - Always console.error with stack + extras (local debugging).
+// - Forwards (context, err) to sendTelemetry — only the sanitized message is
+//   transmitted; `extra` stays local. Safe to call before initTelemetry().
+
+import { sendTelemetry } from '../services/errorReporter/telemetry';
 
 export function logError(context: string, err: unknown, extra?: Record<string, unknown>): void {
     const msg = err instanceof Error ? err.message : String(err);
@@ -8,4 +12,5 @@ export function logError(context: string, err: unknown, extra?: Record<string, u
     if (stack) payload.stack = stack;
     if (extra) Object.assign(payload, extra);
     console.error(`[reIS:error] ${context}: ${msg}`, payload);
+    sendTelemetry(context, err);
 }

--- a/src/utils/reportError.ts
+++ b/src/utils/reportError.ts
@@ -12,5 +12,9 @@ export function logError(context: string, err: unknown, extra?: Record<string, u
     if (stack) payload.stack = stack;
     if (extra) Object.assign(payload, extra);
     console.error(`[reIS:error] ${context}: ${msg}`, payload);
-    sendTelemetry(context, err);
+    try {
+        sendTelemetry(context, err);
+    } catch (telemetryErr) {
+        console.warn('[reIS:error] telemetry dispatch failed', telemetryErr);
+    }
 }

--- a/src/utils/serverTime.ts
+++ b/src/utils/serverTime.ts
@@ -1,6 +1,4 @@
-/**
- * Utility for fetching and synchronizing with IS Mendelu server time.
- */
+import { logError } from './reportError';
 
 let cachedOffset: number | null = null;
 let offsetPromise: Promise<number> | null = null;
@@ -52,7 +50,7 @@ export async function fetchServerTimeOffset(forceRefresh: boolean = false): Prom
             return offsetMs;
             
         } catch (error) {
-            console.error("[AutoReg TimeSync] Failed to sync clock with server:", error);
+            logError('serverTime.syncOffset', error);
             cachedOffset = 0; // Fallback to 0 offset (trust local clock) on failure
             return 0;
         } finally {

--- a/src/utils/userParams.ts
+++ b/src/utils/userParams.ts
@@ -1,6 +1,7 @@
 import { IndexedDBService } from "../services/storage";
 import { STORAGE_KEYS } from "../services/storage/keys";
 import { fetchUserBaseIds, fetchUserStudyDetails, fetchUserNetId } from "./userParams/fetchers";
+import { logError } from "./reportError";
 
 export interface UserParams {
     studium: string; obdobi: string; facultyId: string; username: string; email?: string;
@@ -38,7 +39,7 @@ export async function getUserParams(): Promise<UserParams | null> {
             await IndexedDBService.set('meta', STORAGE_KEYS.USER_PARAMS, params);
             _cached = params;
             return params;
-        } catch (e) { console.warn('[getUserParams] failed:', e); return null; }
+        } catch (e) { logError('getUserParams', e); return null; }
     })();
 
     try { return await _inflight; } finally { _inflight = null; }


### PR DESCRIPTION
## Summary

- **Sanitize hardening**: generalized email regex (was MENDELU-only), generalized MENDELU URL pattern to all subdomains, run redaction patterns over `sanitizeFilePath`, replaced `JSON.stringify` of non-Error rejection reasons with `<non-error rejection: typeof X>` (prevents object payloads with student data from leaking)
- **Single entry point**: `logError(context, err, extra?)` now also calls `sendTelemetry` — one import, one call; `extra` stays local only. Removed all redundant paired `sendTelemetry` calls
- **Coverage sweep**: converted ~55 raw `console.error`/`console.warn` catch blocks across `src/api/`, `src/store/slices/`, `src/services/sync/`, `src/hooks/`, `src/components/`, and `src/injector/` — everything now routes through `logError` (iframe) or the `Messages.telemetryError` postMessage bridge (content scripts)
- **3 new tests**: non-Error rejection privacy guard, generic email redaction, arbitrary `*.mendelu.cz` subdomain redaction

## Test plan
- [ ] 289 tests pass (`npx vitest run`)
- [ ] Typecheck clean (`npm run typecheck`)
- [ ] Build clean (`npm run build`)
- [ ] Lint baseline unchanged (24 pre-existing errors, none introduced)
- [ ] After publishing to Chrome Web Store, verify rows appear in `error_reports` table

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Exam list URL now respects user parameters instead of a hardcoded default.

* **Chores**
  * Centralized error reporting across the app (replaced ad-hoc console logging).
  * Improved telemetry privacy by scrubbing emails and mendelu.cz subdomains from reports.
  * Added tests to strengthen error-sanitization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->