### PR TITLE
fix(pdf-viewer): lazy-init worker to prevent uncaught extension context invalidated error

### DIFF
--- a/src/components/SubjectFileDrawer/PdfViewer.tsx
+++ b/src/components/SubjectFileDrawer/PdfViewer.tsx
@@ -6,12 +6,23 @@ import type { PDFDocumentProxy } from 'pdfjs-dist';
 // Fetch the worker script as text and serve it via a blob URL instead.
 import workerPath from 'pdfjs-dist/build/pdf.worker.min.mjs?url';
 
-const workerReady = fetch(chrome.runtime.getURL(workerPath))
-    .then(r => r.text())
-    .then(text => {
-        const url = URL.createObjectURL(new Blob([text], { type: 'application/javascript' }));
-        pdfjs.GlobalWorkerOptions.workerSrc = url;
-    });
+let workerReadyPromise: Promise<void> | null = null;
+
+function getWorkerReady(): Promise<void> {
+    if (!workerReadyPromise) {
+        try {
+            workerReadyPromise = fetch(chrome.runtime.getURL(workerPath))
+                .then(r => r.text())
+                .then(text => {
+                    const url = URL.createObjectURL(new Blob([text], { type: 'application/javascript' }));
+                    pdfjs.GlobalWorkerOptions.workerSrc = url;
+                });
+        } catch {
+            return Promise.reject(new Error('Extension context invalidated'));
+        }
+    }
+    return workerReadyPromise;
+}
 
 interface PdfViewerProps {
     blobUrl: string;
@@ -25,7 +36,7 @@ export function PdfViewer({ blobUrl, onClose }: PdfViewerProps) {
     const containerRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
-        workerReady.then(() => setReady(true));
+        getWorkerReady().then(() => setReady(true)).catch(() => {});
     }, []);
 
     const onDocumentLoadSuccess = useCallback(async (pdf: PDFDocumentProxy) => {


### PR DESCRIPTION
## Summary

- `chrome.runtime.getURL()` was called at module load time in `PdfViewer.tsx`, causing a synchronous throw (uncaught error) when the extension context is invalidated after a reload
- Replaced the module-level eager promise with a `getWorkerReady()` lazy initializer that wraps the call in `try/catch`
- Added `.catch(() => {})` in the `useEffect` so an invalidated context silently leaves the viewer in loading state instead of crashing

## Test plan

- [ ] Open a PDF in the SubjectFileDrawer — viewer loads normally
- [ ] Reload the extension while a tab with the drawer open is in the background — no uncaught errors in console

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved PDF viewer startup performance through deferred worker initialization and shared caching.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/reis-mendelu/reis-extension/pull/44)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->