### PR TITLE
fix(calendar): improve event card borders and grid line visibility

### DIFF
--- a/src/components/CalendarEventCard.tsx
+++ b/src/components/CalendarEventCard.tsx
@@ -110,18 +110,21 @@ export function CalendarEventCard({ lesson, onClick, language }: CalendarEventCa
             return {
                 bg: 'bg-exam-bg/85',
                 border: 'border-l-exam-border',
+                outerBorder: 'border-exam-border/30',
                 text: 'text-gray-900',
             };
         } else if (lesson.isSeminar === 'true') {
             return {
                 bg: 'bg-seminar-bg/85',
                 border: 'border-l-seminar-border',
+                outerBorder: 'border-seminar-border/30',
                 text: 'text-gray-900',
             };
         } else {
             return {
                 bg: 'bg-lecture-bg/85',
                 border: 'border-l-lecture-border',
+                outerBorder: 'border-lecture-border/30',
                 text: 'text-gray-900',
             };
         }
@@ -143,8 +146,8 @@ export function CalendarEventCard({ lesson, onClick, language }: CalendarEventCa
 
     return (
         <div
-            className={`h-full mx-1 rounded cursor-pointer group 
-                        ${styles.bg} border-l-4 ${styles.border} relative`}
+            className={`h-full mx-1 rounded cursor-pointer group
+                        ${styles.bg} border ${styles.outerBorder} border-l-4 ${styles.border} relative`}
             onClick={onClick}
             title={`${courseTitle}\n${lesson.startTime} - ${lesson.endTime}\n${room}\n${lesson.teachers[0]?.shortName || ''}`}
         >

--- a/src/components/WeeklyCalendar/WeeklyCalendarGrid.tsx
+++ b/src/components/WeeklyCalendar/WeeklyCalendarGrid.tsx
@@ -6,11 +6,11 @@ export function WeeklyCalendarGrid() {
     return (
         <div className="absolute inset-0 flex pointer-events-none">
             {DAYS.map((_, dayIndex) => (
-                <div key={dayIndex} className="flex-1 border-r border-base-300 last:border-r-0">
+                <div key={dayIndex} className="flex-1 border-r border-base-content/10 last:border-r-0">
                     {HOURS.map((_, hourIndex) => (
                         <div
                             key={hourIndex}
-                            className="border-b border-base-200"
+                            className="border-b border-base-content/8"
                             style={{ height: `${100 / TOTAL_HOURS}%` }}
                         ></div>
                     ))}


### PR DESCRIPTION
## Summary
- Add colored outer border to calendar event cards (30% opacity of each event type's accent color), replacing invisible `base-200`/`base-300` borders
- Replace near-white `base-200`/`base-300` grid lines with `base-content/8` and `base-content/10` so they scale correctly in both light and dark themes

## Root cause
`base-200` (#f9fafb) and `base-300` (#f3f4f6) are nearly identical to the card backgrounds (#F0F7FF, #F3FAEA, #FEF2F2) and the white calendar surface — making both borders and grid lines invisible.

## Test plan
- [ ] Light theme: event cards have a subtle colored border matching their type (blue/green/red)
- [ ] Light theme: hour lines and day dividers are clearly visible
- [ ] Dark theme: both borders and grid lines remain visible (colors scale with `base-content`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Calendar event card borders have been enhanced with improved visual styling, providing clearer distinction for exam and seminar event types.
  * Weekly calendar grid separators and row dividers have been refined with more subtle border colors, resulting in a cleaner and more polished overall appearance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/reis-mendelu/reis-extension/pull/42)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->