### PR TITLE
feat(exams): attempt type visibility + timeline expand; fix documents false-positive

### DIFF
--- a/src/api/documents/service.ts
+++ b/src/api/documents/service.ts
@@ -61,16 +61,10 @@ export async function fetchFilesFromFolder(
         const extraResults = await Promise.all(pageRequests);
         allFiles.push(...extraResults.flat());
 
-        // Count actual file attachments (excluding subfolder links)
-        const baseFilesCount = allFiles.reduce((acc, f) => {
-            const fileCount = f.files.filter(fi => fi.link.includes('download') || !fi.link.includes('slozka.pl')).length;
-            return acc + fileCount;
-        }, 0);
-
-        if (totalRecords !== undefined && baseFilesCount < totalRecords) {
+        if (totalRecords !== undefined && allFiles.length < totalRecords) {
             logError(
                 'Documents.integrityMismatch',
-                new Error(`expected ${totalRecords} items, parsed ${baseFilesCount}`),
+                new Error(`expected ${totalRecords} items, parsed ${allFiles.length}`),
             );
         }
 

--- a/src/components/ExamPanel/index.tsx
+++ b/src/components/ExamPanel/index.tsx
@@ -43,7 +43,24 @@ export function ExamPanel() {
         ? `https://is.mendelu.cz/auth/student/terminy_seznam.pl?studium=${studium};obdobi=${obdobi};lang=${lang}`
         : `https://is.mendelu.cz/auth/student/prihlasovani_zkousky.pl?lang=${lang}`;
     const [expandedId, setExpandedId] = useState<string | null>(null);
+    const [timelineSelectedId, setTimelineSelectedId] = useState<string | null>(null);
     const { processingSectionId, pendingAction, setPendingAction, handleRegisterRequest, handleUnregisterRequest, handleConfirmAction } = useExamActions({ exams, setExpandedSectionId: setExpandedId });
+
+    const handleTimelineSelect = (item: TimelineExam) => {
+        const sectionId = item.section?.id;
+        if (!sectionId) return;
+        const next = timelineSelectedId === sectionId ? null : sectionId;
+        setTimelineSelectedId(next);
+        setExpandedId(next);
+    };
+
+    const handleToggleExpand = (id: string) => {
+        setExpandedId(p => {
+            const next = p === id ? null : id;
+            if (next === null) setTimelineSelectedId(null);
+            return next;
+        });
+    };
     const { armedTerms, firingTerms, toggleArm } = useAutoRegistration();
     const studiumId = useAppStore(s => s.studiumId);
     const obdobiId = useAppStore(s => s.obdobiId);
@@ -105,9 +122,8 @@ return (
                     <ExamTimeline
                         exams={realExams as unknown as TimelineExam[]}
                         orientation="horizontal"
-                        onUnregister={handleUnregisterRequest}
-                        onChangeTerm={handleRegisterRequest}
-                        processingSectionId={processingSectionId}
+                        onSelectItem={handleTimelineSelect}
+                        selectedSectionId={timelineSelectedId}
                     />
                 </div>
             )}
@@ -119,9 +135,16 @@ return (
                     <EmptyExamsState />
                     <IsMendeluLink href={href} />
                 </div>
-            ) : sections.length > 0 ? (
+            ) : timelineSelectedId ? (() => {
+                const picked = realExams.find(e => e.section.id === timelineSelectedId);
+                return picked ? (
+                    <div className="flex-1 overflow-y-auto p-4">
+                        <ExamSectionCard subject={picked.subject} section={picked.section} isExpanded={true} isProcessing={processingSectionId === picked.section.id} armedTerms={armedTerms} firingTerms={firingTerms} toggleArm={toggleArm} onToggleExpand={handleToggleExpand} onRegister={handleRegisterRequest} onUnregister={handleUnregisterRequest} />
+                    </div>
+                ) : null;
+            })() : sections.length > 0 ? (
                 <div className="flex-1 overflow-y-auto p-4 space-y-3">
-                    {sections.map(({ subject, section }: { subject: ExamSubject, section: ExamSection }) => <ExamSectionCard key={section.id} subject={subject} section={section} isExpanded={expandedId === section.id} isProcessing={processingSectionId === section.id} armedTerms={armedTerms} firingTerms={firingTerms} toggleArm={toggleArm} onToggleExpand={(id: string) => setExpandedId(p => p === id ? null : id)} onRegister={handleRegisterRequest} onUnregister={handleUnregisterRequest} />)}
+                    {sections.map(({ subject, section }: { subject: ExamSubject, section: ExamSection }) => <ExamSectionCard key={section.id} subject={subject} section={section} isExpanded={expandedId === section.id} isProcessing={processingSectionId === section.id} armedTerms={armedTerms} firingTerms={firingTerms} toggleArm={toggleArm} onToggleExpand={handleToggleExpand} onRegister={handleRegisterRequest} onUnregister={handleUnregisterRequest} />)}
                     <IsMendeluLink href={href} />
                 </div>
             ) : null}

--- a/src/components/ExamPanel/index.tsx
+++ b/src/components/ExamPanel/index.tsx
@@ -55,11 +55,9 @@ export function ExamPanel() {
     };
 
     const handleToggleExpand = (id: string) => {
-        setExpandedId(p => {
-            const next = p === id ? null : id;
-            if (next === null) setTimelineSelectedId(null);
-            return next;
-        });
+        const next = expandedId === id ? null : id;
+        setExpandedId(next);
+        if (next === null) setTimelineSelectedId(null);
     };
     const { armedTerms, firingTerms, toggleArm } = useAutoRegistration();
     const studiumId = useAppStore(s => s.studiumId);

--- a/src/components/Exams/Timeline/ExamTimeline.tsx
+++ b/src/components/Exams/Timeline/ExamTimeline.tsx
@@ -1,6 +1,5 @@
-import React, { useState } from 'react';
+import React from 'react';
 import ExamItem from './ExamItem';
-import { TimelineDrawer } from './TimelineDrawer';
 import { useTranslation } from '../../../hooks/useTranslation';
 import type { ExamSection } from '../../../types/exams';
 
@@ -16,14 +15,12 @@ interface ExamTimelineProps {
   orientation?: 'vertical' | 'horizontal';
   className?: string;
   onSelectItem?: (item: TimelineExam) => void;
-  onUnregister?: (section: ExamSection) => void;
-  onChangeTerm?: (section: ExamSection, termId: string) => void;
-  processingSectionId?: string | null;
+  selectedSectionId?: string | null;
 }
 
 const ExamTimeline: React.FC<ExamTimelineProps> = ({
   exams, orientation = 'vertical', className = '',
-  onSelectItem, onUnregister, onChangeTerm, processingSectionId
+  onSelectItem, selectedSectionId
 }) => {
   const { t, language } = useTranslation();
 
@@ -32,8 +29,6 @@ const ExamTimeline: React.FC<ExamTimelineProps> = ({
     if (!s) return undefined;
     return (language === 'en' ? s.nameEn : s.nameCs) || s.name || undefined;
   };
-  const [selectedId, setSelectedId] = useState<string | null>(null);
-
   const parseDateTime = (d: string, tStr: string) => {
     const parts = d.split('.').map(p => p.trim()).filter(p => p.length > 0);
     return new Date(+parts[2], +parts[1] - 1, +parts[0], ...tStr.split(':').map(Number) as [number, number]);
@@ -44,11 +39,8 @@ const ExamTimeline: React.FC<ExamTimelineProps> = ({
   );
 
   const isHorizontal = orientation === 'horizontal';
-  const selectedExam = selectedId ? sortedExams.find(e => e.term.id === selectedId) ?? null : null;
 
   const handleCardClick = (exam: TimelineExam) => {
-    const id = exam.term.id;
-    setSelectedId(p => p === id ? null : id);
     onSelectItem?.(exam);
   };
 
@@ -95,20 +87,12 @@ const ExamTimeline: React.FC<ExamTimelineProps> = ({
             sectionName={resolveSectionName(item)}
             deadline={item.section?.registeredTerm?.deregistrationDeadline}
             orientation="horizontal"
-            isSelected={selectedId === item.term.id}
+            isSelected={selectedSectionId === item.section?.id}
             onClick={() => handleCardClick(item)}
           />
         ))}
       </div>
 
-      {selectedExam?.section && (
-        <TimelineDrawer
-          exam={selectedExam}
-          onUnregister={onUnregister}
-          onChangeTerm={onChangeTerm}
-          isProcessing={processingSectionId === selectedExam.section.id}
-        />
-      )}
     </>
   );
 };

--- a/src/components/Exams/Timeline/ExamTimeline.tsx
+++ b/src/components/Exams/Timeline/ExamTimeline.tsx
@@ -87,7 +87,7 @@ const ExamTimeline: React.FC<ExamTimelineProps> = ({
             sectionName={resolveSectionName(item)}
             deadline={item.section?.registeredTerm?.deregistrationDeadline}
             orientation="horizontal"
-            isSelected={selectedSectionId === item.section?.id}
+            isSelected={selectedSectionId != null && selectedSectionId === item.section?.id}
             onClick={() => handleCardClick(item)}
           />
         ))}

--- a/src/components/TermTile.tsx
+++ b/src/components/TermTile.tsx
@@ -6,6 +6,7 @@ import { useAppStore } from '../store/useAppStore';
 import { SNIPER_WINDOW_MS } from './ExamPanel/useAutoRegistration';
 
 const attemptAccentClass: Record<string, string> = {
+    regular: 'bg-success/50',
     retake1: 'bg-warning/50',
     retake2: 'bg-error/50',
     retake3: 'bg-error/50',

--- a/src/components/TermTile.tsx
+++ b/src/components/TermTile.tsx
@@ -29,13 +29,13 @@ export function TermTile({ term, section, isArmed, isFiring, onToggleArm, onSele
         <div onClick={() => !disabled && onSelect()}
                 className={`relative flex flex-col w-full rounded-lg border transition-all text-left overflow-hidden ${(isArmed || isFiring) ? 'bg-warning/10 border-warning shadow-[0_0_10px_rgba(251,189,35,0.3)]' : isFuture ? 'bg-warning/5 border-warning/30' : (isFull || isClosed || isBlocked) ? 'bg-base-200 border-transparent opacity-60' : 'bg-base-100 border-transparent hover:border-primary shadow-sm cursor-pointer'}`}>
             {attemptAccent && <div className={`absolute left-0 top-0 bottom-0 w-[3px] ${attemptAccent}`} />}
-            <div className="flex flex-wrap items-center gap-x-4 gap-y-2 w-full p-3.5">
-                {/* Date: Bold & Clear */}
-                <div className="flex flex-col min-w-[70px]">
-                    <span className={`text-base font-bold tracking-tight ${disabled ? 'text-base-content/40 line-through' : 'text-base-content'}`}>
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 w-full p-2.5">
+                {/* Date */}
+                <div className="flex items-baseline gap-1.5 min-w-[58px]">
+                    <span className={`text-sm font-bold tracking-tight ${disabled ? 'text-base-content/30 line-through' : 'text-base-content'}`}>
                         {term.date.split('.').slice(0, 2).join('.')}
                     </span>
-                    <span className="text-[10px] uppercase font-bold tracking-wider opacity-40">
+                    <span className="text-[10px] uppercase tracking-wider opacity-25">
                         {getDayOfWeek(term.date, t)}
                     </span>
                 </div>
@@ -64,13 +64,13 @@ export function TermTile({ term, section, isArmed, isFiring, onToggleArm, onSele
                     </div>
                 )}
 
-                {/* Time & Room: Typographic Priority */}
-                <div className="flex flex-col min-w-[60px] ml-1">
-                    <span className={`text-base font-bold ${disabled ? 'opacity-40' : 'opacity-90'}`}>
+                {/* Time & Room */}
+                <div className="flex items-baseline gap-1.5">
+                    <span className={`text-sm font-bold ${disabled ? 'opacity-30' : 'opacity-90'}`}>
                         {term.time}
                     </span>
                     {term.room && (
-                        <span className="text-[11px] truncate opacity-50 font-medium">
+                        <span className="text-[10px] truncate opacity-25">
                             {(language === 'en' && term.roomEn) ? term.roomEn : (term.roomCs || term.room)}
                         </span>
                     )}
@@ -80,11 +80,11 @@ export function TermTile({ term, section, isArmed, isFiring, onToggleArm, onSele
                 <div className="ml-auto flex items-center justify-end gap-2 sm:gap-3 flex-wrap">
                     {isFuture ? (
                         <div className="flex items-center gap-2 sm:gap-3 justify-end flex-wrap">
-                            <div className={`flex flex-col items-end px-3 py-1.5 rounded-md border transition-colors ${isWithinSniperWindow ? 'bg-warning/10 border-warning/30' : 'bg-base-200/50 border-transparent'} min-w-0 flex-shrink-1`}>
-                                <span className={`text-[10px] font-bold ${isWithinSniperWindow ? 'text-warning' : 'opacity-40'} uppercase tracking-wider whitespace-nowrap`}>
+                            <div className={`flex flex-col items-end transition-colors ${isWithinSniperWindow ? 'text-warning' : 'text-base-content/30'}`}>
+                                <span className="text-[10px] font-bold uppercase tracking-wider whitespace-nowrap">
                                     {t('exams.opening')} {formatCountdown(msRemaining)}
                                 </span>
-                                <span className={`text-[10px] font-mono ${isWithinSniperWindow ? 'text-warning/70' : 'opacity-30'}`}>
+                                <span className="text-[10px] font-mono opacity-60">
                                     {term.registrationStart}
                                 </span>
                             </div>
@@ -132,28 +132,16 @@ export function TermTile({ term, section, isArmed, isFiring, onToggleArm, onSele
 
             </div>
 
-            {/* Constraints: Clearer and More Reliable */}
+            {/* Deadlines */}
             {term.registrationEnd && (
-                <div className="flex items-center gap-4 px-4 pb-3 text-[11px] font-medium border-t border-base-content/5 mt-[-2px] pt-2">
+                <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5 px-3 pb-2 text-[10px] font-medium border-t border-base-content/5 pt-1.5">
                     {sameDeadline ? (
-                        <span className="flex items-center gap-1.5">
-                            <span className="w-1 h-1 rounded-full bg-base-content/30" />
-                            <span className="text-base-content/50">{t('exams.registerAndUnregisterDeadline')}</span>
-                            <b className="text-base-content/80">{term.registrationEnd}</b>
-                        </span>
+                        <span className="text-base-content/40">{t('exams.registerAndUnregisterDeadline')} <b className="text-base-content/60">{term.registrationEnd}</b></span>
                     ) : (
                         <>
-                            <span className="flex items-center gap-1.5">
-                                <span className="w-1 h-1 rounded-full bg-base-content/30" />
-                                <span className="text-base-content/50">{t('exams.registerDeadline')}</span>
-                                <b className="text-base-content/80">{term.registrationEnd}</b>
-                            </span>
+                            <span className="text-base-content/40">{t('exams.registerDeadline')} <b className="text-base-content/60">{term.registrationEnd}</b></span>
                             {term.deregistrationDeadline && (
-                                <span className="flex items-center gap-1.5">
-                                    <span className="w-1 h-1 rounded-full bg-base-content/30" />
-                                    <span className="text-base-content/50">{t('exams.unregisterDeadline')}</span>
-                                    <b className="text-base-content/80">{term.deregistrationDeadline}</b>
-                                </span>
+                                <span className="text-base-content/40">{t('exams.unregisterDeadline')} <b className="text-base-content/60">{term.deregistrationDeadline}</b></span>
                             )}
                         </>
                     )}

--- a/src/components/TermTile.tsx
+++ b/src/components/TermTile.tsx
@@ -104,31 +104,29 @@ export function TermTile({ term, section, isArmed, isFiring, onToggleArm, onSele
                             )}
                         </div>
                     ) : (
-                        term.capacity && (
-                            <div className="flex items-center gap-3">
-                                <div className="flex flex-col items-end gap-1">
+                        <div className="flex items-center gap-3">
+                            {isProcessing ? (
+                                <span className="loading loading-spinner loading-sm text-primary" />
+                            ) : (isClosed || isBlocked) ? (
+                                <span className="text-[10px] font-bold opacity-30 uppercase tracking-wider">{t('exams.closed')}</span>
+                            ) : term.capacity ? (
+                                <>
                                     <div className="flex items-center gap-2">
-                                        <progress 
-                                            className={`progress w-12 h-1 ${disabled ? 'progress-error' : 'progress-primary'} opacity-60`} 
-                                            value={Math.min(100, (term.capacity.occupied / term.capacity.total) * 100)} 
-                                            max="100" 
+                                        <progress
+                                            className={`progress w-12 h-1 ${isFull ? 'progress-error' : 'progress-primary'} opacity-60`}
+                                            value={Math.min(100, (term.capacity.occupied / term.capacity.total) * 100)}
+                                            max="100"
                                         />
-                                        <span className={`text-[11px] font-bold ${isFull ? 'text-error' : 'opacity-60'}`}>
-                                            {isFull ? t('exams.full') : (isClosed || isBlocked) ? t('exams.closed') : term.capacity.raw}
+                                        <span className={`text-[11px] font-bold ${isFull ? 'text-error/60' : 'opacity-60'}`}>
+                                            {isFull ? t('exams.full') : term.capacity.raw}
                                         </span>
                                     </div>
-                                </div>
-                                <div className="w-[100px] flex justify-end">
-                                    {isProcessing ? (
-                                        <span className="loading loading-spinner loading-sm text-primary"></span>
-                                    ) : (isFull || isClosed || isBlocked) ? (
-                                        <span className="text-error/40 text-lg font-bold">✕</span>
-                                    ) : (
+                                    {!isFull && (
                                         <span className="btn btn-primary btn-sm px-4 font-bold">{t('exams.register')}</span>
                                     )}
-                                </div>
-                            </div>
-                        )
+                                </>
+                            ) : null}
+                        </div>
                     )}
                 </div>
 

--- a/src/components/TermTile.tsx
+++ b/src/components/TermTile.tsx
@@ -57,7 +57,7 @@ export function TermTile({ term, section, isArmed, isFiring, onToggleArm, onSele
                             <div className="flex items-center gap-1 px-2 py-0.5 rounded-md bg-error/10">
                                 <RotateCcw size={10} className="text-error" />
                                 <span className="text-[10px] font-bold text-error">
-                                    {term.attemptType === 'retake2' ? t('successRate.retake2') : '3. opravný'}
+                                    {term.attemptType === 'retake2' ? t('successRate.retake2') : t('successRate.retake3')}
                                 </span>
                             </div>
                         )}

--- a/src/components/TermTile.tsx
+++ b/src/components/TermTile.tsx
@@ -1,9 +1,15 @@
-import { CircleCheck, RotateCcw, Zap } from 'lucide-react';
+import { RotateCcw, Zap, CircleCheck } from 'lucide-react';
 import type { ExamTerm, ExamSection } from '../types/exams';
 import { getDayOfWeek, parseRegistrationStart, formatCountdown } from '../utils/termUtils';
 import { useTranslation } from '../hooks/useTranslation';
 import { useAppStore } from '../store/useAppStore';
 import { SNIPER_WINDOW_MS } from './ExamPanel/useAutoRegistration';
+
+const attemptAccentClass: Record<string, string> = {
+    retake1: 'bg-warning/50',
+    retake2: 'bg-error/50',
+    retake3: 'bg-error/50',
+};
 
 export function TermTile({ term, section, isArmed, isFiring, onToggleArm, onSelect, isProcessing = false }: { term: ExamTerm; section?: ExamSection; isArmed?: boolean; isFiring?: boolean; onToggleArm?: () => void; onSelect: () => void; isProcessing?: boolean }) {
     const { t, language } = useTranslation();
@@ -16,10 +22,12 @@ export function TermTile({ term, section, isArmed, isFiring, onToggleArm, onSele
     const isBlocked = term.canRegisterNow === false && !isFuture && !isFull;
     const disabled = isFull || isProcessing || isFuture || isClosed || isBlocked;
     const sameDeadline = term.registrationEnd && term.deregistrationDeadline && term.registrationEnd === term.deregistrationDeadline;
+    const attemptAccent = term.attemptType ? attemptAccentClass[term.attemptType] ?? '' : '';
 
     return (
         <div onClick={() => !disabled && onSelect()}
-                className={`flex flex-col w-full rounded-lg border transition-all text-left ${(isArmed || isFiring) ? 'bg-warning/10 border-warning shadow-[0_0_10px_rgba(251,189,35,0.3)]' : isFuture ? 'bg-warning/5 border-warning/30' : (isFull || isClosed || isBlocked) ? 'bg-base-200 opacity-60' : 'bg-base-100 hover:border-primary shadow-sm cursor-pointer'}`}>
+                className={`relative flex flex-col w-full rounded-lg border transition-all text-left overflow-hidden ${(isArmed || isFiring) ? 'bg-warning/10 border-warning shadow-[0_0_10px_rgba(251,189,35,0.3)]' : isFuture ? 'bg-warning/5 border-warning/30' : (isFull || isClosed || isBlocked) ? 'bg-base-200 border-transparent opacity-60' : 'bg-base-100 border-transparent hover:border-primary shadow-sm cursor-pointer'}`}>
+            {attemptAccent && <div className={`absolute left-0 top-0 bottom-0 w-[3px] ${attemptAccent}`} />}
             <div className="flex flex-wrap items-center gap-x-4 gap-y-2 w-full p-3.5">
                 {/* Date: Bold & Clear */}
                 <div className="flex flex-col min-w-[70px]">
@@ -31,16 +39,24 @@ export function TermTile({ term, section, isArmed, isFiring, onToggleArm, onSele
                     </span>
                 </div>
 
-                {/* Status Icon */}
+                {/* Attempt type pill */}
                 {term.attemptType && (
                     <div className="flex items-center shrink-0">
                         {term.attemptType === 'regular' ? (
-                            <CircleCheck size={16} className="text-success/70" />
-                        ) : (
-                            <div className="flex items-center gap-0.5 px-1.5 py-0.5 rounded bg-warning/10 border border-warning/20">
+                            <div className="flex items-center gap-1 px-2 py-0.5 rounded-md bg-success/10">
+                                <CircleCheck size={10} className="text-success" />
+                                <span className="text-[10px] font-bold text-success">{t('successRate.regular')}</span>
+                            </div>
+                        ) : term.attemptType === 'retake1' ? (
+                            <div className="flex items-center gap-1 px-2 py-0.5 rounded-md bg-warning/10">
                                 <RotateCcw size={10} className="text-warning" />
-                                <span className="text-[10px] font-black text-warning">
-                                    {term.attemptType === 'retake1' ? '1' : term.attemptType === 'retake2' ? '2' : '3'}
+                                <span className="text-[10px] font-bold text-warning">{t('successRate.retake1')}</span>
+                            </div>
+                        ) : (
+                            <div className="flex items-center gap-1 px-2 py-0.5 rounded-md bg-error/10">
+                                <RotateCcw size={10} className="text-error" />
+                                <span className="text-[10px] font-bold text-error">
+                                    {term.attemptType === 'retake2' ? t('successRate.retake2') : '3. opravný'}
                                 </span>
                             </div>
                         )}

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -327,6 +327,7 @@
     "regular": "Řádný",
     "retake1": "1. opravný",
     "retake2": "2. opravný",
+    "retake3": "3. opravný",
     "passed": "Prošlo",
     "allTerms": "Všechny termíny"
   },

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -325,6 +325,7 @@
     "regular": "Regular",
     "retake1": "1st retake",
     "retake2": "2nd retake",
+    "retake3": "3rd retake",
     "passed": "Passed",
     "allTerms": "All terms"
   },


### PR DESCRIPTION
## Summary
- **TermTile**: replace icon-only attempt type badge with readable text pill (Řádný / 1. opravný / 2. opravný) + colored left accent bar for retake terms (orange/red)
- **ExamPanel**: clicking a timeline card now hides all section cards and expands the full `ExamSectionCard` for that registered exam instead of the old cramped TimelineDrawer
- **Documents**: fix false-positive integrity warning for folders that contain only subfolders

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved document pagination validation to report accurate expected vs parsed item counts.

* **New Features / UX**
  * Timeline selection is centralized so selecting a timeline item shows that exam as a single expanded view and collapses/clears selection when closed.
  * Term tiles show attempt-type accent strips, compact attempt badges, and updated capacity/progress and closed/processing visuals.

* **Localization**
  * Added a "3rd retake" label for English and Czech.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->