### PR TITLE
fix(documents): fix false-positive integrity warning for subfolder-only folders

### DIFF
--- a/src/api/documents/service.ts
+++ b/src/api/documents/service.ts
@@ -61,16 +61,10 @@ export async function fetchFilesFromFolder(
         const extraResults = await Promise.all(pageRequests);
         allFiles.push(...extraResults.flat());
 
-        // Count actual file attachments (excluding subfolder links)
-        const baseFilesCount = allFiles.reduce((acc, f) => {
-            const fileCount = f.files.filter(fi => fi.link.includes('download') || !fi.link.includes('slozka.pl')).length;
-            return acc + fileCount;
-        }, 0);
-
-        if (totalRecords !== undefined && baseFilesCount < totalRecords) {
+        if (totalRecords !== undefined && allFiles.length < totalRecords) {
             logError(
                 'Documents.integrityMismatch',
-                new Error(`expected ${totalRecords} items, parsed ${baseFilesCount}`),
+                new Error(`expected ${totalRecords} items, parsed ${allFiles.length}`),
             );
         }
 


### PR DESCRIPTION
## Summary

- The integrity check in `fetchFilesFromFolder` compared `totalRecords` (all items including subfolders) against `baseFilesCount` (download-link files only), producing a false positive for folders that contain only subfolders
- Changed the comparison to use `allFiles.length` (parsed rows) which correctly includes both files and subfolders

## Test plan
- [ ] All existing unit tests pass (`npx vitest run src/api/documents/`)
- [ ] No integrity warning fires when browsing a folder that contains only subfolders (e.g. IS folder id=152414)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation logic for document pagination integrity checks. The system now accurately validates document counts against total attachments, ensuring more reliable error detection and reporting when fetching documents with pagination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->