### PR TITLE
feat(zaznamnik): move PH/VT links from drawer header into zaznamnik tab

### DIFF
--- a/src/components/SubjectFileDrawer/ZaznamnikTab.tsx
+++ b/src/components/SubjectFileDrawer/ZaznamnikTab.tsx
@@ -6,6 +6,8 @@ import type { VtTestAttempt } from '../../types/zaznamnik';
 import { VtTestGroup } from './Zaznamnik/VtTestGroup';
 import { PhArchView } from './Zaznamnik/PhArchView';
 
+const IS_BASE = 'https://is.mendelu.cz';
+
 interface ZaznamnikTabProps {
     courseCode: string;
 }
@@ -20,7 +22,7 @@ export function ZaznamnikTab({ courseCode }: ZaznamnikTabProps) {
     const subjectId = subjectInfo?.subjectId;
 
     const buildUrl = (extra: string) =>
-        `https://is.mendelu.cz/auth/student/list.pl?studium=${studium};obdobi=${obdobi};predmet=${subjectId};${extra};lang=${lang}`;
+        `${IS_BASE}/auth/student/list.pl?studium=${studium};obdobi=${obdobi};predmet=${subjectId};${extra};lang=${lang}`;
 
     if (isLoading) {
         return (

--- a/src/components/SubjectFileDrawer/ZaznamnikTab.tsx
+++ b/src/components/SubjectFileDrawer/ZaznamnikTab.tsx
@@ -1,4 +1,4 @@
-import { ClipboardList } from 'lucide-react';
+import { ClipboardList, ExternalLink } from 'lucide-react';
 import { useZaznamnik } from '../../hooks/data/useZaznamnik';
 import { useAppStore } from '../../store/useAppStore';
 import { useTranslation } from '../../hooks/useTranslation';
@@ -13,7 +13,14 @@ interface ZaznamnikTabProps {
 export function ZaznamnikTab({ courseCode }: ZaznamnikTabProps) {
     const { data, isLoading } = useZaznamnik(courseCode);
     const subjectInfo = useAppStore(s => courseCode ? s.subjects?.data[courseCode] : undefined);
-    const { t } = useTranslation();
+    const studium = useAppStore(s => s.studiumId);
+    const obdobi = useAppStore(s => s.obdobiId);
+    const { t, language } = useTranslation();
+    const lang = language === 'cz' ? 'cz' : 'en';
+    const subjectId = subjectInfo?.subjectId;
+
+    const buildUrl = (extra: string) =>
+        `https://is.mendelu.cz/auth/student/list.pl?studium=${studium};obdobi=${obdobi};predmet=${subjectId};${extra};lang=${lang}`;
 
     if (isLoading) {
         return (
@@ -27,12 +34,32 @@ export function ZaznamnikTab({ courseCode }: ZaznamnikTabProps) {
         );
     }
 
+    const backlinks = (subjectInfo?.hasPrubezne || subjectInfo?.hasTest) && studium && obdobi && subjectId ? (
+        <div className="flex justify-center gap-2 pt-2 pb-2">
+            {subjectInfo!.hasPrubezne && (
+                <a href={buildUrl('prubezne=1')} target="_blank" rel="noopener noreferrer"
+                    className="btn btn-ghost btn-sm gap-2 text-base-content/50 hover:text-primary normal-case font-bold">
+                    <span>PH</span><ExternalLink size={14} />
+                </a>
+            )}
+            {subjectInfo!.hasTest && (
+                <a href={buildUrl('test=1')} target="_blank" rel="noopener noreferrer"
+                    className="btn btn-ghost btn-sm gap-2 text-base-content/50 hover:text-primary normal-case font-bold">
+                    <span>VT</span><ExternalLink size={14} />
+                </a>
+            )}
+        </div>
+    ) : null;
+
     if (!data || (!data.ph.sections.length && !data.vt.tests.length)) {
         const hasFlags = subjectInfo?.hasPrubezne || subjectInfo?.hasTest;
         return (
-            <div className="flex flex-col items-center justify-center h-full p-6 opacity-40 text-center">
-                <ClipboardList className="w-12 h-12 mb-3" />
-                <p className="text-sm">{hasFlags ? t('zaznamnik.noData') : t('zaznamnik.noAssessment')}</p>
+            <div className="flex flex-col h-full">
+                <div className="flex flex-col items-center justify-center flex-1 p-6 opacity-40 text-center">
+                    <ClipboardList className="w-12 h-12 mb-3" />
+                    <p className="text-sm">{hasFlags ? t('zaznamnik.noData') : t('zaznamnik.noAssessment')}</p>
+                </div>
+                {backlinks}
             </div>
         );
     }
@@ -68,6 +95,8 @@ export function ZaznamnikTab({ courseCode }: ZaznamnikTabProps) {
                     <p className="text-sm">{t('zaznamnik.noData')}</p>
                 </div>
             )}
+
+            {backlinks}
         </div>
     );
 }

--- a/src/components/SubjectsPanel/ZaznamnikLine.tsx
+++ b/src/components/SubjectsPanel/ZaznamnikLine.tsx
@@ -36,7 +36,6 @@ export function ZaznamnikLine({ courseCode, subjectId, className }: ZaznamnikLin
     const lang = language === 'cz' ? 'cz' : 'en';
 
     const studium = useAppStore(s => s.studiumId);
-    const obdobi = useAppStore(s => s.obdobiId);
     const attendanceGroups = useAppStore(s => s.attendance[courseCode]);
     const subjectInfo = useAppStore(s => s.subjects?.data[courseCode]);
     const allTests = useAppStore(s => s.cvicneTests);
@@ -74,14 +73,9 @@ export function ZaznamnikLine({ courseCode, subjectId, className }: ZaznamnikLin
             .sort((x, y) => x.ts - y.ts);
     }, [subjectId, allAssignments]);
 
-    const hasPrubezne = subjectInfo?.hasPrubezne;
-    const hasTest = subjectInfo?.hasTest;
     const autoHref = subjectInfo?.autoHref;
 
-    const buildUrl = (extra: string) =>
-        `${IS_BASE}/auth/student/list.pl?studium=${studium};obdobi=${obdobi};predmet=${subjectId};${extra};lang=${lang}`;
-
-    const hasAnything = visibleDots.length > 0 || hasPrubezne || hasTest || autoHref || accessibleCount > 0 || upcomingDeadlines.length > 0;
+    const hasAnything = visibleDots.length > 0 || autoHref || accessibleCount > 0 || upcomingDeadlines.length > 0;
     if (!hasAnything) return null;
 
     const deadlineLabel = (ts: number) => {
@@ -107,17 +101,6 @@ export function ZaznamnikLine({ courseCode, subjectId, className }: ZaznamnikLin
                     <span className="text-[10px] text-base-content/40 ml-0.5 font-mono">{presentCount}/{totalCount}</span>
                 </span>
             )}
-            {hasPrubezne && studium && obdobi && subjectId && (
-                <a
-                    href={buildUrl('prubezne=1')}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    onClick={e => e.stopPropagation()}
-                    className="flex items-center gap-0.5 text-[10px] text-primary/70 hover:text-primary transition-colors shrink-0"
-                >
-                    PH <ExternalLink size={9} />
-                </a>
-            )}
             {autoHref && (
                 <a
                     href={autoHref}
@@ -127,17 +110,6 @@ export function ZaznamnikLine({ courseCode, subjectId, className }: ZaznamnikLin
                     className="flex items-center gap-0.5 text-[10px] text-primary/70 hover:text-primary transition-colors shrink-0"
                 >
                     AH <ExternalLink size={9} />
-                </a>
-            )}
-            {hasTest && studium && obdobi && subjectId && (
-                <a
-                    href={buildUrl('test=1')}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    onClick={e => e.stopPropagation()}
-                    className="flex items-center gap-0.5 text-[10px] text-primary/70 hover:text-primary transition-colors shrink-0"
-                >
-                    VT <ExternalLink size={9} />
                 </a>
             )}
             {accessibleCount > 0 && (accessibleCount === 1 || studium) && (


### PR DESCRIPTION
## Summary
- Removes PH and VT IS MENDELU backlinks from `ZaznamnikLine` (drawer header)
- Adds them as ghost button backlinks at the bottom of `ZaznamnikTab`, matching the file tab's `folderUrl` pattern
- Links render in both the empty state and the data state so they're always accessible when the subject has `hasPrubezne`/`hasTest` flags