### PR TITLE
fix: close HIGH-severity notes-image, Drive-backup & ISKAM-handshake data-loss races

### DIFF
--- a/src/components/SubjectFileDrawer/DocumentNoteEditor.tsx
+++ b/src/components/SubjectFileDrawer/DocumentNoteEditor.tsx
@@ -3,7 +3,7 @@ import { X, Plus } from 'lucide-react';
 import { useDocumentNote } from '../../hooks/data/useDocumentNote';
 import { useTranslation } from '../../hooks/useTranslation';
 import { parseNote, serializeNote, type DocumentNoteData, type NoteCardData } from './utils/noteParser';
-import { NoteCard } from './NoteCard';
+import { NoteCard, type CardPatch } from './NoteCard';
 
 interface DocumentNoteEditorProps {
     courseCode: string;
@@ -29,9 +29,12 @@ export function DocumentNoteEditor({ courseCode, fileLink, fileName, onClose, sh
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [isLoading, fileLink, courseCode]);
 
-    const updateCard = useCallback((id: string, patch: Partial<NoteCardData>) => {
+    const updateCard = useCallback((id: string, patch: CardPatch) => {
         setData((prev) => {
-            const next = { ...prev, cards: prev.cards.map((c) => (c.id === id ? { ...c, ...patch } : c)) };
+            const next = {
+                ...prev,
+                cards: prev.cards.map((c) => (c.id === id ? { ...c, ...(typeof patch === 'function' ? patch(c) : patch) } : c)),
+            };
             setNote(serializeNote(next), fileName);
             return next;
         });

--- a/src/components/SubjectFileDrawer/NoteCard.tsx
+++ b/src/components/SubjectFileDrawer/NoteCard.tsx
@@ -7,10 +7,14 @@ import { normalizeImage } from '../../services/notes/imageNormalize';
 import { storeImage } from '../../services/notes/noteImageStore';
 import { useNoteImage } from './useNoteImage';
 
+/** A field patch, or an updater computed from the *current* card (avoids
+ *  clobbering concurrent edits when the patch is built after an async gap). */
+export type CardPatch = Partial<NoteCardData> | ((card: NoteCardData) => Partial<NoteCardData>);
+
 interface NoteCardProps {
     card: NoteCardData;
     autoFocus: boolean;
-    onChange: (patch: Partial<NoteCardData>) => void;
+    onChange: (patch: CardPatch) => void;
     onEnterAnswer: () => void; // Enter in the answer -> create the next card
     onDelete: () => void;
 }
@@ -72,10 +76,12 @@ export function NoteCard({ card, autoFocus, onChange, onEnterAnswer, onDelete }:
                 /* skip a single undecodable image rather than break the note */
             }
         }
-        if (hashes.length) onChange({ images: [...card.images, ...hashes] });
-    }, [card.images, onChange, t]);
+        // Derive from the live card inside the updater — image encoding above is
+        // async, so `card.images` captured here may be stale by now.
+        if (hashes.length) onChange((c) => ({ images: [...c.images, ...hashes] }));
+    }, [onChange, t]);
 
-    const removeImage = (hash: string) => onChange({ images: card.images.filter((h) => h !== hash) });
+    const removeImage = (hash: string) => onChange((c) => ({ images: c.images.filter((h) => h !== hash) }));
 
     return (
         <div className="group rounded-lg border border-base-300 bg-base-200/30 px-2 py-1.5">

--- a/src/injector/__tests__/iskamMessageHandler.test.ts
+++ b/src/injector/__tests__/iskamMessageHandler.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const { contentWindow } = vi.hoisted(() => ({ contentWindow: {} as Window }));
+
+vi.mock('../iskamInjector', () => ({
+    iskamIframeElement: { contentWindow },
+    markIskamIframeReady: vi.fn(),
+    sendToIskamIframe: vi.fn(),
+}));
+
+// Simulate a session where the initial sync already completed: cached data is
+// present and no sync is in flight (the queue the iframe would have drained is
+// long gone — a reload must be re-seeded from this cache).
+vi.mock('../iskamSyncService', () => ({
+    cachedIskamData: { profile: { name: 'X' } },
+    isSyncingIskam: false,
+}));
+
+import { handleIskamMessage } from '../iskamMessageHandler';
+import { sendToIskamIframe, markIskamIframeReady, iskamIframeElement } from '../iskamInjector';
+
+function readyEvent(): MessageEvent {
+    return {
+        origin: 'chrome-extension://test-extension-id',
+        source: iskamIframeElement!.contentWindow,
+        data: { type: 'ISKAM_READY' },
+    } as MessageEvent;
+}
+
+describe('handleIskamMessage — ISKAM_READY', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('flushes the queue and re-sends current cached state (reloaded iframe must not be stuck on stale IDB)', async () => {
+        await handleIskamMessage(readyEvent());
+        expect(markIskamIframeReady).toHaveBeenCalledTimes(1);
+        expect(sendToIskamIframe).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: 'ISKAM_SYNC_UPDATE',
+                data: expect.objectContaining({ iskamData: { profile: { name: 'X' } }, isSyncing: false }),
+            }),
+        );
+    });
+
+    it('ignores messages from a foreign origin', async () => {
+        const evt = { ...readyEvent(), origin: 'https://evil.example' } as MessageEvent;
+        await handleIskamMessage(evt);
+        expect(markIskamIframeReady).not.toHaveBeenCalled();
+    });
+});

--- a/src/injector/iskamMessageHandler.ts
+++ b/src/injector/iskamMessageHandler.ts
@@ -1,5 +1,6 @@
-import { isIframeMessage, Messages } from '../types/messages';
+import { isIframeMessage, Messages, IskamMessages } from '../types/messages';
 import { iskamIframeElement, markIskamIframeReady, sendToIskamIframe } from './iskamInjector';
+import { cachedIskamData, isSyncingIskam } from './iskamSyncService';
 import { IndexedDBService } from '../services/storage/IndexedDBService';
 import { fetchVolneKapacityBlock } from '../api/iskam/volneKapacity';
 
@@ -12,9 +13,12 @@ export async function handleIskamMessage(event: MessageEvent): Promise<void> {
     if (!isIframeMessage(data)) return;
 
     if (data.type === 'ISKAM_READY') {
-        // Flush queued messages (may include isSyncing:true and/or the final result).
-        // The queue is sufficient — no guarantee message needed.
+        // Flush queued messages (may include isSyncing:true and/or the final result),
+        // then re-send the current cached state as a guarantee. A reloaded iframe
+        // arrives after the queue was already drained, so without this re-seed it
+        // would be stuck on its IDB cache (mirrors the IS-side REIS_READY handler).
         markIskamIframeReady();
+        sendToIskamIframe(IskamMessages.iskamSyncUpdate(cachedIskamData, isSyncingIskam, null));
         return;
     }
 

--- a/src/injector/iskamSyncService.ts
+++ b/src/injector/iskamSyncService.ts
@@ -6,7 +6,7 @@ import { IskamMessages, Messages } from '../types/messages';
 import type { IskamData } from '../types/iskam';
 
 export let cachedIskamData: IskamData | null = null;
-let isSyncingIskam = false;
+export let isSyncingIskam = false;
 
 export async function syncIskamData(): Promise<void> {
     if (isSyncingIskam) return;

--- a/src/services/drive/__tests__/driveManifest.test.ts
+++ b/src/services/drive/__tests__/driveManifest.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { acquireBackupLock, releaseBackupLock } from '../driveManifest';
+
+const LOCK_KEY = 'reis_drive_lock';
+
+/** Wire the bare chrome.storage.local stubs to an in-memory backing store. */
+let store: Record<string, unknown>;
+function wireStore() {
+    vi.mocked(chrome.storage.local.get).mockImplementation((async (k: string) =>
+        (k in store ? { [k]: store[k] } : {})) as never);
+    vi.mocked(chrome.storage.local.set).mockImplementation((async (obj: Record<string, unknown>) => {
+        Object.assign(store, obj);
+    }) as never);
+    vi.mocked(chrome.storage.local.remove).mockImplementation((async (k: string) => {
+        delete store[k];
+    }) as never);
+}
+
+describe('drive backup lock', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        store = {};
+        wireStore();
+    });
+
+    it('acquires when free and stores an owner token record', async () => {
+        const ok = await acquireBackupLock();
+        expect(ok).toBe(true);
+        expect(store[LOCK_KEY]).toMatchObject({ token: expect.any(String), at: expect.any(Number) });
+    });
+
+    it('refuses a second acquire while a fresh lock is held', async () => {
+        await acquireBackupLock();
+        expect(await acquireBackupLock()).toBe(false);
+    });
+
+    it('re-acquires a lock older than the TTL (abandoned)', async () => {
+        store[LOCK_KEY] = { token: 'stale', at: Date.now() - 16 * 60 * 1000 };
+        const ok = await acquireBackupLock();
+        expect(ok).toBe(true);
+        expect((store[LOCK_KEY] as { token: string }).token).not.toBe('stale');
+    });
+
+    it('loses the race when a competitor overwrites between set and read-back', async () => {
+        let gets = 0;
+        vi.mocked(chrome.storage.local.get).mockImplementation((async () => {
+            gets++;
+            // 1st get = initial free check; 2nd get = read-back → competitor won.
+            return gets >= 2 ? { [LOCK_KEY]: { token: 'competitor', at: Date.now() } } : {};
+        }) as never);
+        expect(await acquireBackupLock()).toBe(false);
+    });
+
+    it('release removes the lock we own', async () => {
+        await acquireBackupLock();
+        await releaseBackupLock();
+        expect(store[LOCK_KEY]).toBeUndefined();
+    });
+
+    it('release never clobbers a lock owned by another context', async () => {
+        await acquireBackupLock();
+        // Our lock expired and another tab legitimately took over.
+        store[LOCK_KEY] = { token: 'foreign', at: Date.now() };
+        await releaseBackupLock();
+        expect(store[LOCK_KEY]).toEqual({ token: 'foreign', at: expect.any(Number) });
+    });
+});

--- a/src/services/drive/__tests__/driveNotesBackup.test.ts
+++ b/src/services/drive/__tests__/driveNotesBackup.test.ts
@@ -66,6 +66,36 @@ describe('syncDriveNotesBackup', () => {
         expect(drive.uploadDoc).not.toHaveBeenCalled();
         expect(r?.skipped).toBe(1);
     });
+
+    const withImg: SubjectNotes = {
+        ...subject,
+        files: [{
+            fileLink: '/x', fileName: 'L1.pdf',
+            note: JSON.stringify({ cards: [{ id: 'a', question: 'q', answer: '', collapsed: false, images: ['hashAAA'] }], notes: '' }),
+        }],
+    };
+    const imgHtml = '<html><body><p><img src="data:image/jpeg;base64,AAAA"></p></body></html>';
+
+    it('re-uploads when a subject with images was first stored text-only (override arrives later)', async () => {
+        // Pass 1: no override → text-only fallback is uploaded and the hash is recorded.
+        await syncDriveNotesBackup([withImg]);
+        expect(drive.uploadDoc).toHaveBeenCalledTimes(1);
+        vi.clearAllMocks();
+        // Pass 2: identical note content, but now the image-inlined override is present.
+        const r = await syncDriveNotesBackup([withImg], { 'BIK-DBS': imgHtml });
+        // Must NOT skip — the stored Doc has no images yet.
+        expect(drive.updateDocContent).toHaveBeenCalledWith('doc1', expect.stringContaining('data:image/jpeg'));
+        expect(r?.skipped).toBe(0);
+        expect(r?.written).toBe(1);
+    });
+
+    it('skips a subject already stored WITH images when nothing changed', async () => {
+        await syncDriveNotesBackup([withImg], { 'BIK-DBS': imgHtml }); // imagesEmbedded recorded
+        vi.clearAllMocks();
+        const r = await syncDriveNotesBackup([withImg], { 'BIK-DBS': imgHtml });
+        expect(drive.updateDocContent).not.toHaveBeenCalled();
+        expect(r?.skipped).toBe(1);
+    });
 });
 
 describe('syncDriveNotesBackup deletion reconcile', () => {

--- a/src/services/drive/driveDiff.ts
+++ b/src/services/drive/driveDiff.ts
@@ -28,7 +28,7 @@ export interface DriveManifest {
     /** isLink → mirrored file state. */
     files: Record<string, { driveFileId: string; date: string }>;
     /** courseCode → backed-up notes Doc + sidecar state. */
-    notes: Record<string, { docId: string; docHash: string; jsonId: string }>;
+    notes: Record<string, { docId: string; docHash: string; jsonId: string; imagesEmbedded?: boolean }>;
     /** Epoch ms of the last completed backup pass. */
     lastSync: number;
     /** Epoch ms of the first failure in the current failing streak; null when the last pass succeeded. */

--- a/src/services/drive/driveManifest.ts
+++ b/src/services/drive/driveManifest.ts
@@ -13,23 +13,51 @@ const KEY = 'reis_drive_manifest';
 const LOCK_KEY = 'reis_drive_lock';
 /** A backup pass should never outlast this; a staler lock is treated as abandoned. */
 const LOCK_TTL_MS = 15 * 60 * 1000;
+/** Window we give a racing writer's set to land before confirming ownership. */
+const LOCK_SETTLE_MS = 50;
+
+interface LockRecord { token: string; at: number; }
+
+/** Token of the lock this context currently holds, so release can verify ownership. */
+let heldToken: string | null = null;
+
+function lockAge(rec: LockRecord | number | undefined): number | undefined {
+    // Tolerate a legacy numeric lock written by a previous extension version.
+    const at = typeof rec === 'number' ? rec : rec?.at;
+    return at === undefined ? undefined : Date.now() - at;
+}
 
 /**
  * Best-effort cross-tab/cross-context mutex. The per-instance `running` guard
  * only serialises one content script; multiple IS Mendelu tabs each have their
- * own, so without this two passes could race-create duplicate folders. Returns
- * false if a fresh lock is already held.
+ * own, so without this two passes could race-create duplicate folders.
+ *
+ * chrome.storage has no compare-and-swap, so we write a unique token, let a
+ * racing writer's set land, then read back and only win if our token survived.
+ * Returns false if a fresh lock is already held or we lost the race.
  */
 export async function acquireBackupLock(): Promise<boolean> {
-    const res = await chrome.storage.local.get(LOCK_KEY);
-    const heldAt = res[LOCK_KEY] as number | undefined;
-    if (heldAt && Date.now() - heldAt < LOCK_TTL_MS) return false;
-    await chrome.storage.local.set({ [LOCK_KEY]: Date.now() });
+    const existing = (await chrome.storage.local.get(LOCK_KEY))[LOCK_KEY] as LockRecord | number | undefined;
+    const age = lockAge(existing);
+    if (age !== undefined && age < LOCK_TTL_MS) return false;
+
+    const token = `${Date.now()}-${crypto.randomUUID()}`;
+    await chrome.storage.local.set({ [LOCK_KEY]: { token, at: Date.now() } satisfies LockRecord });
+    await new Promise((r) => setTimeout(r, LOCK_SETTLE_MS));
+    const winner = (await chrome.storage.local.get(LOCK_KEY))[LOCK_KEY] as LockRecord | undefined;
+    if (winner?.token !== token) return false;
+    heldToken = token;
     return true;
 }
 
 export async function releaseBackupLock(): Promise<void> {
-    await chrome.storage.local.remove(LOCK_KEY);
+    // Only remove the lock if we still own it — never clobber a lock another
+    // context legitimately took over after ours expired by TTL.
+    const current = (await chrome.storage.local.get(LOCK_KEY))[LOCK_KEY] as LockRecord | undefined;
+    if (current?.token === heldToken) {
+        await chrome.storage.local.remove(LOCK_KEY);
+    }
+    heldToken = null;
 }
 
 export async function loadManifest(): Promise<DriveManifest> {

--- a/src/services/drive/driveNotesBackup.ts
+++ b/src/services/drive/driveNotesBackup.ts
@@ -19,7 +19,7 @@ import { loadManifest, saveManifest, acquireBackupLock, releaseBackupLock } from
 import { folderKey, type DriveManifest } from './driveDiff';
 import {
     renderSubjectNotesHtml, serializeSubjectNotesJson, notesContentHash,
-    renderEmptyNotesHtml, serializeEmptyNotesJson, type SubjectNotes,
+    renderEmptyNotesHtml, serializeEmptyNotesJson, subjectReferencesImages, type SubjectNotes,
 } from './notesDoc';
 import { logError } from '../../utils/reportError';
 
@@ -113,13 +113,22 @@ async function runNotesPass(subjects: SubjectNotes[], htmlOverrides: Record<stri
             const json = serializeSubjectNotesJson(subject);
             const hash = await notesContentHash(json);
             const prev = manifest.notes[subject.code];
-            if (prev && prev.docHash === hash) { skipped++; continue; }
+            // The note JSON only carries image *hashes*, so docHash is identical
+            // whether or not the uploaded artifact actually inlined the images.
+            // Skip only when the content is unchanged AND either the subject has no
+            // images or the previously-uploaded Doc already embedded them — otherwise
+            // a text-only fallback would be recorded as "done" and the image upload
+            // skipped forever once the override finally arrives.
+            const hasImages = subjectReferencesImages(subject);
+            if (prev && prev.docHash === hash && (!hasImages || prev.imagesEmbedded)) { skipped++; continue; }
 
             // --- Google Doc (readable) ---
             const subjectFolderId = await ensureChildFolder(manifest, subject.folderName);
             // Prefer the iframe-rendered base64-inlined HTML (carries card images);
             // fall back to the text-only render when no override was pushed.
-            const html = htmlOverrides[subject.code] ?? renderSubjectNotesHtml(subject);
+            const override = htmlOverrides[subject.code];
+            const html = override ?? renderSubjectNotesHtml(subject);
+            const imagesEmbedded = hasImages && override !== undefined;
             let docId = prev?.docId ?? (await findFileByProperty(DOC_PROP, subject.code));
             if (docId) {
                 await updateDocContent(docId, html);
@@ -137,7 +146,7 @@ async function runNotesPass(subjects: SubjectNotes[], htmlOverrides: Record<stri
                 jsonId = (await uploadFile(`${subject.code}.json`, jsonBlob, [notesFolderId], { [JSON_PROP]: subject.code })).id;
             }
 
-            manifest.notes[subject.code] = { docId, docHash: hash, jsonId };
+            manifest.notes[subject.code] = { docId, docHash: hash, jsonId, imagesEmbedded };
             await saveManifest(manifest);
             written++;
         } catch (e) {

--- a/src/services/drive/notesDoc.ts
+++ b/src/services/drive/notesDoc.ts
@@ -88,6 +88,11 @@ export async function renderSubjectNotesHtmlWithImages(
     return `<html><body>${parts.join('')}</body></html>`;
 }
 
+/** True if any card in the subject's notes references an image hash. */
+export function subjectReferencesImages(subject: SubjectNotes): boolean {
+    return subject.files.some((f) => parseNote(f.note).cards.some((c) => c.images.length > 0));
+}
+
 /** Body for a subject whose notes were all deleted — keeps the Doc, clears content. */
 export function renderEmptyNotesHtml(): string {
     return `<html><body><p><i>${esc(BANNER)}</i></p></body></html>`;

--- a/src/services/notes/__tests__/noteImageStore.test.ts
+++ b/src/services/notes/__tests__/noteImageStore.test.ts
@@ -23,6 +23,21 @@ describe('noteImageStore', () => {
         expect(all.filter((e) => e.key === a)).toHaveLength(1);
     });
 
+    it('refreshes createdAt on a dedup hit so a re-referenced old blob keeps grace protection', async () => {
+        const h = await storeImage({ blob: jpeg([4, 5]), mime: 'image/jpeg', w: 1, h: 1 });
+        // Backdate it well beyond the grace window (simulates a long-lived blob).
+        const img = await getImage(h);
+        await IndexedDBService.set('note_images', h, { ...img!, createdAt: 0 });
+        // Re-add the identical bytes (e.g. paste the same screenshot again) — dedup hit.
+        await storeImage({ blob: jpeg([4, 5]), mime: 'image/jpeg', w: 1, h: 1 });
+        const refreshed = await getImage(h);
+        expect(refreshed!.createdAt).toBeGreaterThan(0);
+        // It must now survive a sweep even while momentarily unreferenced.
+        const deleted = await sweepOrphans(new Set(), Date.now());
+        expect(deleted).toBe(0);
+        expect(await getImage(h)).toBeDefined();
+    });
+
     it('sweepOrphans deletes unreferenced blobs older than the grace window', async () => {
         const keep = await storeImage({ blob: jpeg([7]), mime: 'image/jpeg', w: 1, h: 1 });
         const drop = await storeImage({ blob: jpeg([8]), mime: 'image/jpeg', w: 1, h: 1 });

--- a/src/services/notes/noteImageStore.ts
+++ b/src/services/notes/noteImageStore.ts
@@ -9,7 +9,13 @@ export const GC_GRACE_MS = 60_000;
 export async function storeImage(img: { blob: Blob; mime: string; w: number; h: number }): Promise<string> {
     const hash = await hashBytes(await img.blob.arrayBuffer());
     const existing = await IndexedDBService.get('note_images', hash);
-    if (existing) return hash; // dedup — identical bytes already stored
+    if (existing) {
+        // Dedup — identical bytes already stored. Refresh createdAt so re-adding a
+        // long-lived blob restarts its grace window; otherwise an old (>grace)
+        // re-referenced image can be swept while its new note save is still in flight.
+        await IndexedDBService.set('note_images', hash, { ...existing, createdAt: Date.now() });
+        return hash;
+    }
     const record: NoteImage = { hash, blob: img.blob, mime: img.mime, w: img.w, h: img.h, createdAt: Date.now() };
     await IndexedDBService.set('note_images', hash, record);
     return hash;

--- a/src/store/slices/createNotesSlice.ts
+++ b/src/store/slices/createNotesSlice.ts
@@ -48,8 +48,19 @@ export const createNotesSlice: AppSlice<NotesSlice> = (set, get) => {
                 detail: { courseCode, fileLink, hasNote: !!value.trim() }
             }));
             // Reclaim image blobs no note references any more (grace-period guarded).
+            // Include not-yet-persisted edits (live Zustand + debounced saves) so the
+            // sweep can't delete an image a card already references but whose note
+            // write hasn't landed in IDB yet.
             void IndexedDBService.getAllWithKeys('document_notes')
-                .then((entries) => sweepOrphans(collectReferencedImages(entries.map((e) => ({ note: e.value.note ?? '' }))), Date.now()))
+                .then((entries) => {
+                    const inFlight = [...Object.values(get().documentNotes), ...Object.values(pendingSaves)]
+                        .map((note) => ({ note: note ?? '' }));
+                    const referenced = collectReferencedImages([
+                        ...entries.map((e) => ({ note: e.value.note ?? '' })),
+                        ...inFlight,
+                    ]);
+                    return sweepOrphans(referenced, Date.now());
+                })
                 .catch((e) => logError('Notes.imageGc', e));
             // Render this subject's HTML (base64-inlined when it has images) and
             // CACHE it in the content script BEFORE the snapshot below triggers the


### PR DESCRIPTION
Fixes the HIGH-severity data-loss / concurrency races surfaced by a focused audit of the notes-image, Drive-backup, and ISKAM-handshake subsystems. Each fix is root-caused and lands with a failing-first test.

## Notes & images (commit 1)
- **Stale-card clobber** — `NoteCard` built the `images` patch from a *captured* `card.images` before the async encode finished, so two near-simultaneous paste/drop gestures silently dropped an image. `onChange`/`updateCard` now accept an updater fn; `images` derives from the live card inside `setData`.
- **Text-only backup poisoned image upload** — the Drive skip key (`docHash`) is identical whether or not the upload inlined images, so a text-only fallback recorded "done" and the image upload was skipped forever. Now records `imagesEmbedded` and only skips when there are no image refs *or* images were already embedded.
- **GC of deduped blob** — `storeImage` dedup returned the old hash without refreshing `createdAt`, losing grace-window protection for a re-pasted image. Now touches `createdAt` on dedup.
- **GC of in-flight reference** — the orphan sweep's referenced set came only from *persisted* notes; debounced/unsaved references were invisible. Now unions live Zustand `documentNotes` + `pendingSaves`.

## Drive backup + ISKAM handshake (commit 2)
- **Cross-tab backup lock** (previously flagged in CLAUDE.md) — `acquireBackupLock` was a non-atomic get-then-set (no CAS) so two tabs could both win, and `releaseBackupLock` removed the key with no ownership check (a finishing pass could delete another tab's live lock). Replaced with a token-based lock: write a unique token, settle, read back, win only if the token survived; release only if we still own it (tolerates a legacy numeric lock).
- **ISKAM reload stuck on stale cache** — `ISKAM_READY` only flushed the queue, so a reloaded iframe (queue already drained) was never re-seeded. Now re-sends current `cachedIskamData`/`isSyncingIskam` after flush, mirroring the IS-side `REIS_READY` handler.

Verified the audit's IS-side reset recommendation was unnecessary: `injectAndInitialize` guards re-injection by element existence and IS Mendelu is multi-page (fresh content script per nav), so the existing IS guarantee re-send already covers reloads.

## Verification
- New failing-first tests: `noteImageStore` dedup-refresh, `driveNotesBackup` text-only-then-override re-upload, `driveManifest` lock (read-back loser + foreign-release), `iskamMessageHandler` ISKAM_READY re-seed.
- Full suite: **550 passed / 3 skipped**. `npm run build` clean. Typecheck: only the 3 pre-existing baseline errors in untouched Erasmus/Exam files.

## Not included (follow-up)
Three sync-core findings remain — torn multi-store IDB writes, out-of-order `REIS_SYNC_UPDATE`, and `cachedData` single-flight. They touch the brittle hydration path and a new transactional primitive, so they're deferred to a separate scoped pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image handling in Drive backups to ensure images are properly synchronized when added later
  * Enhanced concurrent note editing to prevent accidental data loss from stale updates
  * Strengthened cross-device backup locking to prevent synchronization conflicts
  * Improved image storage to preserve referenced images during cleanup operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->