### PR TITLE
fix: Ctrl+K on narrow window, map room suffix strip

### DIFF
--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -1,5 +1,5 @@
 import { ChevronLeft, ChevronRight, Search } from 'lucide-react';
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import { SearchBar } from './SearchBar/index';
 import { MobileSearchOverlay } from './SearchBar/MobileSearchOverlay';
 import { useTranslation } from '../hooks/useTranslation';
@@ -36,6 +36,15 @@ export function AppHeader({
 }: AppHeaderProps) {
   const { t } = useTranslation();
   const [mobileSearchOpen, setMobileSearchOpen] = useState(false);
+
+  useEffect(() => {
+    const openIfMobile = () => { if (window.innerWidth < 768) setMobileSearchOpen(true); };
+    const onKey = (e: KeyboardEvent) => { if ((e.ctrlKey || e.metaKey) && e.key === 'k') openIfMobile(); };
+    const onMsg = (e: MessageEvent) => { if (e.data?.type === 'REIS_OPEN_SEARCH') openIfMobile(); };
+    document.addEventListener('keydown', onKey);
+    window.addEventListener('message', onMsg);
+    return () => { document.removeEventListener('keydown', onKey); window.removeEventListener('message', onMsg); };
+  }, []);
   const teachingWeekData = useAppStore(s => s.teachingWeekData);
   const viewedWeek = useMemo(() => {
     if (!teachingWeekData || !currentDate) return null;

--- a/src/components/ExamPanel/TermsSummary.tsx
+++ b/src/components/ExamPanel/TermsSummary.tsx
@@ -38,15 +38,15 @@ export function TermsSummary({ terms, sectionState }: { terms: ExamTerm[], secti
                             className={`flex items-center gap-0.5 px-1.5 py-0.5 rounded text-[10px] font-bold ${
                                 term.full || (term.capacity && term.capacity.occupied >= term.capacity.total)
                                     ? 'bg-base-200 text-base-content/30'
-                                    : term.attemptType && term.attemptType !== 'regular'
+                                    : term.attemptTypes?.some(t => t !== 'regular')
                                         ? 'bg-warning/10 text-warning/80'
                                         : term.canRegisterNow === true
                                             ? 'bg-success/10 text-success/80'
                                             : 'bg-primary/5 text-primary/70'
                             }`}
                         >
-                            {term.attemptType === 'regular' && <CircleCheck size={9} className="shrink-0" />}
-                            {term.attemptType && term.attemptType !== 'regular' && <RotateCcw size={9} className="shrink-0" />}
+                            {term.attemptTypes?.includes('regular') && !term.attemptTypes?.some(t => t !== 'regular') && <CircleCheck size={9} className="shrink-0" />}
+                            {term.attemptTypes?.some(t => t !== 'regular') && <RotateCcw size={9} className="shrink-0" />}
                             {term.date.split('.').slice(0, 2).join('.')}
                         </div>
                     ))}

--- a/src/components/MapHoverCard.tsx
+++ b/src/components/MapHoverCard.tsx
@@ -73,7 +73,8 @@ export function MapHoverCard({ roomName, children, className }: MapHoverCardProp
 
     useEffect(() => () => cancelTimers(), []);
 
-    const mapUrl = `https://mm.mendelu.cz/mapwidget/embed?placeName=${encodeURIComponent(roomName)}`;
+    const normalizedRoom = roomName.replace(/\s*\(.*?\)\s*/g, '').trim();
+    const mapUrl = `https://mm.mendelu.cz/mapwidget/embed?placeName=${encodeURIComponent(normalizedRoom)}`;
 
     const card = (
         <AnimatePresence>
@@ -109,7 +110,7 @@ export function MapHoverCard({ roomName, children, className }: MapHoverCardProp
                    <div className="px-3 py-2 bg-base-100 border-t border-base-300 flex items-center justify-between">
                         <span className="text-xs font-bold text-base-content/70 flex items-center gap-1.5">
                             <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" className="lucide lucide-map-pin"><path d="M20 10c0 4.993-5.539 10.193-7.399 11.799a1 1 0 0 1-1.202 0C9.539 20.193 4 14.993 4 10a8 8 0 0 1 16 0"/><circle cx="12" cy="10" r="3"/></svg>
-                            {roomName}
+                            {normalizedRoom}
                         </span>
                         <a 
                             href={mapUrl.replace('/embed', '')} 

--- a/src/components/MapHoverCard.tsx
+++ b/src/components/MapHoverCard.tsx
@@ -73,7 +73,7 @@ export function MapHoverCard({ roomName, children, className }: MapHoverCardProp
 
     useEffect(() => () => cancelTimers(), []);
 
-    const normalizedRoom = roomName.replace(/\s*\(.*?\)\s*/g, '').trim();
+    const normalizedRoom = roomName.replace(/\s*\([^)]*\)\s*$/, '').trim() || roomName.trim();
     const mapUrl = `https://mm.mendelu.cz/mapwidget/embed?placeName=${encodeURIComponent(normalizedRoom)}`;
 
     const card = (

--- a/src/components/SearchBar/index.tsx
+++ b/src/components/SearchBar/index.tsx
@@ -46,15 +46,18 @@ export function SearchBar({ placeholder, onSearch, onOpenSubject, prefillRef, ac
   }, [setIsOpen]);
 
   useEffect(() => {
+    const isVisible = () => !!inputWrapRef.current && inputWrapRef.current.offsetWidth > 0;
     const handleGlobalKeyDown = (e: KeyboardEvent) => {
       if ((e.ctrlKey || e.metaKey) && e.key === 'k') {
         e.preventDefault();
+        if (!isVisible()) return;
         inputRef.current?.focus();
         setIsOpen(true);
       }
     };
     const handleParentMessage = (e: MessageEvent) => {
       if (e.data?.type === 'REIS_OPEN_SEARCH') {
+        if (!isVisible()) return;
         inputRef.current?.focus();
         setIsOpen(true);
       }

--- a/src/components/SearchBar/index.tsx
+++ b/src/components/SearchBar/index.tsx
@@ -49,8 +49,8 @@ export function SearchBar({ placeholder, onSearch, onOpenSubject, prefillRef, ac
     const isVisible = () => !!inputWrapRef.current && inputWrapRef.current.offsetWidth > 0;
     const handleGlobalKeyDown = (e: KeyboardEvent) => {
       if ((e.ctrlKey || e.metaKey) && e.key === 'k') {
-        e.preventDefault();
         if (!isVisible()) return;
+        e.preventDefault();
         inputRef.current?.focus();
         setIsOpen(true);
       }

--- a/src/components/SubjectFileDrawer/Header/CourseMeta.tsx
+++ b/src/components/SubjectFileDrawer/Header/CourseMeta.tsx
@@ -22,7 +22,7 @@ export function CourseMeta({ lesson, courseInfo, isSearchContext }: { lesson: Bl
                                 <a href={`https://is.mendelu.cz/auth/lide/clovek.pl?;id=${lesson.teachers[0].id};lang=${language === 'cz' ? 'cz' : 'en'}`} target="_blank" rel="noopener noreferrer" className="clickable-link flex items-center gap-1"><User size={14} /><span>{lesson.teachers[0].fullName}</span></a>
                             </PersonHoverCard>
                         : <span className="flex items-center gap-1"><User size={14} /><span>{lesson.teachers.map(t => t.fullName).join(', ')}</span></span>}
-                        {lesson.teachers[0].id && <TeacherGradingPill teacherId={lesson.teachers[0].id} />}
+                        {lesson.teachers[0].id && <TeacherGradingPill teacherId={String(lesson.teachers[0].id)} />}
                     </span>
                 )}
                 {lesson?.room?.startsWith('Q') && (

--- a/src/components/SubjectFileDrawer/Header/CourseMeta.tsx
+++ b/src/components/SubjectFileDrawer/Header/CourseMeta.tsx
@@ -5,6 +5,7 @@ import type { BlockLesson } from '../../../types/calendarTypes';
 import type { CourseMetadata } from '../../../types/documents';
 import { PersonHoverCard } from '../../PersonHoverCard';
 import { MapHoverCard } from '../../MapHoverCard';
+import { TeacherGradingPill } from './TeacherGradingPill';
 export function CourseMeta({ lesson, courseInfo, isSearchContext }: { lesson: BlockLesson | null; courseInfo: CourseMetadata | undefined; isSearchContext: boolean }) {
     const [expanded, setExpanded] = useState(false);
     const { t, language } = useTranslation();
@@ -15,11 +16,14 @@ export function CourseMeta({ lesson, courseInfo, isSearchContext }: { lesson: Bl
                 <div className="flex items-center gap-4 text-sm text-base-content/60 flex-wrap">
                     {/* ... teachers, rooms, etc. */}
                 {lesson?.teachers && lesson.teachers.length > 0 && (
-                    lesson.teachers[0].id ?
-                        <PersonHoverCard personId={String(lesson.teachers[0].id)} className="flex items-center gap-1">
-                            <a href={`https://is.mendelu.cz/auth/lide/clovek.pl?;id=${lesson.teachers[0].id};lang=${language === 'cz' ? 'cz' : 'en'}`} target="_blank" rel="noopener noreferrer" className="clickable-link flex items-center gap-1"><User size={14} /><span>{lesson.teachers[0].fullName}</span></a>
-                        </PersonHoverCard>
-                    : <span className="flex items-center gap-1"><User size={14} /><span>{lesson.teachers.map(t => t.fullName).join(', ')}</span></span>
+                    <span className="inline-flex items-center gap-1.5">
+                        {lesson.teachers[0].id ?
+                            <PersonHoverCard personId={String(lesson.teachers[0].id)} className="flex items-center gap-1">
+                                <a href={`https://is.mendelu.cz/auth/lide/clovek.pl?;id=${lesson.teachers[0].id};lang=${language === 'cz' ? 'cz' : 'en'}`} target="_blank" rel="noopener noreferrer" className="clickable-link flex items-center gap-1"><User size={14} /><span>{lesson.teachers[0].fullName}</span></a>
+                            </PersonHoverCard>
+                        : <span className="flex items-center gap-1"><User size={14} /><span>{lesson.teachers.map(t => t.fullName).join(', ')}</span></span>}
+                        {lesson.teachers[0].id && <TeacherGradingPill teacherId={lesson.teachers[0].id} />}
+                    </span>
                 )}
                 {lesson?.room?.startsWith('Q') && (
                     <MapHoverCard roomName={lesson.room} className="flex items-center">

--- a/src/components/SubjectFileDrawer/Header/TeacherGradingPill.tsx
+++ b/src/components/SubjectFileDrawer/Header/TeacherGradingPill.tsx
@@ -1,0 +1,166 @@
+import { useState, useEffect } from 'react';
+import { supabase } from '../../../services/spolky/supabaseClient';
+import { ChromeAsyncStorage } from '../../../services/storage/ChromeAsyncStorage';
+import { useTranslation } from '../../../hooks/useTranslation';
+
+type GradingValue = 'strict' | 'fair' | 'generous';
+
+interface Counts { strict: number; fair: number; generous: number }
+
+// Dot color — semantic signal, not decorative
+const DOT: Record<GradingValue, string> = {
+    strict: 'bg-error',
+    fair: 'bg-warning',
+    generous: 'bg-success',
+};
+
+// Hover color for expanded options
+const HOVER: Record<GradingValue, string> = {
+    strict: 'hover:text-error',
+    fair: 'hover:text-warning',
+    generous: 'hover:text-success',
+};
+
+// Active color for expanded options (already voted)
+const ACTIVE: Record<GradingValue, string> = {
+    strict: 'text-error',
+    fair: 'text-warning',
+    generous: 'text-success',
+};
+
+const SESSION_KEY = 'reis_session_id';
+
+const LABEL_KEY: Record<GradingValue, string> = {
+    strict: 'course.teacherRating.strict',
+    fair: 'course.teacherRating.fair',
+    generous: 'course.teacherRating.generous',
+};
+
+function getWinners(counts: Counts): GradingValue[] {
+    const max = Math.max(counts.strict, counts.fair, counts.generous);
+    if (max === 0) return [];
+    return (['strict', 'fair', 'generous'] as GradingValue[]).filter(k => counts[k] === max);
+}
+
+async function getOrCreateSessionId(): Promise<string> {
+    const existing = await ChromeAsyncStorage.get<string>(SESSION_KEY);
+    if (existing) return existing;
+    const id = crypto.randomUUID();
+    await ChromeAsyncStorage.set(SESSION_KEY, id);
+    return id;
+}
+
+export function TeacherGradingPill({ teacherId }: { teacherId: string }) {
+    const { t } = useTranslation();
+    const [counts, setCounts] = useState<Counts>({ strict: 0, fair: 0, generous: 0 });
+    const [voted, setVoted] = useState<GradingValue | null>(null);
+    const [open, setOpen] = useState(false);
+    const [sessionId, setSessionId] = useState<string>('');
+
+    useEffect(() => {
+        let cancelled = false;
+        async function init() {
+            const sid = await getOrCreateSessionId();
+            const existingVote = await ChromeAsyncStorage.get<GradingValue>(`grading_${teacherId}`);
+            if (cancelled) return;
+            setSessionId(sid);
+            if (existingVote) setVoted(existingVote);
+
+            const { data } = await supabase.rpc('get_subject_rating_counts', { p_teacher_id: teacherId });
+            if (cancelled || !data) return;
+            setCounts({ strict: data.strict ?? 0, fair: data.fair ?? 0, generous: data.generous ?? 0 });
+        }
+        init();
+        return () => { cancelled = true; };
+    }, [teacherId]);
+
+    const total = counts.strict + counts.fair + counts.generous;
+    const winners = total >= 3 ? getWinners(counts) : [];
+
+    async function remove() {
+        if (!sessionId || !voted) return;
+        await supabase.rpc('delete_subject_rating', { p_teacher_id: teacherId, p_session_id: sessionId });
+        await ChromeAsyncStorage.remove(`grading_${teacherId}`);
+        setCounts(prev => ({ ...prev, [voted]: Math.max(0, prev[voted] - 1) }));
+        setVoted(null);
+        setOpen(false);
+    }
+
+    async function vote(value: GradingValue) {
+        if (!sessionId) return;
+        await supabase.rpc('upsert_subject_rating', {
+            p_teacher_id: teacherId,
+            p_session_id: sessionId,
+            p_tag_value: value,
+        });
+        await ChromeAsyncStorage.set(`grading_${teacherId}`, value);
+        setCounts(prev => {
+            const next = { ...prev };
+            if (voted) next[voted] = Math.max(0, next[voted] - 1);
+            next[value]++;
+            return next;
+        });
+        setVoted(value);
+        setOpen(false);
+    }
+
+    // Expanded: three plain text options, current vote in accent color with × to remove
+    if (open) {
+        return (
+            <span className="inline-flex items-center gap-2">
+                {(['strict', 'fair', 'generous'] as GradingValue[]).map(v => (
+                    <button
+                        key={v}
+                        onClick={() => vote(v)}
+                        className={`text-[10px] font-semibold transition-colors ${
+                            voted === v ? ACTIVE[v] : `text-base-content/40 ${HOVER[v]}`
+                        }`}
+                    >
+                        {t(LABEL_KEY[v])}
+                    </button>
+                ))}
+                <button
+                    onClick={voted ? remove : () => setOpen(false)}
+                    className={`text-[10px] transition-colors leading-none ${
+                        voted
+                            ? 'text-base-content/30 hover:text-error'
+                            : 'text-base-content/20 hover:text-base-content/50'
+                    }`}
+                >
+                    ✕
+                </button>
+            </span>
+        );
+    }
+
+    // Collapsed with community consensus: dot + label + muted count
+    if (winners.length > 0) {
+        return (
+            <button
+                onClick={() => setOpen(true)}
+                className="inline-flex items-center gap-1 group"
+            >
+                <span className={`w-1.5 h-1.5 rounded-full ${DOT[winners[0]]} shrink-0 opacity-70 group-hover:opacity-100 transition-opacity`} />
+                <span className="text-[10px] font-semibold italic text-base-content/45 group-hover:text-base-content/65 transition-colors">
+                    {winners.map(w => t(LABEL_KEY[w])).join(' · ')}
+                </span>
+                <span className="text-[10px] text-base-content/20 group-hover:text-base-content/35 transition-colors">{total}</span>
+            </button>
+        );
+    }
+
+    // Unvoted / below threshold: near-invisible ghost prompt
+    return (
+        <button
+            onClick={() => setOpen(true)}
+            className="text-[10px] font-semibold italic text-base-content/20 hover:text-base-content/45 transition-colors"
+        >
+            {voted ? (
+                <span className="inline-flex items-center gap-1">
+                    <span className={`w-1.5 h-1.5 rounded-full ${DOT[voted]} shrink-0 opacity-40`} />
+                    <span>{t(LABEL_KEY[voted])}</span>
+                </span>
+            ) : t('course.teacherRating.rate')}
+        </button>
+    );
+}

--- a/src/components/SubjectFileDrawer/Header/TeacherGradingPill.tsx
+++ b/src/components/SubjectFileDrawer/Header/TeacherGradingPill.tsx
@@ -79,7 +79,8 @@ export function TeacherGradingPill({ teacherId }: { teacherId: string }) {
 
     async function remove() {
         if (!sessionId || !voted) return;
-        await supabase.rpc('delete_subject_rating', { p_teacher_id: teacherId, p_session_id: sessionId });
+        const { error } = await supabase.rpc('delete_subject_rating', { p_teacher_id: teacherId, p_session_id: sessionId });
+        if (error) return;
         await ChromeAsyncStorage.remove(`grading_${teacherId}`);
         setCounts(prev => ({ ...prev, [voted]: Math.max(0, prev[voted] - 1) }));
         setVoted(null);
@@ -88,11 +89,12 @@ export function TeacherGradingPill({ teacherId }: { teacherId: string }) {
 
     async function vote(value: GradingValue) {
         if (!sessionId) return;
-        await supabase.rpc('upsert_subject_rating', {
+        const { error } = await supabase.rpc('upsert_subject_rating', {
             p_teacher_id: teacherId,
             p_session_id: sessionId,
             p_tag_value: value,
         });
+        if (error) return;
         await ChromeAsyncStorage.set(`grading_${teacherId}`, value);
         setCounts(prev => {
             const next = { ...prev };

--- a/src/components/TermTile.tsx
+++ b/src/components/TermTile.tsx
@@ -12,6 +12,17 @@ const attemptAccentClass: Record<string, string> = {
     retake3: 'bg-error/50',
 };
 
+function attemptPillClass(type: string) {
+    if (type === 'regular') return 'bg-success/10';
+    if (type === 'retake1') return 'bg-warning/10';
+    return 'bg-error/10';
+}
+function attemptIconClass(type: string) {
+    if (type === 'regular') return 'text-success';
+    if (type === 'retake1') return 'text-warning';
+    return 'text-error';
+}
+
 export function TermTile({ term, section, isArmed, isFiring, onToggleArm, onSelect, isProcessing = false }: { term: ExamTerm; section?: ExamSection; isArmed?: boolean; isFiring?: boolean; onToggleArm?: () => void; onSelect: () => void; isProcessing?: boolean }) {
     const { t, language } = useTranslation();
     const now = useAppStore(s => s.now);
@@ -23,7 +34,8 @@ export function TermTile({ term, section, isArmed, isFiring, onToggleArm, onSele
     const isBlocked = term.canRegisterNow === false && !isFuture && !isFull;
     const disabled = isFull || isProcessing || isFuture || isClosed || isBlocked;
     const sameDeadline = term.registrationEnd && term.deregistrationDeadline && term.registrationEnd === term.deregistrationDeadline;
-    const attemptAccent = term.attemptType ? attemptAccentClass[term.attemptType] ?? '' : '';
+    const primaryAttempt = term.attemptTypes?.find(t => t !== 'regular') ?? term.attemptTypes?.[0];
+    const attemptAccent = primaryAttempt ? attemptAccentClass[primaryAttempt] ?? '' : '';
 
     return (
         <div onClick={() => !disabled && onSelect()}
@@ -40,27 +52,16 @@ export function TermTile({ term, section, isArmed, isFiring, onToggleArm, onSele
                     </span>
                 </div>
 
-                {/* Attempt type pill */}
-                {term.attemptType && (
-                    <div className="flex items-center shrink-0">
-                        {term.attemptType === 'regular' ? (
-                            <div className="flex items-center gap-1 px-2 py-0.5 rounded-md bg-success/10">
-                                <CircleCheck size={10} className="text-success" />
-                                <span className="text-[10px] font-bold text-success">{t('successRate.regular')}</span>
+                {/* Attempt type pills — one per type; regular shows icon only */}
+                {term.attemptTypes && term.attemptTypes.length > 0 && (
+                    <div className="flex items-center gap-1 shrink-0">
+                        {term.attemptTypes.map(type => (
+                            <div key={type} className={`flex items-center gap-1 px-2 py-0.5 rounded-md ${attemptPillClass(type)}`}>
+                                {type === 'regular'
+                                    ? <CircleCheck size={10} className={attemptIconClass(type)} />
+                                    : <RotateCcw size={10} className={attemptIconClass(type)} />}
                             </div>
-                        ) : term.attemptType === 'retake1' ? (
-                            <div className="flex items-center gap-1 px-2 py-0.5 rounded-md bg-warning/10">
-                                <RotateCcw size={10} className="text-warning" />
-                                <span className="text-[10px] font-bold text-warning">{t('successRate.retake1')}</span>
-                            </div>
-                        ) : (
-                            <div className="flex items-center gap-1 px-2 py-0.5 rounded-md bg-error/10">
-                                <RotateCcw size={10} className="text-error" />
-                                <span className="text-[10px] font-bold text-error">
-                                    {term.attemptType === 'retake2' ? t('successRate.retake2') : t('successRate.retake3')}
-                                </span>
-                            </div>
-                        )}
+                        ))}
                     </div>
                 )}
 

--- a/src/components/TermTile.tsx
+++ b/src/components/TermTile.tsx
@@ -56,10 +56,10 @@ export function TermTile({ term, section, isArmed, isFiring, onToggleArm, onSele
                 {term.attemptTypes && term.attemptTypes.length > 0 && (
                     <div className="flex items-center gap-1 shrink-0">
                         {term.attemptTypes.map(type => (
-                            <div key={type} className={`flex items-center gap-1 px-2 py-0.5 rounded-md ${attemptPillClass(type)}`}>
+                            <div key={type} className={`flex items-center gap-1 px-2 py-0.5 rounded-md ${attemptPillClass(type)}`} title={t(`successRate.${type}`)}>
                                 {type === 'regular'
                                     ? <CircleCheck size={10} className={attemptIconClass(type)} />
-                                    : <RotateCcw size={10} className={attemptIconClass(type)} />}
+                                    : <><RotateCcw size={10} className={attemptIconClass(type)} /><span className={`text-[9px] font-bold leading-none ${attemptIconClass(type)}`}>{type === 'retake1' ? '1' : type === 'retake2' ? '2' : '3'}</span></>}
                             </div>
                         ))}
                     </div>

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -293,6 +293,12 @@
       "placeholder": "Tvá poznámka k souboru...",
       "badge": "1 poznámka",
       "subjectPlaceholder": "Poznámka..."
+    },
+    "teacherRating": {
+      "strict": "přísný",
+      "fair": "férový",
+      "generous": "mírný",
+      "rate": "ohodnotit?"
     }
   },
   "syllabus": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -291,6 +291,12 @@
       "add": "Add note...",
       "placeholder": "Your note for this file...",
       "badge": "1 note"
+    },
+    "teacherRating": {
+      "strict": "strict",
+      "fair": "fair",
+      "generous": "generous",
+      "rate": "rate?"
     }
   },
   "syllabus": {

--- a/src/injector/messageHandler.ts
+++ b/src/injector/messageHandler.ts
@@ -63,6 +63,10 @@ async function handleFetchRequest(id: string, url: string, options?: { method?: 
                 method: options?.method ?? "GET", headers: options?.headers,
                 body: options?.body, credentials: "include",
             });
+            if (response.status === 401 || response.status === 403) {
+                window.location.href = "https://is.mendelu.cz/system/login.pl?lang=cz";
+                throw new Error(`HTTP ${response.status}`);
+            }
             if (!response.ok) throw new Error(`HTTP ${response.status}`);
             text = await response.text();
         } else {

--- a/src/injector/syncService.ts
+++ b/src/injector/syncService.ts
@@ -184,7 +184,8 @@ async function syncSubjectDetails(subjectsValue: { data: Record<string, { folder
         let predmetIdMap: Record<string, string>;
         try {
             predmetIdMap = await fetchSeminarGroupIds(studium, obdobi);
-        } catch {
+        } catch (err) {
+            sendToIframe(Messages.telemetryError('Sync.fetchSeminarGroupIds.retry', err));
             await new Promise(r => setTimeout(r, 2000));
             predmetIdMap = await fetchSeminarGroupIds(studium, obdobi);
         }

--- a/src/injector/syncService.ts
+++ b/src/injector/syncService.ts
@@ -181,7 +181,13 @@ async function syncSubjectDetails(subjectsValue: { data: Record<string, { folder
 
     try {
         // predmetIdMap: { [predmetId]: skupinaId }
-        const predmetIdMap = await fetchSeminarGroupIds(studium, obdobi);
+        let predmetIdMap: Record<string, string>;
+        try {
+            predmetIdMap = await fetchSeminarGroupIds(studium, obdobi);
+        } catch {
+            await new Promise(r => setTimeout(r, 2000));
+            predmetIdMap = await fetchSeminarGroupIds(studium, obdobi);
+        }
         if (!cachedData.classmates) cachedData.classmates = {};
 
         // Build tasks by iterating enrolled subjects and matching their subjectId

--- a/src/schemas/__tests__/examSchema.test.ts
+++ b/src/schemas/__tests__/examSchema.test.ts
@@ -34,7 +34,7 @@ describe('ExamSubjectSchema', () => {
                         teacherId: '5432',
                         registrationStart: '01.12.2025 08:00',
                         registrationEnd: '04.01.2026 23:59',
-                        attemptType: 'regular',
+                        attemptTypes: ['regular'],
                         canRegisterNow: true
                     }
                 ]
@@ -97,7 +97,7 @@ describe('ExamSubjectSchema', () => {
                     terms: [
                         {
                             ...goldStandardSubject.sections[0].terms[0],
-                            attemptType: 'invalid-type'
+                            attemptTypes: ['invalid-type']
                         }
                     ]
                 }

--- a/src/schemas/examSchema.ts
+++ b/src/schemas/examSchema.ts
@@ -28,7 +28,7 @@ export const ExamTermSchema = z.object({
     registrationStart: z.string().optional(),
     registrationEnd: z.string().optional(),
     deregistrationDeadline: z.string().optional(),
-    attemptType: z.enum(['regular', 'retake1', 'retake2', 'retake3']).optional(),
+    attemptTypes: z.array(z.enum(['regular', 'retake1', 'retake2', 'retake3'])).optional(),
     canRegisterNow: z.boolean().optional(),
 });
 

--- a/src/types/exams.ts
+++ b/src/types/exams.ts
@@ -27,7 +27,7 @@ export interface ExamTerm {
     registrationStart?: string;  // When registration opens
     registrationEnd?: string;    // When registration closes
     deregistrationDeadline?: string;  // When deregistration closes (format: "DD.MM.YYYY HH:MM")
-    attemptType?: 'regular' | 'retake1' | 'retake2' | 'retake3';  // Exam attempt type
+    attemptTypes?: ('regular' | 'retake1' | 'retake2' | 'retake3')[];  // One or more attempt types (e.g. a term can serve as both regular and retake)
     canRegisterNow?: boolean;  // True if registration link is available now
 }
 

--- a/src/utils/mock/data/esn.ts
+++ b/src/utils/mock/data/esn.ts
@@ -36,7 +36,7 @@ export const esnDataset: SocietyDataset = {
               teacherId: 'smith-john',
               registrationStart: '01.02.2026 00:00',
               registrationEnd: '14.02.2026 23:59',
-              attemptType: 'regular',
+              attemptTypes: ['regular'],
               canRegisterNow: true
             }
           ]
@@ -66,7 +66,7 @@ export const esnDataset: SocietyDataset = {
               teacherId: 'novakova-anna',
               registrationStart: '05.02.2026 00:00',
               registrationEnd: '17.02.2026 23:59',
-              attemptType: 'regular',
+              attemptTypes: ['regular'],
               canRegisterNow: true
             }
           ]

--- a/src/utils/mock/data/ldf.ts
+++ b/src/utils/mock/data/ldf.ts
@@ -27,7 +27,7 @@ export const ldfDataset: SocietyDataset = {
               teacherId: 'green-robert',
               registrationStart: '15.02.2026 00:00',
               registrationEnd: '19.02.2026 23:59',
-              attemptType: 'regular',
+              attemptTypes: ['regular'],
               canRegisterNow: false
             }
           ]

--- a/src/utils/mock/data/supef.ts
+++ b/src/utils/mock/data/supef.ts
@@ -76,7 +76,7 @@ export const supefDataset: SocietyDataset = {
               teacherId: 'melicharova-alena',
               registrationStart: '01.01.2026 00:00',
               registrationEnd: '11.02.2026 23:59',
-              attemptType: 'regular',
+              attemptTypes: ['regular'],
               canRegisterNow: true
             }
           ]
@@ -106,7 +106,7 @@ export const supefDataset: SocietyDataset = {
               teacherId: 'janku-martin',
               registrationStart: '05.02.2026 00:00',
               registrationEnd: '18.02.2026 23:59',
-              attemptType: 'regular',
+              attemptTypes: ['regular'],
               canRegisterNow: true
             }
           ]
@@ -136,7 +136,7 @@ export const supefDataset: SocietyDataset = {
               teacherId: 'andrlik-bretislav',
               registrationStart: '01.02.2026 00:00',
               registrationEnd: '22.02.2026 23:59',
-              attemptType: 'regular',
+              attemptTypes: ['regular'],
               canRegisterNow: true
             }
           ]
@@ -166,7 +166,7 @@ export const supefDataset: SocietyDataset = {
               teacherId: 'zufan-pavel',
               registrationStart: '01.02.2026 00:00',
               registrationEnd: '24.02.2026 23:59',
-              attemptType: 'regular',
+              attemptTypes: ['regular'],
               canRegisterNow: true
             }
           ]
@@ -196,7 +196,7 @@ export const supefDataset: SocietyDataset = {
               teacherId: 'strelec-lubos',
               registrationStart: '01.02.2026 00:00',
               registrationEnd: '25.02.2026 23:59',
-              attemptType: 'regular',
+              attemptTypes: ['regular'],
               canRegisterNow: true
             }
           ]
@@ -226,7 +226,7 @@ export const supefDataset: SocietyDataset = {
               teacherId: 'paseka-jaroslav',
               registrationStart: '01.02.2026 00:00',
               registrationEnd: '01.03.2026 23:59',
-              attemptType: 'regular',
+              attemptTypes: ['regular'],
               canRegisterNow: true
             }
           ]
@@ -256,7 +256,7 @@ export const supefDataset: SocietyDataset = {
               teacherId: 'prichystal-jan',
               registrationStart: '01.02.2026 00:00',
               registrationEnd: '02.03.2026 23:59',
-              attemptType: 'regular',
+              attemptTypes: ['regular'],
               canRegisterNow: true
             }
           ]

--- a/src/utils/parsers/exams/availableTermsParser.ts
+++ b/src/utils/parsers/exams/availableTermsParser.ts
@@ -54,14 +54,21 @@ export function parseAvailableTerms(doc: Document, getOrCreateSubject: (c: strin
             }
         }
 
-        let attemptType: 'regular' | 'retake1' | 'retake2' | 'retake3' | undefined;
+        // A single term can serve multiple attempt types (e.g. both řádný and 1. opravný).
+        // IS Mendelu uses sysid="termin-radny" / "termin-opravny-1" etc. on <img> tags in the Typ termínu cell.
+        const attemptTypes: ('regular' | 'retake1' | 'retake2' | 'retake3')[] = [];
+        const sysidMap: Record<string, 'regular' | 'retake1' | 'retake2' | 'retake3'> = {
+            'termin-radny': 'regular',
+            'termin-opravny-1': 'retake1',
+            'termin-opravny-2': 'retake2',
+            'termin-opravny-3': 'retake3',
+        };
         for (let i = 0; i < cols.length; i++) {
-            const text = (cols[i].innerHTML + (cols[i].querySelector('img')?.getAttribute('alt') || '') + (cols[i].querySelector('img')?.getAttribute('title') || '')).toLowerCase();
-            if (text.includes('opravný 3') || text.includes('3rd resit')) attemptType = 'retake3';
-            else if (text.includes('opravný 2') || text.includes('2nd resit')) attemptType = 'retake2';
-            else if (text.includes('opravný 1') || text.includes('opravný') || text.includes('resit')) attemptType = 'retake1';
-            else if (text.includes('řádný') || text.includes('first sit')) attemptType = 'regular';
-            if (attemptType) break;
+            cols[i].querySelectorAll('img[sysid]').forEach(img => {
+                const mapped = sysidMap[img.getAttribute('sysid') || ''];
+                if (mapped && !attemptTypes.includes(mapped)) attemptTypes.push(mapped);
+            });
+            if (attemptTypes.length > 0) break;
         }
 
         const subject = getOrCreateSubject(code, name);
@@ -78,7 +85,7 @@ export function parseAvailableTerms(doc: Document, getOrCreateSubject: (c: strin
             registrationStart,
             registrationEnd,
             deregistrationDeadline,
-            attemptType, 
+            attemptTypes: attemptTypes.length > 0 ? attemptTypes : undefined,
             canRegisterNow: !!row.querySelector('a[href*="prihlasit_ihned=1"]') && !isFull,
             roomCs: isEn ? undefined : room,
             roomEn: isEn ? room : undefined


### PR DESCRIPTION
## Summary
- Ctrl+K on a narrow window (e.g. split with another app) now opens the mobile search overlay instead of rendering a floating results dropdown with no visible input bar (`SearchBar` is `hidden md:flex`; added a visibility guard + mobile fallback in `AppHeader`)
- Map hover card strips parenthetical suffixes from room names (e.g. `Q04 (ČP)` → `Q04`) before passing to the MendELU map widget URL, fixing the "place not found" error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mobile search overlay opens via Ctrl/⌘+K or window message on small screens
  * Teacher rating pill added to course headers for quick grading feedback
  * Timeline selection focuses the panel on the chosen exam section
  * Exam terms now support multiple attempt types (e.g., regular + retake)

* **Bug Fixes**
  * Search shortcut only triggers when search UI is visible
  * Auto-redirect to login on certain auth failures (401/403)
  * Room names normalized for more reliable map/embed links and footer display

* **Style**
  * Redesigned exam term tiles with clearer accents, deadlines, capacity, and actions

* **Localization**
  * Added/updated teacher rating and course note strings (en + cs)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->