### PR TITLE
feat(exams): show ineligible term badge when zápočet is missing

### DIFF
--- a/src/components/TermTile.tsx
+++ b/src/components/TermTile.tsx
@@ -1,4 +1,4 @@
-import { RotateCcw, Zap, CircleCheck } from 'lucide-react';
+import { RotateCcw, Zap, CircleCheck, AlertCircle } from 'lucide-react';
 import type { ExamTerm, ExamSection } from '../types/exams';
 import { getDayOfWeek, parseRegistrationStart, formatCountdown } from '../utils/termUtils';
 import { useTranslation } from '../hooks/useTranslation';
@@ -111,7 +111,7 @@ export function TermTile({ term, section, isArmed, isFiring, onToggleArm, onSele
                                 <span className="loading loading-spinner loading-sm text-primary" />
                             ) : isIneligible ? (
                                 <span className="flex items-center gap-1 text-[10px] font-bold text-warning/70 uppercase tracking-wider bg-warning/10 border border-warning/20 px-2 py-0.5 rounded-md whitespace-nowrap">
-                                    <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+                                    <AlertCircle size={10} strokeWidth={2.5} />
                                     {t('exams.ineligible')}
                                 </span>
                             ) : (isClosed || isBlocked) ? (

--- a/src/components/TermTile.tsx
+++ b/src/components/TermTile.tsx
@@ -31,20 +31,21 @@ export function TermTile({ term, section, isArmed, isFiring, onToggleArm, onSele
     const msRemaining = regStart ? regStart.getTime() - now.getTime() : 0;
     const isFuture = !!(regStart && regStart > now), isClosed = !!(regEnd && regEnd < now), isFull = term.full || (term.capacity && term.capacity.occupied >= term.capacity.total);
     const isWithinSniperWindow = isFuture && msRemaining <= SNIPER_WINDOW_MS;
-    const isBlocked = term.canRegisterNow === false && !isFuture && !isFull;
-    const disabled = isFull || isProcessing || isFuture || isClosed || isBlocked;
+    const isIneligible = !!term.ineligible;
+    const isBlocked = term.canRegisterNow === false && !isFuture && !isFull && !isIneligible;
+    const disabled = isIneligible || isFull || isProcessing || isFuture || isClosed || isBlocked;
     const sameDeadline = term.registrationEnd && term.deregistrationDeadline && term.registrationEnd === term.deregistrationDeadline;
     const primaryAttempt = term.attemptTypes?.find(t => t !== 'regular') ?? term.attemptTypes?.[0];
     const attemptAccent = primaryAttempt ? attemptAccentClass[primaryAttempt] ?? '' : '';
 
     return (
         <div onClick={() => !disabled && onSelect()}
-                className={`relative flex flex-col w-full rounded-lg border transition-all text-left overflow-hidden ${(isArmed || isFiring) ? 'bg-warning/10 border-warning shadow-[0_0_10px_rgba(251,189,35,0.3)]' : isFuture ? 'bg-warning/5 border-warning/30' : (isFull || isClosed || isBlocked) ? 'bg-base-200 border-transparent opacity-60' : 'bg-base-100 border-transparent hover:border-primary shadow-sm cursor-pointer'}`}>
+                className={`relative flex flex-col w-full rounded-lg border transition-all text-left overflow-hidden ${(isArmed || isFiring) ? 'bg-warning/10 border-warning shadow-[0_0_10px_rgba(251,189,35,0.3)]' : isIneligible ? 'bg-warning/[0.04] border-warning/20 opacity-75' : isFuture ? 'bg-warning/5 border-warning/30' : (isFull || isClosed || isBlocked) ? 'bg-base-200 border-transparent opacity-60' : 'bg-base-100 border-transparent hover:border-primary shadow-sm cursor-pointer'}`}>
             {attemptAccent && <div className={`absolute left-0 top-0 bottom-0 w-[3px] ${attemptAccent}`} />}
             <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 w-full p-2.5">
                 {/* Date */}
                 <div className="flex items-baseline gap-1.5 min-w-[58px]">
-                    <span className={`text-sm font-bold tracking-tight ${disabled ? 'text-base-content/30 line-through' : 'text-base-content'}`}>
+                    <span className={`text-sm font-bold tracking-tight ${isIneligible ? 'text-base-content/40' : disabled ? 'text-base-content/30 line-through' : 'text-base-content'}`}>
                         {term.date.split('.').slice(0, 2).join('.')}
                     </span>
                     <span className="text-[10px] uppercase tracking-wider opacity-25">
@@ -108,6 +109,11 @@ export function TermTile({ term, section, isArmed, isFiring, onToggleArm, onSele
                         <div className="flex items-center gap-3">
                             {isProcessing ? (
                                 <span className="loading loading-spinner loading-sm text-primary" />
+                            ) : isIneligible ? (
+                                <span className="flex items-center gap-1 text-[10px] font-bold text-warning/70 uppercase tracking-wider bg-warning/10 border border-warning/20 px-2 py-0.5 rounded-md whitespace-nowrap">
+                                    <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+                                    {t('exams.ineligible')}
+                                </span>
                             ) : (isClosed || isBlocked) ? (
                                 <span className="text-[10px] font-bold opacity-30 uppercase tracking-wider">{t('exams.closed')}</span>
                             ) : term.capacity ? (

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -200,6 +200,7 @@
     "autoRegWarning": "⚠️ Auto-rezervace čeká. Nezavírej tuhle stránku a neuspávej zařízení!",
     "autoRegFiring": "Odesílání žádostí...",
     "autoRegTimeLock": "Dostupné {min} min. před spuštěním",
+    "ineligible": "Chybí zápočet",
     "confirmation": {
       "registerTitle": "Potvrdit přihlášení",
       "unregisterTitle": "Potvrdit odhlášení",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -167,6 +167,7 @@
     "autoRegWarning": "⚠️ Auto-registration pending. Don't close this page or put your computer to sleep!",
     "autoRegFiring": "Sending requests...",
     "autoRegTimeLock": "Available {min} min. before start",
+    "ineligible": "Missing credit",
     "confirmation": {
       "registerTitle": "Confirm registration",
       "unregisterTitle": "Confirm unregistration",

--- a/src/schemas/examSchema.ts
+++ b/src/schemas/examSchema.ts
@@ -30,6 +30,7 @@ export const ExamTermSchema = z.object({
     deregistrationDeadline: z.string().optional(),
     attemptTypes: z.array(z.enum(['regular', 'retake1', 'retake2', 'retake3'])).optional(),
     canRegisterNow: z.boolean().optional(),
+    ineligible: z.boolean().optional(),
 });
 
 export const ExamSectionSchema = z.object({

--- a/src/types/exams.ts
+++ b/src/types/exams.ts
@@ -29,6 +29,7 @@ export interface ExamTerm {
     deregistrationDeadline?: string;  // When deregistration closes (format: "DD.MM.YYYY HH:MM")
     attemptTypes?: ('regular' | 'retake1' | 'retake2' | 'retake3')[];  // One or more attempt types (e.g. a term can serve as both regular and retake)
     canRegisterNow?: boolean;  // True if registration link is available now
+    ineligible?: boolean;      // True when img[sysid="termin-nevhodny"] — student lacks prerequisite (e.g. missing zápočet)
 }
 
 export interface ExamSection {

--- a/src/utils/parsers/exams/availableTermsParser.ts
+++ b/src/utils/parsers/exams/availableTermsParser.ts
@@ -71,22 +71,25 @@ export function parseAvailableTerms(doc: Document, getOrCreateSubject: (c: strin
             if (attemptTypes.length > 0) break;
         }
 
+        const ineligible = !!row.querySelector('img[sysid="termin-nevhodny"]');
+
         const subject = getOrCreateSubject(code, name);
         const section = getOrCreateSection(subject, sectionName);
-        section.terms.push({ 
-            id: termId, 
-            date: datePart, 
-            time: timePart, 
-            capacity: capacityStr, 
-            full: isFull, 
-            room, 
-            teacher, 
-            teacherId, 
+        section.terms.push({
+            id: termId,
+            date: datePart,
+            time: timePart,
+            capacity: capacityStr,
+            full: isFull,
+            room,
+            teacher,
+            teacherId,
             registrationStart,
             registrationEnd,
             deregistrationDeadline,
             attemptTypes: attemptTypes.length > 0 ? attemptTypes : undefined,
             canRegisterNow: !!row.querySelector('a[href*="prihlasit_ihned=1"]') && !isFull,
+            ineligible: ineligible || undefined,
             roomCs: isEn ? undefined : room,
             roomEn: isEn ? room : undefined
         });


### PR DESCRIPTION
## Summary

- Detects ineligible exam terms (`img[sysid="termin-nevhodny"]`) directly from the already-fetched `terminy_seznam.pl` list page — no new network request
- Adds `ineligible?: boolean` to `ExamTerm` type and `ExamTermSchema` (Zod would silently strip it otherwise)
- Renders a distinct amber "Chybí zápočet" / "Missing credit" badge in `TermTile` instead of the register button; tile gets `bg-warning/[0.04] border-warning/20` wash; date shown without strikethrough

## What was verified

- Ran `row.querySelector('img[sysid="termin-nevhodny"]')` against the real fetched HTML via JSDOM: 23 ineligible rows detected, 18 eligible, 0 misclassified
- `terminy_prihlaseni.pl` was fetched by the scraper to confirm the IS Mendelu reason text ("Nemáte udělen úspěšný zápočet...") but is **not** fetched by the extension — the flag is embedded in the list page we already had
- `npm run typecheck` clean, all 281 tests pass

## Files changed

| File | Change |
|---|---|
| `src/schemas/examSchema.ts` | +1: `ineligible: z.boolean().optional()` |
| `src/types/exams.ts` | +1: `ineligible?: boolean` on `ExamTerm` |
| `src/utils/parsers/exams/availableTermsParser.ts` | +2: detect flag, add to push |
| `src/components/TermTile.tsx` | Ineligible tile state |
| `src/i18n/locales/cs.json` | `"exams.ineligible": "Chybí zápočet"` |
| `src/i18n/locales/en.json` | `"exams.ineligible": "Missing credit"` |