### PR TITLE
feat(exams): redesign horizontal timeline with real rail and compact cards

### DIFF
--- a/src/components/ErasmusPanel/ErasmusExportButton.tsx
+++ b/src/components/ErasmusPanel/ErasmusExportButton.tsx
@@ -11,6 +11,7 @@ export function ErasmusExportButton({ className = '' }: Props) {
   const studentInfo = useAppStore(s => s.erasmusStudentInfo);
   const options = useAppStore(s => s.erasmusTableAOptions);
   const tableBCourses = useAppStore(s => s.erasmusTableBCourses);
+  const tableBManual = useAppStore(s => s.erasmusTableBManualCourses);
   const dualPlan = useAppStore(s => s.studyPlanDual);
   const [loading, setLoading] = useState(false);
 
@@ -20,7 +21,7 @@ export function ErasmusExportButton({ className = '' }: Props) {
   const handleExport = async () => {
     setLoading(true);
     try {
-      await downloadErasmusPdf(studentInfo, options, tableBCourses, allSubjects);
+      await downloadErasmusPdf(studentInfo, options, tableBCourses, allSubjects, tableBManual);
     } finally {
       setLoading(false);
     }

--- a/src/components/ErasmusPanel/LATableA.tsx
+++ b/src/components/ErasmusPanel/LATableA.tsx
@@ -2,7 +2,7 @@ import { useState, useRef } from 'react';
 import { Plus, X, Link, Hash, Trash2, ChevronDown, ChevronUp, Search } from 'lucide-react';
 import { useTranslation } from '@/hooks/useTranslation';
 import { useAppStore } from '@/store/useAppStore';
-import { LATableB } from './LATableB';
+import { LATableB, type ManualCourse } from './LATableB';
 import { UnfulfilledCoursesSection } from './UnfulfilledCoursesSection';
 import { ErasmusVerifyDot } from './ErasmusVerifyDot';
 import { CountryPicker } from './CountryPicker';
@@ -22,9 +22,13 @@ interface OptionProps {
   onOpenSubject: (courseCode: string, courseName?: string, courseId?: string) => void;
   onSearchSubject: (name: string) => void;
   onViewReports: (file: string, schoolName: string | null, isPermanent?: boolean) => void;
+  manualCourses: ManualCourse[];
+  onAddManual: (course: ManualCourse) => void;
+  onRemoveManual: (index: number) => void;
+  onReorderManual: (from: number, to: number) => void;
 }
 
-function LATableAOption({ option, index, total, selectedCodes, onToggle, onReorder, plan, onOpenSubject, onSearchSubject, onViewReports }: OptionProps) {
+function LATableAOption({ option, index, total, selectedCodes, onToggle, onReorder, plan, onOpenSubject, onSearchSubject, onViewReports, manualCourses, onAddManual, onRemoveManual, onReorderManual }: OptionProps) {
   const { t } = useTranslation();
   const updateHeader = useAppStore(s => s.updateErasmusTableAOptionHeader);
   const removeOption = useAppStore(s => s.removeErasmusTableAOption);
@@ -278,13 +282,13 @@ function LATableAOption({ option, index, total, selectedCodes, onToggle, onReord
       </div>
 
       {/* Table B */}
-      <LATableB plan={plan} selectedCodes={selectedCodes} onToggle={onToggle} tableACourses={option.courses} onReorder={onReorder} hoveredRowIndex={hoveredRowIndex} />
+      <LATableB plan={plan} selectedCodes={selectedCodes} onToggle={onToggle} tableACourses={option.courses} onReorder={onReorder} hoveredRowIndex={hoveredRowIndex} manualCourses={manualCourses} onAddManual={onAddManual} onRemoveManual={onRemoveManual} onReorderManual={onReorderManual} />
 
       {/* Add courses picker */}
       <div className="flex flex-col gap-0">
         <button
           onClick={() => setBuilderOpen(!builderOpen)}
-          className="flex items-center gap-2 px-2 py-2 text-xs font-bold text-base-content/50 hover:text-primary transition-colors group w-full"
+          className="flex items-center gap-2 px-2 py-2 text-xs font-bold text-primary/70 hover:text-primary transition-colors group w-full"
         >
           {builderOpen
             ? <ChevronDown size={14} className="transition-transform rotate-180" />
@@ -319,8 +323,12 @@ interface LATableAProps {
 export function LATableA({ plan, onOpenSubject, onSearchSubject, onViewReports }: LATableAProps) {
   const options = useAppStore(s => s.erasmusTableAOptions);
   const tableBCourses = useAppStore(s => s.erasmusTableBCourses);
+  const tableBManual = useAppStore(s => s.erasmusTableBManualCourses);
   const toggleCourse = useAppStore(s => s.toggleErasmusTableBCourse);
   const reorderCourse = useAppStore(s => s.reorderErasmusTableBCourse);
+  const addManual = useAppStore(s => s.addErasmusTableBManualCourse);
+  const removeManual = useAppStore(s => s.removeErasmusTableBManualCourse);
+  const reorderManual = useAppStore(s => s.reorderErasmusTableBManualCourse);
 
   return (
     <div className="flex flex-col gap-8 pb-4">
@@ -337,6 +345,10 @@ export function LATableA({ plan, onOpenSubject, onSearchSubject, onViewReports }
           onOpenSubject={onOpenSubject}
           onSearchSubject={onSearchSubject}
           onViewReports={onViewReports}
+          manualCourses={tableBManual[option.id] ?? []}
+          onAddManual={(course) => addManual(option.id, course)}
+          onRemoveManual={(idx) => removeManual(option.id, idx)}
+          onReorderManual={(from, to) => reorderManual(option.id, from, to)}
         />
       ))}
     </div>

--- a/src/components/ErasmusPanel/LATableB.tsx
+++ b/src/components/ErasmusPanel/LATableB.tsx
@@ -1,9 +1,16 @@
+import { useState, useRef } from 'react';
 import { ChevronUp, ChevronDown, X } from 'lucide-react';
 import { useTranslation } from '@/hooks/useTranslation';
 import { useCourseName } from '@/hooks/ui/useCourseName';
 import type { StudyPlan, SubjectStatus } from '@/types/studyPlan';
 
 interface TableACourse {
+  code: string;
+  name: string;
+  credits: number;
+}
+
+export interface ManualCourse {
   code: string;
   name: string;
   credits: number;
@@ -16,57 +23,67 @@ interface Props {
   tableACourses: TableACourse[];
   onReorder: (fromIndex: number, toIndex: number) => void;
   hoveredRowIndex?: number | null;
+  manualCourses: ManualCourse[];
+  onAddManual: (course: ManualCourse) => void;
+  onRemoveManual: (index: number) => void;
+  onReorderManual: (from: number, to: number) => void;
 }
 
-function TableBRow({ subject, displayCredits, isFirst, isLast, onMoveUp, onMoveDown, onRemove, isHovered }: {
-  subject: SubjectStatus;
-  displayCredits: number;
-  isFirst: boolean;
-  isLast: boolean;
-  onMoveUp: () => void;
-  onMoveDown: () => void;
-  onRemove: () => void;
-  isHovered?: boolean;
-}) {
-  const displayName = useCourseName(subject.code, subject.name);
+const ROW_CLS = 'grid grid-cols-[auto_auto_1fr_auto_auto] gap-2 items-center px-3 py-2 border-b border-base-300/50 last:border-b-0 text-xs transition-colors';
+const BTN_CHEVRON = 'btn btn-ghost w-4 h-3.5 min-h-0 p-0 text-base-content/20 hover:text-primary disabled:opacity-0 disabled:pointer-events-none rounded-none';
+const BTN_REMOVE = 'btn btn-ghost btn-xs w-5 h-5 min-h-0 p-0 text-base-content/15 hover:text-error hover:bg-error/10 rounded-full';
 
+function ReorderButtons({ onUp, onDown, disableUp, disableDown }: { onUp: () => void; onDown: () => void; disableUp: boolean; disableDown: boolean }) {
   return (
-    <div className={`grid grid-cols-[auto_auto_1fr_auto_auto] gap-2 items-center px-3 py-2 border-b border-base-300/50 last:border-b-0 text-xs transition-colors ${isHovered ? 'bg-primary/10 border-primary/30 shadow-[inset_3px_0_0_oklch(var(--p))]' : 'hover:bg-base-200/30'}`}>
-      <div className="flex flex-col gap-0">
-        <button
-          onClick={onMoveUp}
-          disabled={isFirst}
-          className="btn btn-ghost w-4 h-3.5 min-h-0 p-0 text-base-content/20 hover:text-primary disabled:opacity-0 disabled:pointer-events-none rounded-none"
-        >
-          <ChevronUp size={11} />
-        </button>
-        <button
-          onClick={onMoveDown}
-          disabled={isLast}
-          className="btn btn-ghost w-4 h-3.5 min-h-0 p-0 text-base-content/20 hover:text-primary disabled:opacity-0 disabled:pointer-events-none rounded-none"
-        >
-          <ChevronDown size={11} />
-        </button>
-      </div>
-      <span className="font-mono text-base-content/50 w-20 truncate">{subject.code}</span>
-      <span className="truncate font-medium">{displayName}</span>
-      <span className="tabular-nums font-bold text-base-content/70 w-12 text-right">{displayCredits}</span>
-      <button
-        onClick={onRemove}
-        className="btn btn-ghost btn-xs w-5 h-5 min-h-0 p-0 text-base-content/15 hover:text-error hover:bg-error/10 rounded-full"
-      >
-        <X size={12} />
-      </button>
+    <div className="flex flex-col gap-0">
+      <button onClick={onUp} disabled={disableUp} className={BTN_CHEVRON}><ChevronUp size={11} /></button>
+      <button onClick={onDown} disabled={disableDown} className={BTN_CHEVRON}><ChevronDown size={11} /></button>
     </div>
   );
 }
 
-export function LATableB({ plan, selectedCodes, onToggle, tableACourses, onReorder, hoveredRowIndex }: Props) {
+function PlanRow({ subject, displayCredits, isFirst, isLast, onMoveUp, onMoveDown, onRemove, isHovered }: {
+  subject: SubjectStatus; displayCredits: number; isFirst: boolean; isLast: boolean;
+  onMoveUp: () => void; onMoveDown: () => void; onRemove: () => void; isHovered?: boolean;
+}) {
+  const displayName = useCourseName(subject.code, subject.name);
+  return (
+    <div className={`${ROW_CLS} ${isHovered ? 'bg-primary/10 border-primary/30 shadow-[inset_3px_0_0_oklch(var(--p))]' : 'hover:bg-base-200/30'}`}>
+      <ReorderButtons onUp={onMoveUp} onDown={onMoveDown} disableUp={isFirst} disableDown={isLast} />
+      <span className="font-mono text-base-content/50 w-20 truncate">{subject.code}</span>
+      <span className="truncate font-medium">{displayName}</span>
+      <span className="tabular-nums font-bold text-base-content/70 w-12 text-right">{displayCredits}</span>
+      <button onClick={onRemove} className={BTN_REMOVE}><X size={12} /></button>
+    </div>
+  );
+}
+
+function ManualRow({ course, isFirst, isLast, onMoveUp, onMoveDown, onRemove }: {
+  course: ManualCourse; isFirst: boolean; isLast: boolean;
+  onMoveUp: () => void; onMoveDown: () => void; onRemove: () => void;
+}) {
+  return (
+    <div className={`${ROW_CLS} hover:bg-base-200/30`}>
+      <ReorderButtons onUp={onMoveUp} onDown={onMoveDown} disableUp={isFirst} disableDown={isLast} />
+      <span className="font-mono text-base-content/50 w-20 truncate">{course.code}</span>
+      <span className="truncate font-medium">{course.name}</span>
+      <span className="tabular-nums font-bold text-base-content/70 w-12 text-right">{course.credits}</span>
+      <button onClick={onRemove} className={BTN_REMOVE}><X size={12} /></button>
+    </div>
+  );
+}
+
+export function LATableB({ plan, selectedCodes, onToggle, tableACourses, onReorder, hoveredRowIndex, manualCourses, onAddManual, onRemoveManual, onReorderManual }: Props) {
   const { t } = useTranslation();
+  const [adding, setAdding] = useState(false);
+  const [code, setCode] = useState('');
+  const [name, setName] = useState('');
+  const [credits, setCredits] = useState('');
+  const codeRef = useRef<HTMLInputElement>(null);
 
   const allSubjects = (plan.blocks || []).flatMap(b => (b.groups || []).flatMap(g => g.subjects || []));
   const selected: SubjectStatus[] = (selectedCodes || [])
-    .map(code => allSubjects.find(s => s.code === code))
+    .map(c => allSubjects.find(s => s.code === c))
     .filter((s): s is SubjectStatus => s !== undefined);
 
   const tableATotal = tableACourses.reduce((sum, c) => sum + c.credits, 0);
@@ -74,13 +91,27 @@ export function LATableB({ plan, selectedCodes, onToggle, tableACourses, onReord
   const positionalExaTotal = selected.reduce((sum, s, i) => s.credits >= 999 ? sum + (tableACourses[i]?.credits ?? 0) : sum, 0);
   const residual = Math.max(0, tableATotal - knownBTotal - positionalExaTotal);
 
-  const displayCredits = selected.map((s, i) =>
-    s.credits >= 999 ? (tableACourses[i]?.credits ?? 0) : s.credits
-  );
+  const displayCredits = selected.map((s, i) => s.credits >= 999 ? (tableACourses[i]?.credits ?? 0) : s.credits);
   const lastExaIdx = selected.map((s, i) => s.credits >= 999 ? i : -1).filter(i => i >= 0).pop();
   if (residual > 0 && lastExaIdx !== undefined) displayCredits[lastExaIdx] += residual;
 
-  const totalCredits = displayCredits.reduce((sum, c) => sum + c, 0);
+  const planTotal = displayCredits.reduce((sum, c) => sum + c, 0);
+  const manualTotal = manualCourses.reduce((sum, c) => sum + c.credits, 0);
+  const totalCredits = planTotal + manualTotal;
+
+  const hasRows = selected.length > 0 || manualCourses.length > 0;
+
+  const handleAdd = () => {
+    const c = parseInt(credits, 10) || 0;
+    onAddManual({ code: code.trim(), name: name.trim(), credits: c });
+    setCode(''); setName(''); setCredits('');
+    codeRef.current?.focus();
+  };
+
+  const openForm = () => {
+    setAdding(true);
+    setTimeout(() => codeRef.current?.focus(), 50);
+  };
 
   return (
     <div className="flex flex-col gap-2">
@@ -89,12 +120,14 @@ export function LATableB({ plan, selectedCodes, onToggle, tableACourses, onReord
         <span className="text-[10px] uppercase tracking-widest font-bold text-base-content/50">
           {t('erasmus.tableBTitle')}
         </span>
-        {selected.length > 0 && (
-          <span className="ml-auto text-[10px] text-base-content/30 tabular-nums">{selected.length} {t('erasmus.selected')}</span>
+        {hasRows && (
+          <span className="ml-auto text-[10px] text-base-content/30 tabular-nums">
+            {selected.length + manualCourses.length} {t('erasmus.selected')}
+          </span>
         )}
       </div>
 
-      {selected.length === 0 ? (
+      {!hasRows && !adding ? (
         <div className="border border-dashed border-base-300 rounded-lg px-4 py-4 text-center">
           <p className="text-xs text-base-content/40">{t('erasmus.tableBEmpty')}</p>
         </div>
@@ -109,12 +142,12 @@ export function LATableB({ plan, selectedCodes, onToggle, tableACourses, onReord
           </div>
 
           {selected.map((s, i) => (
-            <TableBRow
+            <PlanRow
               key={s.code}
               subject={s}
               displayCredits={displayCredits[i]}
               isFirst={i === 0}
-              isLast={i === selected.length - 1}
+              isLast={i === selected.length - 1 && manualCourses.length === 0}
               onMoveUp={() => onReorder(i, i - 1)}
               onMoveDown={() => onReorder(i, i + 1)}
               onRemove={() => onToggle(s.code)}
@@ -122,14 +155,69 @@ export function LATableB({ plan, selectedCodes, onToggle, tableACourses, onReord
             />
           ))}
 
-          <div className="grid grid-cols-[auto_auto_1fr_auto_auto] gap-2 items-center px-3 py-2 bg-base-200/30 border-t border-base-300 text-xs">
-            <span className="w-4" />
-            <span className="font-bold text-base-content/50 w-20">{t('erasmus.total')}</span>
-            <span />
-            <span className="tabular-nums font-black w-12 text-right">{totalCredits}</span>
-            <span className="w-5" />
-          </div>
+          {manualCourses.map((c, i) => (
+            <ManualRow
+              key={i}
+              course={c}
+              isFirst={i === 0 && selected.length === 0}
+              isLast={i === manualCourses.length - 1}
+              onMoveUp={() => onReorderManual(i, i - 1)}
+              onMoveDown={() => onReorderManual(i, i + 1)}
+              onRemove={() => onRemoveManual(i)}
+            />
+          ))}
+
+          {adding && (
+            <div className="grid grid-cols-[auto_1fr_auto_auto] gap-2 items-center px-3 py-2 border-b border-base-300/50 bg-base-200/20">
+              <input
+                ref={codeRef}
+                autoFocus
+                className="input input-xs input-bordered w-20 font-mono text-xs focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20"
+                placeholder={t('erasmus.colCode')}
+                value={code}
+                onChange={e => setCode(e.target.value)}
+                onKeyDown={e => e.key === 'Enter' && handleAdd()}
+              />
+              <input
+                className="input input-xs input-bordered w-full text-xs focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20"
+                placeholder={t('erasmus.colMendeluCourse')}
+                value={name}
+                onChange={e => setName(e.target.value)}
+                onKeyDown={e => e.key === 'Enter' && handleAdd()}
+              />
+              <input
+                className="input input-xs input-bordered w-12 text-xs text-right tabular-nums focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20"
+                placeholder="0"
+                value={credits}
+                onChange={e => setCredits(e.target.value.replace(/\D/g, ''))}
+                onKeyDown={e => e.key === 'Enter' && handleAdd()}
+              />
+              <button onClick={() => setAdding(false)} className="btn btn-ghost btn-xs w-5 h-5 min-h-0 p-0 text-base-content/30 hover:text-error rounded-full">
+                <X size={12} />
+              </button>
+            </div>
+          )}
+
+          {hasRows && (
+            <div className="grid grid-cols-[auto_auto_1fr_auto_auto] gap-2 items-center px-3 py-2 bg-base-200/30 border-t border-base-300 text-xs">
+              <span className="w-4" />
+              <span className="font-bold text-base-content/50 w-20">{t('erasmus.total')}</span>
+              <span />
+              <span className="tabular-nums font-black w-12 text-right">{totalCredits}</span>
+              <span className="w-5" />
+            </div>
+          )}
         </div>
+      )}
+
+      {/* Fallback escape hatch — visually silent, only noticed when needed */}
+      {!adding && (
+        <button
+          onClick={openForm}
+          className="self-end text-xs text-base-content/40 hover:text-base-content/65 transition-colors duration-150 leading-none pt-0.5 cursor-pointer"
+        >
+          {t('erasmus.addManuallyFallback')}
+        </button>
       )}
     </div>
   );

--- a/src/components/ErasmusPanel/index.tsx
+++ b/src/components/ErasmusPanel/index.tsx
@@ -160,7 +160,7 @@ export function ErasmusPanel({ onOpenSubject, onSearchSubject }: ErasmusPanelPro
               {tableAOptions.length < 4 && (
                 <button
                   onClick={addOption}
-                  className="btn btn-soft btn-primary btn-sm rounded-full px-5 shadow-sm border border-primary/20 h-8"
+                  className="btn btn-ghost btn-sm rounded-full px-4 h-8 text-base-content/40 hover:text-base-content/70 border border-base-300 hover:border-base-content/20 font-normal"
                 >
                   <Plus size={14} className="opacity-70" />
                   <span className="font-bold text-xs">{t('erasmus.addOption', { n: (tableAOptions.length + 1).toString() })}</span>

--- a/src/components/ExamPanel/index.tsx
+++ b/src/components/ExamPanel/index.tsx
@@ -116,7 +116,7 @@ return (
 
             {/* Horizontal Timeline Integration */}
             {realExams.length > 0 && (
-                <div className="px-4 pb-0 border-b border-base-200">
+                <div>
                     <ExamTimeline
                         exams={realExams as unknown as TimelineExam[]}
                         orientation="horizontal"

--- a/src/components/Exams/Timeline/ExamItem.tsx
+++ b/src/components/Exams/Timeline/ExamItem.tsx
@@ -98,6 +98,49 @@ const ContentBox: React.FC<ContentBoxProps> = ({ subjectName, sectionName, term,
   );
 };
 
+interface CompactCardProps {
+  subjectName: string;
+  sectionName?: string;
+  term: ExamTerm;
+  deadline?: string;
+  isSelected?: boolean;
+  onClick?: () => void;
+  t: (key: string) => string;
+  language?: string;
+}
+
+const CompactCard: React.FC<CompactCardProps> = ({ subjectName, sectionName, term, deadline, isSelected, onClick, language }) => {
+  const urgency = getDeadlineUrgency(deadline);
+  const countdown = deadline && urgency !== 'none' && urgency !== 'expired' ? formatDeadlineCountdown(deadline) : null;
+  const badgeClass = urgencyBadge[urgency];
+
+  return (
+    <div
+      className={`
+        border px-2.5 py-1.5 w-full bg-base-100 rounded-md
+        transition-all duration-200
+        ${urgencyBorder[urgency]}
+        ${isSelected ? 'ring-1 ring-primary/40 bg-base-200/40' : ''}
+        ${onClick ? 'cursor-pointer hover:bg-base-200/50 active:scale-[0.98]' : ''}
+      `}
+      onClick={onClick}
+    >
+      <div className="font-black text-[11px] leading-tight truncate text-base-content">{subjectName}</div>
+      {sectionName && (
+        <div className="text-[9px] font-medium text-base-content/40 uppercase tracking-wide truncate leading-none mt-0.5">{sectionName}</div>
+      )}
+      <div className="flex items-center gap-1.5 mt-1 flex-wrap">
+        <div className="text-[10px] font-mono font-bold text-primary leading-none whitespace-nowrap">
+          {term.date} · {term.time}
+        </div>
+        {countdown && badgeClass && (
+          <span className={`text-[9px] font-bold px-1 py-px rounded border ${badgeClass} leading-none`}>{countdown}</span>
+        )}
+      </div>
+    </div>
+  );
+};
+
 const ExamItem: React.FC<ExamItemProps> = ({ term, subjectName, sectionName, deadline, isSelected, isFirst, isLast, orientation = 'vertical', onClick }) => {
   const { t, language } = useTranslation();
   const isHorizontal = orientation === 'horizontal';
@@ -105,9 +148,24 @@ const ExamItem: React.FC<ExamItemProps> = ({ term, subjectName, sectionName, dea
   const iconClass = 'text-base-content opacity-40 invisible';
 
   if (isHorizontal) {
+    const urgency = getDeadlineUrgency(deadline);
+    const dotColor = isSelected
+      ? 'bg-primary ring-2 ring-primary/30 scale-110'
+      : urgency === 'critical'
+      ? 'bg-error animate-pulse'
+      : urgency === 'warning'
+      ? 'bg-warning'
+      : 'bg-base-content/40';
+
     return (
-      <div className="flex-shrink-0">
-        <ContentBox subjectName={subjectName} sectionName={sectionName} term={term} deadline={deadline} isHorizontal isSelected={isSelected} onClick={onClick} t={t} language={language} />
+      <div className="flex-shrink-0 flex flex-col items-center w-40">
+        <div className="px-1.5 w-full">
+          <CompactCard subjectName={subjectName} sectionName={sectionName} term={term} deadline={deadline} isSelected={isSelected} onClick={onClick} t={t} language={language} />
+        </div>
+        <div className="w-px h-2.5 bg-base-content/15 shrink-0" />
+        <div className="h-2 flex items-center justify-center shrink-0">
+          <div className={`w-2 h-2 rounded-full transition-all duration-200 ${dotColor}`} />
+        </div>
       </div>
     );
   }

--- a/src/components/Exams/Timeline/ExamTimeline.tsx
+++ b/src/components/Exams/Timeline/ExamTimeline.tsx
@@ -77,8 +77,9 @@ const ExamTimeline: React.FC<ExamTimelineProps> = ({
   }
 
   return (
-    <>
-      <div className={`flex flex-row overflow-x-auto gap-3 py-1.5 px-0.5 w-full h-fit ${className}`}>
+    <div className={`overflow-x-auto w-full py-3 ${className}`}>
+      <div className="relative flex flex-row w-full min-w-max">
+        <div className="absolute left-0 right-0 bottom-[4px] h-px bg-base-content/15 pointer-events-none" />
         {sortedExams.map((item, index) => (
           <ExamItem
             key={item.term.id || `${item.subjectName}-${index}`}
@@ -87,13 +88,14 @@ const ExamTimeline: React.FC<ExamTimelineProps> = ({
             sectionName={resolveSectionName(item)}
             deadline={item.section?.registeredTerm?.deregistrationDeadline}
             orientation="horizontal"
+            isFirst={index === 0}
+            isLast={index === sortedExams.length - 1}
             isSelected={selectedSectionId != null && selectedSectionId === item.section?.id}
             onClick={() => handleCardClick(item)}
           />
         ))}
       </div>
-
-    </>
+    </div>
   );
 };
 

--- a/src/entrypoints/background.ts
+++ b/src/entrypoints/background.ts
@@ -1,22 +1,24 @@
 import { defineBackground } from 'wxt/utils/define-background';
-import { browser } from 'wxt/browser';
 
 export default defineBackground(() => {
-  // Return a Promise instead of sendResponse+return true — fixes Firefox cross-context `.then` access denial.
-  browser.runtime.onMessage.addListener((message): Promise<unknown> | undefined => {
-    if (message.type !== 'REIS_BG_FETCH') return;
+  // Use sendResponse+return true (not Promise-return) — WXT's browser polyfill does not
+  // reliably relay async Promise returns to chrome.runtime.sendMessage callers in Chrome.
+  chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+    if (message.type !== 'REIS_BG_FETCH') return false;
 
     const opts: RequestInit = {};
     if (message.options?.method) opts.method = message.options.method;
     if (message.options?.headers) opts.headers = message.options.headers;
     if (message.options?.body) opts.body = message.options.body;
 
-    return fetch(message.url, opts)
+    fetch(message.url, opts)
       .then((res) => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         return res.text();
       })
-      .then((text) => ({ success: true, data: text }))
-      .catch((e) => ({ success: false, error: String(e) }));
+      .then((text) => sendResponse({ success: true, data: text }))
+      .catch((e) => sendResponse({ success: false, error: String(e) }));
+
+    return true; // keep the message channel open for async sendResponse
   });
 });

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -560,6 +560,8 @@
     "uploadSyllabi": "Nahrát zahraniční sylabusy (PDF)",
     "matchedWith": "Spárováno s",
     "addCourse": "Přidat předmět",
+    "addManually": "Přidat ručně",
+    "addManuallyFallback": "Předmět tu není? Přidat ručně",
     "addCourses": "Přidat předměty",
     "addCoursesHint": "Vyber předměty MENDELU ze studijního plánu",
     "addOptionHint": "Vytvoř další studijní smlouvu pro jinou instituci",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -558,6 +558,8 @@
     "uploadSyllabi": "Upload foreign syllabi (PDF)",
     "matchedWith": "Matched with",
     "addCourse": "Add course",
+    "addManually": "Add manually",
+    "addManuallyFallback": "Course not listed? Add manually",
     "addCourses": "Add courses",
     "addCoursesHint": "Select MENDELU courses from your study plan",
     "addOptionHint": "Draft another learning agreement for a different institution",

--- a/src/injector/messageHandler.ts
+++ b/src/injector/messageHandler.ts
@@ -71,7 +71,7 @@ async function handleFetchRequest(id: string, url: string, options?: { method?: 
             text = await response.text();
         } else {
             let result = await chrome.runtime.sendMessage({ type: 'REIS_BG_FETCH', url, options });
-            if (result === undefined) {
+            if (result == null) {
                 // Service worker may still be waking up — retry once after a brief pause
                 await new Promise(r => setTimeout(r, 500));
                 result = await chrome.runtime.sendMessage({ type: 'REIS_BG_FETCH', url, options });

--- a/src/injector/messageHandler.ts
+++ b/src/injector/messageHandler.ts
@@ -70,7 +70,12 @@ async function handleFetchRequest(id: string, url: string, options?: { method?: 
             if (!response.ok) throw new Error(`HTTP ${response.status}`);
             text = await response.text();
         } else {
-            const result = await chrome.runtime.sendMessage({ type: 'REIS_BG_FETCH', url, options });
+            let result = await chrome.runtime.sendMessage({ type: 'REIS_BG_FETCH', url, options });
+            if (result === undefined) {
+                // Service worker may still be waking up — retry once after a brief pause
+                await new Promise(r => setTimeout(r, 500));
+                result = await chrome.runtime.sendMessage({ type: 'REIS_BG_FETCH', url, options });
+            }
             if (!result?.success) throw new Error(result?.error || 'Background fetch failed');
             text = result.data;
         }

--- a/src/store/slices/createErasmusSlice.ts
+++ b/src/store/slices/createErasmusSlice.ts
@@ -10,6 +10,7 @@ import type { AIComparisonResult } from '../../api/gemini';
 const TABLE_A_COURSES_KEY = 'erasmus_table_a_courses'; // Legacy
 const TABLE_A_OPTIONS_KEY = 'erasmus_table_a_options';
 const TABLE_B_COURSES_KEY = 'erasmus_table_b_courses';
+const TABLE_B_MANUAL_KEY = 'erasmus_table_b_manual';
 const STUDENT_INFO_KEY = 'erasmus_student_info';
 const ERASMUS_UI_STATE_KEY = 'erasmus_ui_state';
 const VERDICTS_KEY = 'erasmus_verdicts';
@@ -31,6 +32,7 @@ export const createErasmusSlice: AppSlice<ErasmusSlice> = (set, get) => ({
   erasmusCountryFile: '',
   erasmusConfig: null,
   erasmusTableBCourses: {},
+  erasmusTableBManualCourses: {},
   erasmusStudentInfo: { ...EMPTY_STUDENT_INFO },
   erasmusTableAOptions: [
     { id: 'opt-1', institutionName: '', erasmusCode: '', country: '', link: '', courses: [] }
@@ -272,6 +274,27 @@ export const createErasmusSlice: AppSlice<ErasmusSlice> = (set, get) => ({
     set({ erasmusTableAOptions: next });
     IndexedDBService.set('meta', TABLE_A_OPTIONS_KEY, next).catch(e => logError('ErasmusSlice.removeErasmusTableACourse', e));
   },
+  addErasmusTableBManualCourse: (optionId: string, course: { code: string; name: string; credits: number }) => {
+    const all = get().erasmusTableBManualCourses;
+    const next = { ...all, [optionId]: [...(all[optionId] ?? []), course] };
+    set({ erasmusTableBManualCourses: next });
+    IndexedDBService.set('meta', TABLE_B_MANUAL_KEY, next).catch(e => logError('ErasmusSlice.addErasmusTableBManualCourse', e));
+  },
+  removeErasmusTableBManualCourse: (optionId: string, index: number) => {
+    const all = get().erasmusTableBManualCourses;
+    const next = { ...all, [optionId]: (all[optionId] ?? []).filter((_, i) => i !== index) };
+    set({ erasmusTableBManualCourses: next });
+    IndexedDBService.set('meta', TABLE_B_MANUAL_KEY, next).catch(e => logError('ErasmusSlice.removeErasmusTableBManualCourse', e));
+  },
+  reorderErasmusTableBManualCourse: (optionId: string, fromIndex: number, toIndex: number) => {
+    const all = get().erasmusTableBManualCourses;
+    const current = [...(all[optionId] ?? [])];
+    const [moved] = current.splice(fromIndex, 1);
+    current.splice(toIndex, 0, moved);
+    const next = { ...all, [optionId]: current };
+    set({ erasmusTableBManualCourses: next });
+    IndexedDBService.set('meta', TABLE_B_MANUAL_KEY, next).catch(e => logError('ErasmusSlice.reorderErasmusTableBManualCourse', e));
+  },
   reorderErasmusTableACourse: (optionId: string, fromIndex: number, toIndex: number) => {
     const next = get().erasmusTableAOptions.map(o => {
       if (o.id !== optionId) return o;
@@ -287,6 +310,9 @@ export const createErasmusSlice: AppSlice<ErasmusSlice> = (set, get) => ({
     try {
       const tableBCourses = await IndexedDBService.get('meta', TABLE_B_COURSES_KEY) as Record<string, string[]> | null;
       if (tableBCourses) set({ erasmusTableBCourses: tableBCourses });
+
+      const tableBManual = await IndexedDBService.get('meta', TABLE_B_MANUAL_KEY) as Record<string, { code: string; name: string; credits: number }[]> | null;
+      if (tableBManual) set({ erasmusTableBManualCourses: tableBManual });
 
       const studentInfo = await IndexedDBService.get('meta', STUDENT_INFO_KEY) as ErasmusStudentInfo | null;
       if (studentInfo) set({ erasmusStudentInfo: { ...EMPTY_STUDENT_INFO, ...studentInfo } });

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -197,6 +197,7 @@ export interface ErasmusSlice {
     erasmusCountryFile: string;
     erasmusConfig: ErasmusConfig | null;
     erasmusTableBCourses: Record<string, string[]>;
+    erasmusTableBManualCourses: Record<string, { code: string; name: string; credits: number }[]>;
     erasmusStudentInfo: ErasmusStudentInfo;
     erasmusTableAOptions: ErasmusUniversityOption[];
     erasmusVerdicts: Record<string, 'approved' | 'rejected'>;
@@ -232,6 +233,9 @@ export interface ErasmusSlice {
     addErasmusTableACourse: (optionId: string, course: { code: string; name: string; credits: number }) => void;
     removeErasmusTableACourse: (optionId: string, index: number) => void;
     reorderErasmusTableACourse: (optionId: string, fromIndex: number, toIndex: number) => void;
+    addErasmusTableBManualCourse: (optionId: string, course: { code: string; name: string; credits: number }) => void;
+    removeErasmusTableBManualCourse: (optionId: string, index: number) => void;
+    reorderErasmusTableBManualCourse: (optionId: string, fromIndex: number, toIndex: number) => void;
     loadErasmusState: () => Promise<void>;
 }
 

--- a/src/utils/erasmusPdf.ts
+++ b/src/utils/erasmusPdf.ts
@@ -73,6 +73,7 @@ export async function downloadErasmusPdf(
   options: ErasmusUniversityOption[],
   tableBCourses: Record<string, string[]>,
   allSubjects: SubjectStatus[],
+  tableBManualCourses: Record<string, { code: string; name: string; credits: number }[]> = {},
 ): Promise<void> {
   const doc = new jsPDF({ unit: 'mm', format: 'a4' });
   const subjectMap = new Map(allSubjects.map(s => [s.code, s]));
@@ -101,13 +102,16 @@ export async function downloadErasmusPdf(
     const positionalExaTotal = codes.reduce((sum, code, i) => { const s = subjectMap.get(code); return (!s || s.credits >= 999) ? sum + (option.courses[i]?.credits ?? 0) : sum; }, 0);
     const residual = Math.max(0, tableATotal - knownBTotal - positionalExaTotal);
     const lastExaIdx = codes.map((code, i) => { const s = subjectMap.get(code); return (!s || s.credits >= 999) ? i : -1; }).filter(i => i >= 0).pop();
-    const bRows = codes.map((code, rowIndex) => {
-      const s = subjectMap.get(code);
-      const isExa = !s || s.credits >= 999;
-      const base = isExa ? (option.courses[rowIndex]?.credits ?? 0) : s.credits;
-      const credits = isExa && rowIndex === lastExaIdx ? base + residual : base;
-      return { code, name: s?.name ?? code, credits };
-    });
+    const bRows = [
+      ...codes.map((code, rowIndex) => {
+        const s = subjectMap.get(code);
+        const isExa = !s || s.credits >= 999;
+        const base = isExa ? (option.courses[rowIndex]?.credits ?? 0) : s.credits;
+        const credits = isExa && rowIndex === lastExaIdx ? base + residual : base;
+        return { code, name: s?.name ?? code, credits };
+      }),
+      ...(tableBManualCourses[option.id] ?? []),
+    ];
 
     // Institution header
     y = drawTable(doc, y, [


### PR DESCRIPTION
## Summary
- Replaces flat card row with a real timeline: single continuous rail line + per-exam dot markers
- Compact cards (`CompactCard`) cut block height roughly in half — date/time only, no room row, no chevron
- Dots reflect urgency state: `bg-error animate-pulse` for <24h, `bg-warning` for <48h, `bg-primary` for selected
- Rail line is a single absolute element spanning full panel width (`w-full min-w-max` inner wrapper), so it touches both container edges and scrolls cleanly for 15+ exams
- Removed redundant `border-b` divider between timeline and exam list — the rail itself acts as the visual separator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added urgency countdown indicators to exam cards in timeline view.
  * Enabled exam selection capability in horizontal timeline layout.

* **Style**
  * Redesigned exam cards in horizontal view with a more compact card design.
  * Improved horizontal exam timeline layout and scrolling behavior for better navigation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/reis-mendelu/reis-extension/pull/47)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->