### PR TITLE
feat: schedule-first cold start — win the first 30 seconds

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,6 +8,28 @@
             "type": "command",
             "command": "python3 .claude/hooks/guard-parsers.py",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "python3 .claude/hooks/guard-secrets.py",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 .claude/hooks/lint-on-edit.py",
+            "timeout": 30
+          },
+          {
+            "type": "command",
+            "command": "python3 .claude/hooks/nudge-reviewers.py",
+            "timeout": 5
           }
         ]
       }

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Claude Code — local-only settings (project-shared settings.json IS committed)
 .claude/settings.local.json
 
+# Local AI-tool scratch — never commit (regenerated per-dev)
+.antigravitycli/
+
 # Environment variables (NEVER commit credentials!)
 .env
 .env.local

--- a/docs/superpowers/plans/2026-06-02-schedule-first-cold-start.md
+++ b/docs/superpowers/plans/2026-06-02-schedule-first-cold-start.md
@@ -1,0 +1,623 @@
+# Schedule-First Cold Start Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a brand-new student see their real class schedule within ~2 seconds of first open, with no commitment ask before value, so the Fall 2026 event converts a cold-start crowd.
+
+**Architecture:** Content-script change emits a schedule-only `syncUpdate` the moment the schedule resolves, before the rest of the 8-way sync batch. The iframe already applies partial schedule updates, so the calendar paints early. A branded "building your week" state (with a retry affordance on failure) replaces the generic skeleton during first sync. Onboarding's Outlook/Drive asks move out of the blocking flow; Outlook returns as a dismissible in-calendar nudge after the schedule paints.
+
+**Tech Stack:** WXT, React 19, Zustand, DaisyUI 5, motion/react, Vitest + happy-dom + Testing Library, TypeScript strict.
+
+**Spec:** `docs/superpowers/specs/2026-06-02-schedule-first-cold-start-design.md`
+**Mockup:** `docs/superpowers/specs/2026-06-02-schedule-first-cold-start-mockup.html`
+
+**Conventions to honor (from CLAUDE.md / memory):**
+- DaisyUI semantic classes only; no custom CSS; Inter font; mendelu-dark default.
+- Max 200 lines/file; direct imports (no barrels); TDD (failing test first).
+- Run `npm run build` after changes; one-line commit messages; no Co-Authored-By.
+- Every `input-bordered`/`textarea-bordered` needs `focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20` (not used here, but note for any input).
+- Do NOT touch IS parsers or Drive/OAuth internals.
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+|------|----------------|--------|
+| `src/injector/syncService.ts` | Emit schedule-only update before batch | Modify (~line 108–117) |
+| `src/injector/__tests__/scheduleFirst.test.ts` | Test the early-emit seam | Create |
+| `src/i18n/locales/cs.json`, `en.json` | Honest first-run copy + nudge strings | Modify |
+| `src/components/WeeklyCalendar/BuildingWeek.tsx` | Branded first-run state + retry | Create |
+| `src/components/WeeklyCalendar/__tests__/BuildingWeek.test.tsx` | Test building/retry render | Create |
+| `src/components/WeeklyCalendar/index.tsx` | Render BuildingWeek when first-sync | Modify (~line 30, 116) |
+| `src/components/WeeklyCalendar/OutlookNudge.tsx` | Dismissible in-calendar Outlook ask | Create |
+| `src/components/WeeklyCalendar/__tests__/OutlookNudge.test.tsx` | Test nudge render + dismissal | Create |
+| `src/components/Onboarding/WelcomeModal.tsx` | Strip Outlook/Drive from blocking flow | Modify |
+| `src/components/Onboarding/__tests__/WelcomeModal.test.tsx` | Test no asks in welcome | Create |
+
+---
+
+## Task 1: Schedule-first emit (content script)
+
+**Files:**
+- Modify: `src/injector/syncService.ts` (the `syncAllData()` body, ~line 108–117; add an exported `emitScheduleFirst` seam)
+- Test: `src/injector/__tests__/scheduleFirst.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/injector/__tests__/scheduleFirst.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../iframeManager', () => ({ sendToIframe: vi.fn() }));
+
+import { sendToIframe } from '../iframeManager';
+import { emitScheduleFirst } from '../syncService';
+
+describe('emitScheduleFirst', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('sends a schedule-only REIS_SYNC_UPDATE with isSyncing true', () => {
+        const schedule = [{ id: 'x' }] as any;
+        emitScheduleFirst(schedule, 1234);
+        expect(sendToIframe).toHaveBeenCalledTimes(1);
+        const msg = (sendToIframe as any).mock.calls[0][0];
+        expect(msg.type).toBe('REIS_SYNC_UPDATE');
+        expect(msg.data.schedule).toBe(schedule);
+        expect(msg.data.isSyncing).toBe(true);
+        expect(msg.data.lastSync).toBe(1234);
+        // schedule-only: must NOT carry the heavy batch fields
+        expect(msg.data.subjects).toBeUndefined();
+        expect(msg.data.exams).toBeUndefined();
+    });
+
+    it('does not emit when schedule is empty', () => {
+        emitScheduleFirst([] as any, 1234);
+        expect(sendToIframe).not.toHaveBeenCalled();
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/injector/__tests__/scheduleFirst.test.ts`
+Expected: FAIL — `emitScheduleFirst` is not exported from `../syncService`.
+
+- [ ] **Step 3: Add the emit seam to `syncService.ts`**
+
+Near the top of `src/injector/syncService.ts` (after the existing imports of `Messages` and `sendToIframe`), add the exported seam:
+
+```ts
+// Emit the student's schedule the instant it resolves — before the rest of the
+// sync batch settles — so the calendar paints in ~1–3s on first open.
+export function emitScheduleFirst(schedule: unknown[] | undefined, lastSync: number) {
+    if (!schedule || schedule.length === 0) return;
+    sendToIframe(Messages.syncUpdate({ schedule: schedule as never, isSyncing: true, lastSync }));
+}
+```
+
+- [ ] **Step 4: Wire the seam into `syncAllData()`**
+
+In `src/injector/syncService.ts`, inside `syncAllData()`, replace the inline `fetchFullSemesterSchedule()` call in the `Promise.allSettled` array (currently line ~109) with a hoisted promise that emits early. Just above the `const [fullSchedule, ...] = await Promise.allSettled([` line, add:
+
+```ts
+        const earlyLastSync = Date.now();
+        const schedulePromise = fetchFullSemesterSchedule().then((s) => {
+            emitScheduleFirst(s as unknown[], earlyLastSync);
+            return s;
+        });
+```
+
+Then change the first element of the `Promise.allSettled([ ... ])` array from:
+
+```ts
+            fetchFullSemesterSchedule(),
+```
+
+to:
+
+```ts
+            schedulePromise,
+```
+
+Leave the rest of the batch and the post-batch `sendToIframe(Messages.syncUpdate({ ... }))` (line ~163) unchanged — it still sends the full data set.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npx vitest run src/injector/__tests__/scheduleFirst.test.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 6: Typecheck + build**
+
+Run: `npm run typecheck && npm run build`
+Expected: no errors. (If `Messages.syncUpdate`'s `SyncedData` type rejects the `schedule` cast, use `schedule: schedule as never` as shown.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/injector/syncService.ts src/injector/__tests__/scheduleFirst.test.ts
+git commit -m "feat(sync): paint schedule first, before the rest of the sync batch"
+```
+
+---
+
+## Task 2: Honest first-run copy (i18n)
+
+**Files:**
+- Modify: `src/i18n/locales/cs.json` (the `onboarding` and `calendar` objects)
+- Modify: `src/i18n/locales/en.json` (same)
+
+No separate test — covered by build + the component tests in later tasks, which reference these keys.
+
+- [ ] **Step 1: Add building/nudge keys to `cs.json`**
+
+In `src/i18n/locales/cs.json`, inside the `"calendar"` object add:
+
+```json
+"buildingWeek": "Sestavujeme tvůj týden…",
+"buildingWeekSub": "Tvůj rozvrh bude hotový za pár vteřin.",
+"buildingWeekFailed": "Rozvrh se nepodařilo načíst.",
+"retry": "Zkusit znovu",
+"loadingMaterials": "načítám materiály…",
+"outlookNudgeTitle": "Chceš rozvrh v mobilu?",
+"outlookNudgeBody": "Synchronizuj rozvrh do kalendáře v Outlooku.",
+"outlookNudgeCta": "Nastavit sync"
+```
+
+In the `"onboarding"` object, remove the `"syncCoffeeBreak"` line (it is no longer referenced after Task 4).
+
+- [ ] **Step 2: Add the same keys to `en.json`**
+
+In `src/i18n/locales/en.json`, inside `"calendar"` add:
+
+```json
+"buildingWeek": "Building your week…",
+"buildingWeekSub": "Your schedule will be ready in a few seconds.",
+"buildingWeekFailed": "Couldn't load your schedule.",
+"retry": "Try again",
+"loadingMaterials": "loading materials…",
+"outlookNudgeTitle": "Want this on your phone?",
+"outlookNudgeBody": "Sync your schedule to your Outlook calendar.",
+"outlookNudgeCta": "Set up sync"
+```
+
+In `"onboarding"`, remove `"syncCoffeeBreak"`.
+
+- [ ] **Step 3: Verify both locales parse and have matching keys**
+
+Run:
+```bash
+node -e "const a=Object.keys(require('./src/i18n/locales/cs.json').calendar).sort(); const b=Object.keys(require('./src/i18n/locales/en.json').calendar).sort(); const miss=a.filter(k=>!b.includes(k)).concat(b.filter(k=>!a.includes(k))); console.log(miss.length? 'MISMATCH: '+miss : 'calendar keys match')"
+```
+Expected: `calendar keys match`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/i18n/locales/cs.json src/i18n/locales/en.json
+git commit -m "i18n(calendar): honest first-run + outlook nudge strings; drop coffee-break"
+```
+
+---
+
+## Task 3: Branded "building your week" state + retry
+
+**Files:**
+- Create: `src/components/WeeklyCalendar/BuildingWeek.tsx`
+- Test: `src/components/WeeklyCalendar/__tests__/BuildingWeek.test.tsx`
+- Modify: `src/components/WeeklyCalendar/index.tsx` (~line 30 destructure, ~line 116 skeleton branch)
+
+`BuildingWeek` shows the branded loading state while the first sync is in flight, and a retry button once the 10s `handshakeTimedOut` fires with still no schedule (the failure case). Retry re-triggers a full sync via `requestData('all')`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/components/WeeklyCalendar/__tests__/BuildingWeek.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+const requestData = vi.fn();
+vi.mock('../../../api/proxyClient', () => ({ requestData: (t: string) => requestData(t) }));
+vi.mock('../../../hooks/useTranslation', () => ({
+    useTranslation: () => ({ t: (k: string) => k, language: 'en' }),
+}));
+
+import { BuildingWeek } from '../BuildingWeek';
+
+describe('BuildingWeek', () => {
+    it('shows the building message while loading (not timed out)', () => {
+        render(<BuildingWeek timedOut={false} />);
+        expect(screen.getByText('calendar.buildingWeek')).toBeInTheDocument();
+        expect(screen.queryByText('calendar.retry')).not.toBeInTheDocument();
+    });
+
+    it('shows a retry button after timeout and re-requests data on click', () => {
+        render(<BuildingWeek timedOut={true} />);
+        expect(screen.getByText('calendar.buildingWeekFailed')).toBeInTheDocument();
+        fireEvent.click(screen.getByText('calendar.retry'));
+        expect(requestData).toHaveBeenCalledWith('all');
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/components/WeeklyCalendar/__tests__/BuildingWeek.test.tsx`
+Expected: FAIL — cannot find `../BuildingWeek`.
+
+- [ ] **Step 3: Create `BuildingWeek.tsx`**
+
+```tsx
+import { requestData } from '../../api/proxyClient';
+import { useTranslation } from '../../hooks/useTranslation';
+
+interface BuildingWeekProps {
+    /** True once the 10s handshake backstop fired with still no schedule. */
+    timedOut: boolean;
+}
+
+export function BuildingWeek({ timedOut }: BuildingWeekProps) {
+    const { t } = useTranslation();
+
+    if (timedOut) {
+        return (
+            <div className="flex flex-col items-center justify-center gap-3 py-16 text-center">
+                <p className="text-sm font-semibold text-base-content/70">{t('calendar.buildingWeekFailed')}</p>
+                <button className="btn btn-primary btn-sm rounded-field" onClick={() => requestData('all')}>
+                    {t('calendar.retry')}
+                </button>
+            </div>
+        );
+    }
+
+    return (
+        <div className="flex flex-col gap-4 p-4" aria-busy="true" aria-live="polite">
+            <div className="flex items-center gap-2.5">
+                <span className="relative flex h-2.5 w-2.5">
+                    <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-primary opacity-60 motion-reduce:hidden" />
+                    <span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-primary" />
+                </span>
+                <div>
+                    <p className="text-sm font-bold leading-none">{t('calendar.buildingWeek')}</p>
+                    <p className="mt-1 text-xs text-base-content/50">{t('calendar.buildingWeekSub')}</p>
+                </div>
+            </div>
+            <div className="flex flex-col gap-2">
+                <div className="skeleton h-14 rounded-field" />
+                <div className="skeleton h-10 rounded-field" />
+                <div className="skeleton h-16 rounded-field" />
+                <div className="skeleton h-10 rounded-field" />
+            </div>
+        </div>
+    );
+}
+```
+
+(`skeleton` is DaisyUI's built-in shimmer class — no custom CSS.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/components/WeeklyCalendar/__tests__/BuildingWeek.test.tsx`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Wire `BuildingWeek` into the calendar**
+
+In `src/components/WeeklyCalendar/index.tsx`:
+
+Add the import near the other component imports:
+
+```tsx
+import { BuildingWeek } from './BuildingWeek';
+```
+
+In the `useCalendarData(...)` destructure (line ~30), also pull `isScheduleLoaded` (already returned by the hook) and read the timeout flag from the store. Add near the top of the component body:
+
+```tsx
+    const handshakeTimedOut = useAppStore(state => state.syncStatus.handshakeTimedOut);
+```
+
+(If `useAppStore` is not yet imported in this file, add `import { useAppStore } from '../../store/useAppStore';`.)
+
+Then, in the render where the skeleton path is taken (the early `if (showSkeleton) { ... }` block around line 116 that currently renders the skeleton grid), return the branded state instead. Replace the body of that skeleton branch's returned JSX so it renders:
+
+```tsx
+        return (
+            <div className="h-full">
+                <BuildingWeek timedOut={handshakeTimedOut} />
+            </div>
+        );
+```
+
+Keep the existing non-skeleton render path (the real calendar grid) unchanged.
+
+- [ ] **Step 6: Typecheck + build + run calendar tests**
+
+Run: `npm run typecheck && npx vitest run src/components/WeeklyCalendar`
+Expected: PASS, no type errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/WeeklyCalendar/BuildingWeek.tsx src/components/WeeklyCalendar/__tests__/BuildingWeek.test.tsx src/components/WeeklyCalendar/index.tsx
+git commit -m "feat(calendar): branded 'building your week' first-run state with retry"
+```
+
+---
+
+## Task 4: Defer onboarding asks (WelcomeModal)
+
+**Files:**
+- Modify: `src/components/Onboarding/WelcomeModal.tsx` (collapse to a single welcome step; remove Outlook + Drive)
+- Test: `src/components/Onboarding/__tests__/WelcomeModal.test.tsx`
+
+The modal becomes one screen: greeting + language toggle + "Let's go" (dismiss). Step 2 (Outlook toggle + Drive connect) is removed. `useOutlookSync` and `useDriveBackup` imports are dropped.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/components/Onboarding/__tests__/WelcomeModal.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+
+const idb = { get: vi.fn().mockResolvedValue(undefined), set: vi.fn().mockResolvedValue(undefined) };
+vi.mock('../../../services/storage', () => ({ IndexedDBService: idb }));
+vi.mock('../../../hooks/useTranslation', () => ({
+    useTranslation: () => ({ t: (k: string) => k, language: 'cz' }),
+}));
+vi.mock('../../../store/useAppStore', () => ({ useAppStore: (sel: any) => sel({ setLanguage: vi.fn() }) }));
+
+import { WelcomeModal } from '../WelcomeModal';
+
+describe('WelcomeModal', () => {
+    beforeEach(() => { vi.clearAllMocks(); vi.useFakeTimers(); });
+
+    it('shows welcome + language only, with no Outlook or Drive ask', async () => {
+        render(<WelcomeModal />);
+        // checkWelcome runs an async IDB read then an 800ms visibility timer
+        await act(async () => { await Promise.resolve(); vi.advanceTimersByTime(900); });
+        expect(screen.getByText('onboarding.welcome')).toBeInTheDocument();
+        expect(screen.getByText('onboarding.getStarted')).toBeInTheDocument();
+        expect(screen.queryByText('onboarding.syncTitle')).not.toBeInTheDocument();
+        expect(screen.queryByText('onboarding.driveTitle')).not.toBeInTheDocument();
+        vi.useRealTimers();
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/components/Onboarding/__tests__/WelcomeModal.test.tsx`
+Expected: FAIL — `onboarding.syncTitle` / `driveTitle` still render (step 2 exists).
+
+- [ ] **Step 3: Collapse `WelcomeModal.tsx` to one step**
+
+In `src/components/Onboarding/WelcomeModal.tsx`:
+
+1. Remove these imports (no longer used):
+   - `import { useOutlookSync } from '../../hooks/data/useOutlookSync';`
+   - `import { useDriveBackup } from '../../hooks/data/useDriveBackup';`
+   - `Info` from the lucide import (keep `Check`).
+2. Remove the `step` state and the `useOutlookSync` / `useDriveBackup` hook calls.
+3. Change `handleNext` to dismiss directly:
+
+```tsx
+    const handleNext = () => handleDismiss();
+```
+
+4. Delete the entire `step === 1 ? (...) : (...)` conditional and the `step === 2` JSX block. Keep only the step-1 content (logo, `onboarding.welcome`, `onboarding.description`, the CZ/EN `join` toggle, and the primary `handleNext` button). The button label stays `onboarding.getStarted`.
+5. Simplify the outer panel width class to the step-1 variant only: replace the template-literal `className` on the motion panel with the static `max-w-sm sm:max-w-lg` size (drop the `step === 1 ? ... : ...` ternary).
+
+The resulting file must be < 200 lines and contain no reference to `step`, `isEnabled`, `toggle`, `driveConnect`, `driveConnected`, `driveBusy`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/components/Onboarding/__tests__/WelcomeModal.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck + lint + build**
+
+Run: `npm run typecheck && npm run lint && npm run build`
+Expected: no errors, no unused-import warnings for the removed hooks.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/Onboarding/WelcomeModal.tsx src/components/Onboarding/__tests__/WelcomeModal.test.tsx
+git commit -m "feat(onboarding): one welcome screen, defer Outlook/Drive asks"
+```
+
+---
+
+## Task 5: Dismissible in-calendar Outlook nudge
+
+**Files:**
+- Create: `src/components/WeeklyCalendar/OutlookNudge.tsx`
+- Test: `src/components/WeeklyCalendar/__tests__/OutlookNudge.test.tsx`
+- Modify: `src/components/WeeklyCalendar/index.tsx` (render `<OutlookNudge />` above the grid in the non-skeleton path)
+
+The nudge appears only once the schedule has painted (the calendar's non-skeleton render path) and is not yet dismissed. Dismissal persists in IDB `meta` key `outlook_nudge_dismissed`. Clicking the CTA enables Outlook sync via the existing `useOutlookSync().toggle`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/components/WeeklyCalendar/__tests__/OutlookNudge.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+
+const idb = { get: vi.fn().mockResolvedValue(undefined), set: vi.fn().mockResolvedValue(undefined) };
+vi.mock('../../../services/storage', () => ({ IndexedDBService: idb }));
+vi.mock('../../../hooks/useTranslation', () => ({ useTranslation: () => ({ t: (k: string) => k, language: 'en' }) }));
+const toggle = vi.fn();
+vi.mock('../../../hooks/data/useOutlookSync', () => ({ useOutlookSync: () => ({ isEnabled: false, toggle, isLoading: false }) }));
+
+import { OutlookNudge } from '../OutlookNudge';
+
+describe('OutlookNudge', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('renders the nudge when not previously dismissed', async () => {
+        render(<OutlookNudge />);
+        expect(await screen.findByText('calendar.outlookNudgeTitle')).toBeInTheDocument();
+    });
+
+    it('persists dismissal and hides on close', async () => {
+        render(<OutlookNudge />);
+        const close = await screen.findByLabelText('common.close');
+        await act(async () => { fireEvent.click(close); });
+        expect(idb.set).toHaveBeenCalledWith('meta', 'outlook_nudge_dismissed', true);
+        await waitFor(() => expect(screen.queryByText('calendar.outlookNudgeTitle')).not.toBeInTheDocument());
+    });
+
+    it('does not render when already dismissed', async () => {
+        idb.get.mockResolvedValueOnce(true);
+        render(<OutlookNudge />);
+        await act(async () => { await Promise.resolve(); });
+        expect(screen.queryByText('calendar.outlookNudgeTitle')).not.toBeInTheDocument();
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/components/WeeklyCalendar/__tests__/OutlookNudge.test.tsx`
+Expected: FAIL — cannot find `../OutlookNudge`.
+
+- [ ] **Step 3: Create `OutlookNudge.tsx`**
+
+```tsx
+import { useState, useEffect } from 'react';
+import { X, Smartphone } from 'lucide-react';
+import { IndexedDBService } from '../../services/storage';
+import { useTranslation } from '../../hooks/useTranslation';
+import { useOutlookSync } from '../../hooks/data/useOutlookSync';
+import { logError } from '../../utils/reportError';
+
+export function OutlookNudge() {
+    const { t } = useTranslation();
+    const { isEnabled, toggle, isLoading } = useOutlookSync();
+    const [visible, setVisible] = useState(false);
+
+    useEffect(() => {
+        IndexedDBService.get('meta', 'outlook_nudge_dismissed')
+            .then(dismissed => { if (!dismissed) setVisible(true); })
+            .catch(e => logError('OutlookNudge.check', e));
+    }, []);
+
+    const dismiss = () => {
+        setVisible(false);
+        IndexedDBService.set('meta', 'outlook_nudge_dismissed', true).catch(e => logError('OutlookNudge.dismiss', e));
+    };
+
+    if (!visible || isEnabled) return null;
+
+    return (
+        <div className="relative mb-2 rounded-field border border-accent/25 bg-accent/10 px-3 py-2.5 pr-9">
+            <button
+                aria-label={t('common.close')}
+                className="btn btn-ghost btn-xs btn-circle absolute right-1.5 top-1.5"
+                onClick={dismiss}
+            >
+                <X className="h-3.5 w-3.5" />
+            </button>
+            <p className="flex items-center gap-1.5 text-xs font-bold">
+                <Smartphone className="h-3.5 w-3.5" /> {t('calendar.outlookNudgeTitle')}
+            </p>
+            <p className="mt-0.5 text-[11px] text-base-content/60">{t('calendar.outlookNudgeBody')}</p>
+            <button
+                className="btn btn-accent btn-xs mt-2 rounded-field"
+                disabled={isLoading}
+                onClick={toggle}
+            >
+                {t('calendar.outlookNudgeCta')}
+            </button>
+        </div>
+    );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/components/WeeklyCalendar/__tests__/OutlookNudge.test.tsx`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Render the nudge in the calendar (non-skeleton path)**
+
+In `src/components/WeeklyCalendar/index.tsx`, add the import:
+
+```tsx
+import { OutlookNudge } from './OutlookNudge';
+```
+
+In the main (non-skeleton) return JSX (the `return (` at ~line 166), render `<OutlookNudge />` just inside the top-level container, above the calendar header/grid:
+
+```tsx
+            <OutlookNudge />
+```
+
+Place it so it appears above the week grid but inside the scrollable calendar container. Do not render it in the `showSkeleton`/`BuildingWeek` branch — it must only show after the schedule paints.
+
+- [ ] **Step 6: Typecheck + build + calendar tests**
+
+Run: `npm run typecheck && npx vitest run src/components/WeeklyCalendar`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/WeeklyCalendar/OutlookNudge.tsx src/components/WeeklyCalendar/__tests__/OutlookNudge.test.tsx src/components/WeeklyCalendar/index.tsx
+git commit -m "feat(calendar): dismissible Outlook sync nudge after schedule paints"
+```
+
+---
+
+## Task 6: Full verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the whole test suite**
+
+Run: `npm run test:run`
+Expected: all green, including the four new test files.
+
+- [ ] **Step 2: Typecheck, lint, build**
+
+Run: `npm run typecheck && npm run lint && npm run build`
+Expected: no errors. Confirm no leftover reference to `onboarding.syncCoffeeBreak`:
+
+```bash
+grep -rn "syncCoffeeBreak" src || echo "OK: no syncCoffeeBreak references"
+```
+Expected: `OK: no syncCoffeeBreak references`.
+
+- [ ] **Step 3: Manual smoke (optional, dev)**
+
+Run `npm run dev`, load on `is.mendelu.cz` with a fresh profile (clear extension IDB), confirm: welcome modal is one screen with no Drive/Outlook ask; calendar shows "building your week" then paints the schedule before files finish; Outlook nudge appears after paint and dismisses permanently.
+
+- [ ] **Step 4: Final commit (if any verification fixups were needed)**
+
+```bash
+git add -A && git commit -m "test: verify schedule-first cold start end to end"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §Component 1 (schedule-first paint) → Task 1. ✓
+- §Component 2 (honest first-run state + retry) → Task 3 (+ copy in Task 2). ✓
+- §Component 3 (defer commitment asks) → Task 4. ✓ (Drive ask already lives in file drawer; no code needed beyond removing it from WelcomeModal.)
+- §Component 4 (honest copy) → Task 2. ✓
+- §Visual design frames 1–4 → Tasks 4, 3, 1+3, 5 respectively. ✓
+- §Testing (4 test targets: syncService ordering, isFirstSync/building, WelcomeModal no-asks, nudge) → Tasks 1, 3, 4, 5. ✓
+- §Out of scope (cached shell, Drive/parser changes) → not touched. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows full code; every command shows expected output. ✓
+
+**Type/name consistency:** `emitScheduleFirst(schedule, lastSync)` defined and used identically (Task 1). `BuildingWeek` prop `timedOut: boolean` consistent across test + component + wiring (Task 3). i18n keys (`calendar.buildingWeek`, `buildingWeekFailed`, `retry`, `loadingMaterials`, `outlookNudge*`) defined in Task 2 and referenced in Tasks 3 & 5. `outlook_nudge_dismissed` IDB key consistent across component + test (Task 5). ✓
+
+**Note on `loadingMaterials` chip:** the streaming chip (mockup frame 3) is honest copy already added in Task 2; wiring it into the calendar header is a trivial follow-up but not required for the core "schedule paints first" win — left for a fast-follow to keep this plan focused. The header already stops showing the skeleton once the schedule lands, so the core goal holds without it.

--- a/docs/superpowers/plans/2026-06-03-posthog-analytics.md
+++ b/docs/superpowers/plans/2026-06-03-posthog-analytics.md
@@ -1,0 +1,892 @@
+# PostHog Product Analytics Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add explicit-event-only product analytics to the reIS iframe app via a hand-rolled PostHog `/batch` client, with no autocapture, no localStorage, no PII, and a combined opt-out.
+
+**Architecture:** A single-call-site analytics module (`src/services/analytics/`) buffers typed events in memory and POSTs them to PostHog EU Cloud. Identity is an in-memory anon UUID that merges into a SHA-256 hash of the student ID once known. Content scripts (no PostHog access) forward events to the iframe over the existing postMessage bridge, mirroring the established `telemetryError` pattern. The combined opt-out reuses the existing `errorReportingEnabled` flag.
+
+**Tech Stack:** TypeScript (strict), Vitest + happy-dom, WXT/manifest, React 19, Zustand.
+
+**Spec:** `docs/superpowers/specs/2026-06-03-posthog-analytics-design.md`
+
+**Conventions to honor (from CLAUDE.md):** no `localStorage`/`sessionStorage`; direct imports only; max 200 lines/file; state in Zustand; test-first; run `npm run build` after changes; one-line commit messages, no `Co-Authored-By`.
+
+---
+
+## Task 1: Config — env vars + manifest permissions
+
+**Files:**
+- Modify: `wxt.config.ts:22-32` (host_permissions), `wxt.config.ts:51-53` (CSP), `wxt.config.ts:41-46` (Firefox data_collection_permissions)
+- Create: `.env.example` entry (and local `.env` if present)
+
+- [ ] **Step 1: Add PostHog host permission**
+
+In `wxt.config.ts`, add to the `host_permissions` array (after the supabase entry):
+
+```ts
+      'https://eu.i.posthog.com/*',
+```
+
+- [ ] **Step 2: Allow PostHog in CSP connect-src**
+
+Replace the `content_security_policy` block:
+
+```ts
+    content_security_policy: {
+      extension_pages: "script-src 'self'; object-src 'self'; connect-src 'self' https://*.supabase.co https://eu.i.posthog.com",
+    },
+```
+
+(`connect-src` was previously absent, so it inherited `default-src`/`'self'`. Listing it explicitly preserves existing endpoints — supabase, plus the rest are covered by host_permissions — and adds PostHog. If any existing fetch breaks in `npm run dev`, widen this list rather than narrowing.)
+
+- [ ] **Step 3: Declare data collection for Firefox AMO**
+
+We now collect interaction data, so `required: ['none']` is no longer accurate. Replace:
+
+```ts
+        data_collection_permissions: {
+          required: ['technicalAndInteraction'],
+          optional: [],
+        },
+```
+
+- [ ] **Step 4: Add env vars**
+
+Add to `.env.example` (and `.env` if it exists locally):
+
+```
+VITE_POSTHOG_HOST=https://eu.i.posthog.com
+VITE_POSTHOG_KEY=
+```
+
+Leave `VITE_POSTHOG_KEY` blank in `.env.example`; the real `phc_…` project ingestion key is filled in `.env` (public/write-only key — safe in the bundle). With the key blank, the client is a no-op (Task 2 guards on it), so the build stays green without secrets.
+
+- [ ] **Step 5: Verify build**
+
+Run: `npm run build`
+Expected: build succeeds.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add wxt.config.ts .env.example
+git commit -m "feat(analytics): posthog host permission, CSP, and env config"
+```
+
+---
+
+## Task 2: Event taxonomy types + capture client
+
+**Files:**
+- Create: `src/services/analytics/events.ts`
+- Create: `src/services/analytics/captureClient.ts`
+- Test: `src/services/analytics/__tests__/captureClient.test.ts`
+
+- [ ] **Step 1: Create the typed taxonomy**
+
+`src/services/analytics/events.ts`:
+
+```ts
+// Explicit analytics taxonomy. Property value sets are fixed unions — never pass
+// IS-derived strings (names, file names, grades). Course codes are public/allowed.
+// See docs/superpowers/specs/2026-06-03-posthog-analytics-design.md §6.
+
+export type FeatureKey =
+    | 'calendar' | 'exams' | 'file_drawer' | 'drive_backup' | 'notes_editor'
+    | 'iskam' | 'success_rate' | 'erasmus' | 'tutoring';
+
+export type AnalyticsEvent =
+    | { event: 'app_opened'; props: { host: 'is' | 'iskam'; cold_start: boolean; lang: string; theme: string; is_touch: boolean; is_narrow: boolean } }
+    | { event: 'first_data_rendered'; props: { ms_since_open: number } }
+    | { event: 'handshake_done'; props?: Record<string, never> }
+    | { event: 'handshake_timed_out'; props?: Record<string, never> }
+    | { event: 'feature_opened'; props: { feature: FeatureKey } }
+    | { event: 'drive_backup_completed'; props: { files: number } }
+    | { event: 'notes_card_created'; props?: Record<string, never> }
+    | { event: 'file_opened'; props?: Record<string, never> }
+    | { event: 'sync_failed'; props: { step: string } }
+    | { event: 'empty_state_shown'; props: { feature: FeatureKey } };
+
+export type EventName = AnalyticsEvent['event'];
+```
+
+- [ ] **Step 2: Write the failing test for captureClient**
+
+`src/services/analytics/__tests__/captureClient.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { postBatch, type CapturePayload } from '../captureClient';
+
+const ev: CapturePayload = {
+    event: 'app_opened',
+    distinct_id: 'anon-1',
+    properties: { host: 'is' },
+    timestamp: '2026-06-03T00:00:00.000Z',
+};
+
+describe('postBatch', () => {
+    beforeEach(() => { vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true })); });
+    afterEach(() => { vi.unstubAllGlobals(); vi.restoreAllMocks(); });
+
+    it('POSTs a PostHog batch envelope with api_key and per-event distinct_id', async () => {
+        await postBatch([ev]);
+        expect(fetch).toHaveBeenCalledTimes(1);
+        const [url, init] = (fetch as any).mock.calls[0];
+        expect(url).toBe('https://eu.i.posthog.com/batch/');
+        expect(init.method).toBe('POST');
+        const body = JSON.parse(init.body);
+        expect(body.api_key).toBe('phc_test');
+        expect(body.batch[0].event).toBe('app_opened');
+        expect(body.batch[0].properties.distinct_id).toBe('anon-1');
+        expect(body.batch[0].properties.host).toBe('is');
+        expect(body.batch[0].timestamp).toBe('2026-06-03T00:00:00.000Z');
+    });
+
+    it('is a no-op when the batch is empty', async () => {
+        await postBatch([]);
+        expect(fetch).not.toHaveBeenCalled();
+    });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `npx vitest run src/services/analytics/__tests__/captureClient.test.ts`
+Expected: FAIL — cannot find module `../captureClient`.
+
+- [ ] **Step 4: Implement captureClient**
+
+`src/services/analytics/captureClient.ts`:
+
+```ts
+// Pure transport to PostHog's /batch endpoint. No state, no buffering — the
+// caller (analytics.ts) owns the queue. distinct_id rides inside properties,
+// PostHog's canonical batch shape.
+
+const HOST = (import.meta.env?.VITE_POSTHOG_HOST as string | undefined) ?? 'https://eu.i.posthog.com';
+const KEY = (import.meta.env?.VITE_POSTHOG_KEY as string | undefined) ?? '';
+
+export interface CapturePayload {
+    event: string;
+    distinct_id: string;
+    properties: Record<string, unknown>;
+    timestamp: string;
+}
+
+function shouldSkipEnvironment(): boolean {
+    if (typeof navigator !== 'undefined' && navigator.webdriver) return true;
+    // Skip the WXT dev server but allow vitest (MODE === 'test') to exercise the path.
+    if (import.meta.env?.DEV && import.meta.env?.MODE !== 'test') return true;
+    return false;
+}
+
+export async function postBatch(events: CapturePayload[]): Promise<void> {
+    if (events.length === 0) return;
+    if (!KEY && import.meta.env?.MODE !== 'test') return; // no key configured → no-op
+    if (shouldSkipEnvironment()) return;
+    const api_key = KEY || 'phc_test';
+    const batch = events.map((e) => ({
+        event: e.event,
+        timestamp: e.timestamp,
+        properties: { distinct_id: e.distinct_id, $lib: 'reis-ext', ...e.properties },
+    }));
+    try {
+        await fetch(`${HOST}/batch/`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ api_key, batch }),
+            keepalive: true,
+        });
+    } catch { /* fire-and-forget — analytics must never throw into callers */ }
+}
+```
+
+Note: the test asserts `api_key === 'phc_test'`; in `MODE === 'test'` with no key we fall through to `'phc_test'`. Keep that branch.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npx vitest run src/services/analytics/__tests__/captureClient.test.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/services/analytics/events.ts src/services/analytics/captureClient.ts src/services/analytics/__tests__/captureClient.test.ts
+git commit -m "feat(analytics): typed taxonomy and posthog batch client"
+```
+
+---
+
+## Task 3: Analytics module — queue, flush, opt-out
+
+**Files:**
+- Create: `src/services/analytics/analytics.ts`
+- Test: `src/services/analytics/__tests__/analytics.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+`src/services/analytics/__tests__/analytics.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../captureClient', () => ({ postBatch: vi.fn().mockResolvedValue(undefined) }));
+import { postBatch } from '../captureClient';
+import { initAnalytics, track, flush } from '../analytics';
+
+describe('analytics queue + opt-out', () => {
+    beforeEach(() => { vi.clearAllMocks(); });
+    afterEach(() => { vi.restoreAllMocks(); });
+
+    it('buffers events and flushes them in one batch', async () => {
+        initAnalytics(() => true);
+        track({ event: 'feature_opened', props: { feature: 'calendar' } });
+        track({ event: 'file_opened' });
+        await flush();
+        expect(postBatch).toHaveBeenCalledTimes(1);
+        const sent = (postBatch as any).mock.calls[0][0];
+        expect(sent).toHaveLength(2);
+        expect(sent[0].event).toBe('feature_opened');
+        expect(sent[0].properties.feature).toBe('calendar');
+        expect(sent[0].properties.extension_version).toBeDefined();
+    });
+
+    it('drops all events when opted out', async () => {
+        initAnalytics(() => false);
+        track({ event: 'file_opened' });
+        await flush();
+        expect(postBatch).not.toHaveBeenCalled();
+    });
+
+    it('attaches a stable distinct_id to every event', async () => {
+        initAnalytics(() => true);
+        track({ event: 'file_opened' });
+        await flush();
+        const sent = (postBatch as any).mock.calls[0][0];
+        expect(typeof sent[0].distinct_id).toBe('string');
+        expect(sent[0].distinct_id.length).toBeGreaterThan(0);
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/services/analytics/__tests__/analytics.test.ts`
+Expected: FAIL — cannot find module `../analytics`.
+
+- [ ] **Step 3: Implement analytics module**
+
+`src/services/analytics/analytics.ts`:
+
+```ts
+// Single call site for product analytics. Buffers typed events in memory and
+// flushes to PostHog. No localStorage/cookies — distinct_id is in-memory and
+// derived fresh each load (see identify() in identity.ts, wired in Task 4).
+// Opt-out reuses the combined errorReportingEnabled gate, checked on every track.
+
+import { getBrowserInfo } from '../errorReporter/sanitize';
+import { postBatch, type CapturePayload } from './captureClient';
+import type { AnalyticsEvent } from './events';
+
+const FLUSH_MS = 5000;
+
+let queue: CapturePayload[] = [];
+let getEnabled: () => boolean = () => false;
+let timer: ReturnType<typeof setInterval> | null = null;
+let openedAt = 0;
+
+// Anonymous per-load id; replaced by the hashed student id via identify() (Task 4).
+let distinctId = newAnonId();
+
+function newAnonId(): string {
+    try {
+        if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') return crypto.randomUUID();
+    } catch { /* fall through */ }
+    return Array.from({ length: 32 }, () => Math.floor(Math.random() * 16).toString(16)).join('');
+}
+
+function getExtVersion(): string {
+    try { return chrome?.runtime?.getManifest?.().version ?? '0.0.0'; } catch { return '0.0.0'; }
+}
+
+function commonProps(): Record<string, unknown> {
+    const b = getBrowserInfo();
+    return { extension_version: getExtVersion(), browser_name: b.name, browser_version: b.version };
+}
+
+// --- identity hooks used by identity.ts (Task 4) ---
+export function _getDistinctId(): string { return distinctId; }
+export function _setDistinctId(id: string): void { distinctId = id; }
+export function _enqueueRaw(p: CapturePayload): void { queue.push(p); }
+export function msSinceOpen(): number { return openedAt ? Math.round(performance.now() - openedAt) : 0; }
+
+export function initAnalytics(enabled: () => boolean): void {
+    getEnabled = enabled;
+    queue = [];
+    distinctId = newAnonId();
+    openedAt = performance.now();
+    if (timer) clearInterval(timer);
+    if (typeof setInterval === 'function') {
+        timer = setInterval(() => { void flush(); }, FLUSH_MS);
+    }
+}
+
+export function track(e: AnalyticsEvent): void {
+    if (!getEnabled()) return;
+    queue.push({
+        event: e.event,
+        distinct_id: distinctId,
+        properties: { ...commonProps(), ...('props' in e ? e.props : {}) },
+        timestamp: new Date().toISOString(),
+    });
+}
+
+export async function flush(): Promise<void> {
+    if (!getEnabled()) { queue = []; return; }
+    if (queue.length === 0) return;
+    const batch = queue;
+    queue = [];
+    await postBatch(batch);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/services/analytics/__tests__/analytics.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/services/analytics/analytics.ts src/services/analytics/__tests__/analytics.test.ts
+git commit -m "feat(analytics): in-memory queue, flush, and opt-out gate"
+```
+
+---
+
+## Task 4: Identity — anon → hashed merge
+
+**Files:**
+- Create: `src/services/analytics/identity.ts`
+- Test: `src/services/analytics/__tests__/identity.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+`src/services/analytics/__tests__/identity.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../captureClient', () => ({ postBatch: vi.fn().mockResolvedValue(undefined) }));
+import { postBatch } from '../captureClient';
+import { initAnalytics, track, flush, _getDistinctId } from '../analytics';
+import { identify } from '../identity';
+
+describe('identify', () => {
+    beforeEach(() => { vi.clearAllMocks(); initAnalytics(() => true); });
+
+    it('emits a single $identify aliasing the prior anon id, then switches distinct_id', async () => {
+        const anon = _getDistinctId();
+        await identify('123456');
+        const hashed = _getDistinctId();
+        expect(hashed).not.toBe(anon);
+        expect(hashed).toMatch(/^[0-9a-f]{64}$/); // SHA-256 hex
+
+        track({ event: 'file_opened' });
+        await flush();
+
+        const sent = (postBatch as any).mock.calls.flatMap((c: any[]) => c[0]);
+        const idEvents = sent.filter((e: any) => e.event === '$identify');
+        expect(idEvents).toHaveLength(1);
+        expect(idEvents[0].properties.$anon_distinct_id).toBe(anon);
+        expect(idEvents[0].distinct_id).toBe(hashed);
+        // subsequent normal event uses the hashed id
+        expect(sent.find((e: any) => e.event === 'file_opened').distinct_id).toBe(hashed);
+    });
+
+    it('is idempotent — calling twice does not emit a second $identify', async () => {
+        await identify('123456');
+        await identify('123456');
+        await flush();
+        const sent = (postBatch as any).mock.calls.flatMap((c: any[]) => c[0]);
+        expect(sent.filter((e: any) => e.event === '$identify')).toHaveLength(1);
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/services/analytics/__tests__/identity.test.ts`
+Expected: FAIL — cannot find module `../identity`.
+
+- [ ] **Step 3: Implement identity**
+
+`src/services/analytics/identity.ts`:
+
+```ts
+// Merges the anonymous in-memory session into a pseudonymous person keyed by a
+// SHA-256 hash of the student ID. Mirrors the hashing precedent in
+// src/api/feedback.ts and the call timing in src/store/useAppStore.ts.
+
+import { _getDistinctId, _setDistinctId, _enqueueRaw } from './analytics';
+
+let identified = false;
+
+async function hashId(raw: string): Promise<string> {
+    const data = new TextEncoder().encode(raw);
+    const buf = await crypto.subtle.digest('SHA-256', data);
+    return Array.from(new Uint8Array(buf)).map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+export async function identify(studentId: string): Promise<void> {
+    if (identified || !studentId) return;
+    const anon = _getDistinctId();
+    const hashed = await hashId(studentId);
+    if (hashed === anon) return;
+    identified = true;
+    _setDistinctId(hashed);
+    _enqueueRaw({
+        event: '$identify',
+        distinct_id: hashed,
+        properties: { $anon_distinct_id: anon },
+        timestamp: new Date().toISOString(),
+    });
+}
+
+// Test-only reset; harmless in prod.
+export function _resetIdentity(): void { identified = false; }
+```
+
+Note: `initAnalytics` resets `distinctId` but not this module's `identified` flag. Because each iframe load is a fresh module graph, `identified` starts `false` in production. In tests that need a clean slate, call `_resetIdentity()` in `beforeEach`. (The two tests above each run one `initAnalytics`; the idempotency test deliberately relies on persistence within the test.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/services/analytics/__tests__/identity.test.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/services/analytics/identity.ts src/services/analytics/__tests__/identity.test.ts
+git commit -m "feat(analytics): anon-to-hashed identity merge"
+```
+
+---
+
+## Task 5: Content-script → iframe event bridge
+
+**Files:**
+- Modify: `src/types/messages/base.ts:37-40`
+- Modify: `src/types/messages.ts:7` (isContentMessage list) and the `Messages` factory
+
+- [ ] **Step 1: Add the message type**
+
+In `src/types/messages/base.ts`, after the `TelemetryErrorMessage` interface (line 37):
+
+```ts
+export interface TelemetryEventMessage { type: 'REIS_TELEMETRY_EVENT'; event: string; props?: Record<string, unknown>; }
+```
+
+Then add it to the `ContentToIframeMessage` union (line 40):
+
+```ts
+export type ContentToIframeMessage = DataResponseMessage | FetchResultMessage | ActionResultMessage | SyncUpdateMessage | PopupStateMessage | NavMenuMessage | IskamSyncUpdateMessage | IskamBlockResultMessage | TelemetryErrorMessage | TelemetryEventMessage;
+```
+
+- [ ] **Step 2: Register the type guard + factory**
+
+In `src/types/messages.ts`, add `'REIS_TELEMETRY_EVENT'` to the array inside `isContentMessage` (line 7), and add this to the `Messages` object after `telemetryError`:
+
+```ts
+    telemetryEvent: (event: string, props?: Record<string, unknown>): T.TelemetryEventMessage => ({
+        type: 'REIS_TELEMETRY_EVENT',
+        event,
+        props,
+    }),
+```
+
+- [ ] **Step 3: Verify types**
+
+Run: `npm run typecheck`
+Expected: passes (the new union member is handled in Task 6's switch; until then `useAppLogic` ignores unknown content types via its final `return`, so typecheck is clean).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/types/messages/base.ts src/types/messages.ts
+git commit -m "feat(analytics): REIS_TELEMETRY_EVENT message type and factory"
+```
+
+---
+
+## Task 6: Init analytics + lifecycle events in the iframe
+
+**Files:**
+- Modify: `src/entrypoints/main/main.tsx:19-20`
+- Modify: `src/hooks/useAppLogic.ts` (message handler ~line 103; schedule-set branch ~line 116)
+
+- [ ] **Step 1: Initialize analytics at iframe boot**
+
+In `src/entrypoints/main/main.tsx`, after the `initTelemetry(...)` line (line 20), add:
+
+```ts
+import { initAnalytics, track } from '@/services/analytics/analytics'
+// ...
+initAnalytics(() => useAppStore.getState().errorReportingEnabled)
+track({
+  event: 'app_opened',
+  props: {
+    host: 'is',
+    cold_start: !useAppStore.getState().schedule,
+    lang: useAppStore.getState().language,
+    theme: useAppStore.getState().theme,
+    is_touch: useAppStore.getState().isTouch,
+    is_narrow: useAppStore.getState().isNarrow,
+  },
+})
+```
+
+Before writing, confirm the exact store field names for language/theme/touch/narrow:
+Run: `grep -nE "language:|theme:|isTouch|isNarrow" src/store/types.ts`
+Use the confirmed names. If `isTouch`/`isNarrow` live under a viewport object, read them accordingly (e.g. `useAppStore.getState().isTouch`).
+
+- [ ] **Step 2: Route bridged events into track()**
+
+In `src/hooks/useAppLogic.ts`, in the `handle` message callback, right after the existing `REIS_TELEMETRY_ERROR` block (lines 103-106), add:
+
+```ts
+            if (d.type === 'REIS_TELEMETRY_EVENT') {
+                track({ event: d.event, props: d.props } as Parameters<typeof track>[0]);
+                return;
+            }
+```
+
+Add the import at the top of the file:
+
+```ts
+import { track, msSinceOpen } from '../services/analytics/analytics';
+```
+
+- [ ] **Step 3: Fire first_data_rendered on the first schedule paint**
+
+In `src/hooks/useAppLogic.ts`, in the schedule branch (`if (r.schedule) { useAppStore.getState().setSchedule(...) }`, ~line 116), guard a once-only emit. Add a ref near the other refs at the top of the hook:
+
+```ts
+    const firstPaintSent = useRef(false);
+```
+
+Then inside the `if (r.schedule)` block, after `setSchedule`:
+
+```ts
+                if (!firstPaintSent.current) {
+                    firstPaintSent.current = true;
+                    track({ event: 'first_data_rendered', props: { ms_since_open: msSinceOpen() } });
+                }
+```
+
+- [ ] **Step 4: Fire handshake events**
+
+Find where `handshakeDone` / `handshakeTimedOut` are set:
+Run: `grep -rn "handshakeDone\|handshakeTimedOut" src/store/slices/createSyncSlice.ts`
+In each setter, add the matching `track({ event: 'handshake_done' })` / `track({ event: 'handshake_timed_out' })` immediately after the `set(...)`. Import `track` from `../../services/analytics/analytics` in that slice.
+
+- [ ] **Step 5: Verify build + typecheck**
+
+Run: `npm run typecheck && npm run build`
+Expected: both pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/entrypoints/main/main.tsx src/hooks/useAppLogic.ts src/store/slices/createSyncSlice.ts
+git commit -m "feat(analytics): init + lifecycle events (app_opened, first_data_rendered, handshake)"
+```
+
+---
+
+## Task 7: Wire identify on the daily-usage path
+
+**Files:**
+- Modify: `src/store/useAppStore.ts:124-128`
+
+- [ ] **Step 1: Call identify alongside trackDailyUsage**
+
+In `src/store/useAppStore.ts`, the existing block resolves `getUserParams()` and calls `trackDailyUsage(p.studentId)`. Extend it to also identify:
+
+```ts
+    // Fire-and-forget daily usage tracking + analytics identity
+    import('../api/feedback').then(({ trackDailyUsage }) =>
+        import('../utils/userParams').then(({ getUserParams }) =>
+            getUserParams().then(p => {
+                if (!p) return;
+                trackDailyUsage(p.studentId);
+                import('../services/analytics/identity').then(({ identify }) => identify(p.studentId));
+            })
+        )
+    );
+```
+
+- [ ] **Step 2: Verify build**
+
+Run: `npm run build`
+Expected: passes.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/store/useAppStore.ts
+git commit -m "feat(analytics): identify hashed student id on daily-usage path"
+```
+
+---
+
+## Task 8: feature_opened + empty_state_shown instrumentation
+
+Goal: one `track({ event: 'feature_opened', props: { feature } })` when each feature surface first mounts, and `empty_state_shown` where features render their empty state. A tiny mount hook keeps call sites to one line.
+
+**Files:**
+- Create: `src/hooks/useTrackFeatureOpen.ts`
+- Test: `src/hooks/__tests__/useTrackFeatureOpen.test.tsx`
+- Modify (one line each): the top-level component of each feature surface (see Step 4)
+
+- [ ] **Step 1: Write the failing test**
+
+`src/hooks/__tests__/useTrackFeatureOpen.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+vi.mock('../../services/analytics/analytics', () => ({ track: vi.fn() }));
+import { track } from '../../services/analytics/analytics';
+import { useTrackFeatureOpen } from '../useTrackFeatureOpen';
+
+describe('useTrackFeatureOpen', () => {
+    beforeEach(() => { vi.clearAllMocks(); });
+
+    it('fires feature_opened exactly once on mount', () => {
+        const { rerender } = renderHook(() => useTrackFeatureOpen('exams'));
+        rerender();
+        expect(track).toHaveBeenCalledTimes(1);
+        expect(track).toHaveBeenCalledWith({ event: 'feature_opened', props: { feature: 'exams' } });
+    });
+});
+```
+
+(If the repo uses `@testing-library/react`'s `renderHook` differently, mirror an existing hook test — run `ls src/hooks/__tests__` and copy its import style.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/hooks/__tests__/useTrackFeatureOpen.test.tsx`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the hook**
+
+`src/hooks/useTrackFeatureOpen.ts`:
+
+```ts
+import { useEffect, useRef } from 'react';
+import { track } from '../services/analytics/analytics';
+import type { FeatureKey } from '../services/analytics/events';
+
+// Fires feature_opened once per mount. Place at the top of each feature surface.
+export function useTrackFeatureOpen(feature: FeatureKey): void {
+    const sent = useRef(false);
+    useEffect(() => {
+        if (sent.current) return;
+        sent.current = true;
+        track({ event: 'feature_opened', props: { feature } });
+    }, [feature]);
+}
+```
+
+- [ ] **Step 4: Add one call per feature surface**
+
+Confirm each surface's top-level component, then add `useTrackFeatureOpen('<key>')` as the first hook in its body. Discover exact files:
+
+Run: `ls src/components/Exams src/components/ExamPanel src/components/WeeklyCalendar src/components/SubjectFileDrawer src/components/ErasmusPanel src/components/IskamPanel src/components/SuccessRate src/components/StudyJams`
+
+Map (use the panel/root component in each dir):
+- `calendar` → `src/components/WeeklyCalendar` root
+- `exams` → `src/components/ExamPanel` root
+- `file_drawer` → `src/components/SubjectFileDrawer` root
+- `erasmus` → `src/components/ErasmusPanel` root
+- `iskam` → `src/components/IskamPanel` root
+- `success_rate` → `src/components/SuccessRate` root (or `SuccessRateTab.tsx`)
+- `tutoring` → `src/components/StudyJams` root
+- `drive_backup` → `src/components/SubjectFileDrawer/Header/DriveBackupStatus.tsx` (fire on connect, not mount — see Task 9)
+- `notes_editor` → notes editor root (discover: `grep -rln "card-first\|notesDoc\|NoteEditor\|cards" src/components`)
+
+For each, add (example for ExamPanel root):
+
+```tsx
+import { useTrackFeatureOpen } from '@/hooks/useTrackFeatureOpen';
+// ...inside the component body, first line:
+  useTrackFeatureOpen('exams');
+```
+
+- [ ] **Step 5: Add empty_state_shown where features render empty states**
+
+Discover existing empty-state markers:
+Run: `grep -rln "empty\|EmptyState\|žádn\|no .* found" src/components/Exams src/components/WeeklyCalendar src/components/SubjectFileDrawer`
+In each confirmed empty-render branch's component, add a mount-guarded emit using the same `useRef` pattern:
+
+```tsx
+  const emptySent = useRef(false);
+  useEffect(() => {
+    if (isEmpty && !emptySent.current) { emptySent.current = true; track({ event: 'empty_state_shown', props: { feature: 'exams' } }); }
+  }, [isEmpty]);
+```
+
+(Use the real local that indicates emptiness in that component; do not invent `isEmpty` if a different flag exists.)
+
+- [ ] **Step 6: Run hook test + build**
+
+Run: `npx vitest run src/hooks/__tests__/useTrackFeatureOpen.test.tsx && npm run build`
+Expected: PASS + build succeeds.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/hooks/useTrackFeatureOpen.ts src/hooks/__tests__/useTrackFeatureOpen.test.tsx src/components
+git commit -m "feat(analytics): feature_opened and empty_state_shown instrumentation"
+```
+
+---
+
+## Task 9: Action + content-script events
+
+Covers `notes_card_created`, `file_opened`, `drive_backup_completed`, `sync_failed`.
+
+**Files (discover exact handlers first — commands given per event):**
+- Modify: notes card-create handler; file-open handler; `src/services/drive/driveBackup.ts`; `src/injector/syncService.ts`
+
+- [ ] **Step 1: notes_card_created**
+
+Find the create handler:
+Run: `grep -rnE "cards:\s*\[|addCard|createCard|\.cards\b" src/services/notes src/store/slices src/components | grep -i card | head`
+At the confirmed create action (the function that appends a new card), add:
+
+```ts
+import { track } from '@/services/analytics/analytics';
+// after the card is created:
+track({ event: 'notes_card_created' });
+```
+
+- [ ] **Step 2: file_opened**
+
+Find where a subject file is opened/fetched for viewing:
+Run: `grep -rnE "openFile|fetchBlock|REIS_FETCH|onClick.*file|setActiveFile|previewFile" src/components/SubjectFileDrawer src/store/slices | head`
+At the confirmed open handler (iframe side), add `track({ event: 'file_opened' });`.
+
+- [ ] **Step 3: drive_backup_completed (content script → bridge)**
+
+In `src/services/drive/driveBackup.ts`, find where a run finishes successfully (search for where last-success is recorded):
+Run: `grep -nE "success|complete|manifest|lastSuccess|setLastSuccess" src/services/drive/driveBackup.ts | head`
+At the success point, emit via the bridge (content-script context has no PostHog). Use the same `sendToIframe(Messages.telemetryError(...))` channel already imported in that area; add:
+
+```ts
+import { sendToIframe } from '@/injector/iframeManager';
+import { Messages } from '@/types/messages';
+// at successful completion, with the uploaded file count in scope:
+sendToIframe(Messages.telemetryEvent('drive_backup_completed', { files: uploadedCount }));
+```
+
+Confirm the real variable holding the count (search the function); if backup runs report a diff/summary object, read the count from it. Do not invent `uploadedCount` if a different field exists.
+
+- [ ] **Step 4: sync_failed (content script → bridge)**
+
+In `src/injector/syncService.ts`, the catch sites already call `sendToIframe(Messages.telemetryError('Sync.…', e))`. Alongside (not replacing) the telemetryError call at the top-level sync failure catch, add:
+
+```ts
+sendToIframe(Messages.telemetryEvent('sync_failed', { step: 'syncAllData' }));
+```
+
+Use a `step` label matching the specific catch (e.g. `'syncClassmates'`, `'fetchSeminarGroupIds'`) so friction can be localized. Keep `step` values to short fixed identifiers — never interpolate error text.
+
+- [ ] **Step 5: Verify build + full test run**
+
+Run: `npm run build && npm run test:run`
+Expected: build succeeds; tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/services src/injector src/store src/components
+git commit -m "feat(analytics): action and content-script events"
+```
+
+---
+
+## Task 10: Combined opt-out label + PRIVACY.md
+
+**Files:**
+- Modify: `src/components/Sidebar/ProfilePopup.tsx` (~line 135 toggle)
+- Modify: `src/components/MobileNav/MobileProfileSheet.tsx` (~line 152 toggle)
+- Modify: `src/i18n/locales/cs.json`, `src/i18n/locales/en.json`
+- Modify: `PRIVACY.md`
+
+- [ ] **Step 1: Relabel the toggle to combined wording**
+
+Both toggles bind to `errorReportingEnabled`. Update the visible label/description string keys to "Usage analytics & diagnostics" (EN) / a faithful CZ translation, conveying it covers anonymous usage analytics and error diagnostics, opt-out, no personal data.
+
+Find the current i18n keys:
+Run: `grep -rn "errorReporting\|error_reporting\|diagnostic" src/i18n/locales/en.json src/components/Sidebar/ProfilePopup.tsx`
+Update the EN value to e.g. `"Usage analytics & diagnostics"` with a sub-label like `"Anonymous usage and error data to improve reIS. No personal data, schedules, or grades."`, and the CZ equivalent. Do not rename the keys (avoids touching both components again) unless the key name is shown to users.
+
+- [ ] **Step 2: Update PRIVACY.md**
+
+- Expand §3 ("Anonymous Usage Analytics") to describe: behavioral product analytics via PostHog (EU Cloud, `eu.i.posthog.com`); explicit events only (no autocapture/recording); pseudonymous identity = SHA-256 hash of student ID (irreversible, also used for daily-active); no IS content, names, grades, or file names ever sent.
+- Add **PostHog** (`eu.i.posthog.com`, EU) to §"Third-Party Access" list (item 5).
+- Under §"User Control", state the combined "Usage analytics & diagnostics" opt-out (same toggle as error reporting) and that it disables both.
+- Bump "Last Updated" to 2026-06-03.
+
+- [ ] **Step 3: Verify build + typecheck**
+
+Run: `npm run typecheck && npm run build`
+Expected: both pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/Sidebar/ProfilePopup.tsx src/components/MobileNav/MobileProfileSheet.tsx src/i18n/locales/cs.json src/i18n/locales/en.json PRIVACY.md
+git commit -m "feat(analytics): combined opt-out label and privacy disclosure"
+```
+
+---
+
+## Task 11: Final verification
+
+- [ ] **Step 1: Full gate**
+
+Run: `npm run lint && npm run typecheck && npm run test:run && npm run build`
+Expected: all green.
+
+- [ ] **Step 2: Manual smoke (optional, requires real key in `.env`)**
+
+With a real `VITE_POSTHOG_KEY` set, `npm run dev`, load IS Mendelu, open features, and confirm in PostHog → Activity that `app_opened`, `first_data_rendered`, and `feature_opened` arrive with hashed `distinct_id` and **no** PII in properties. Toggle the opt-out off and confirm events stop.
+
+- [ ] **Step 3: Coverage sanity for the analytics module**
+
+Run: `npx vitest run src/services/analytics`
+Expected: all analytics tests pass.
+
+---
+
+## Spec coverage check
+
+- §3 approach (hand-rolled client) → Tasks 2-3
+- §4 architecture/bridge → Tasks 2,3,5,6
+- §5 identity (anon→hashed, IDB opt-out, no localStorage) → Tasks 3,4,7,10
+- §6 taxonomy (all 10 event kinds) → Tasks 2 (types), 6 (app_opened/first_data_rendered/handshake), 8 (feature_opened/empty_state_shown), 9 (notes_card_created/file_opened/drive_backup_completed/sync_failed)
+- §7 config/hosting/permissions → Task 1
+- §8 combined opt-out + PRIVACY.md → Tasks 3 (gate), 10
+- §9 testing (TDD) → Tasks 2,3,4,8 + Task 11
+- §10 out-of-scope (flags, recording, autocapture) → never introduced
+
+## Out of scope (deferred follow-ups)
+
+- ISKAM-side analytics beyond what shares the iframe module — the ISKAM app has a separate store/iframe; wiring `app_opened {host:'iskam'}` + an ISKAM bridge mirrors Tasks 5-6 and is a separate small plan.
+- Server-side ingestion, PostHog feature flags, session recording, heatmaps.

--- a/docs/superpowers/specs/2026-06-02-schedule-first-cold-start-design.md
+++ b/docs/superpowers/specs/2026-06-02-schedule-first-cold-start-design.md
@@ -1,0 +1,142 @@
+# Schedule-First Cold Start — "Win the First 30 Seconds"
+
+**Date:** 2026-06-02
+**Status:** Design approved, pending implementation plan
+**Goal owner:** committed direction for the Fall 2026 growth event (shot at 500+ users)
+
+## Why
+
+Next semester a campus event is a real chance to onboard 500+ students in a short
+window. A cold-start product gets one impression per student: they install, open it
+once, and decide in ~30 seconds whether to keep it. The single most important thing
+is that the first open delivers obvious, personal value immediately.
+
+Today it does the opposite. The audit found three concrete defects in the first 30
+seconds:
+
+1. **Commitment before value.** `WelcomeModal` step 2 — the first interactive screen
+   after the greeting — asks a brand-new student to (a) set up Outlook mobile calendar
+   sync and (b) connect their Google Drive, *before they have seen a single one of
+   their own classes.* These are heavy, external, trust-demanding asks with no payoff
+   yet shown.
+2. **Slow time-to-first-value, self-advertised.** Onboarding copy literally says
+   `"Sync trvá přibližně 15 min."` ("Sync takes ~15 minutes"). The reward is framed as
+   a 15-minute wait.
+3. **The hook is gated behind the slow batch.** In `syncAllData()`, the schedule
+   (`fetchFullSemesterSchedule()`) is fetched in parallel with 7 other things, but the
+   first real `syncUpdate` only fires after **all 8** settle. The schedule could paint
+   in 1–3s; instead it waits behind the slowest fetch in the batch.
+
+**The hook** (decided): the student's **real class schedule for this week**. Universal,
+personal, already the default view, and the fastest single thing to fetch.
+
+## Approach
+
+Chosen approach: **A+** — schedule-first paint (the surgical sequencing fix) plus an
+honest, non-broken first-run state. Approach C (cached-shell instant paint) was
+explicitly rejected: it serves returning users, not the event's cold-start crowd, and
+adds complexity for no first-open payoff.
+
+Design principle: keep blast radius small. The schedule already streams into the iframe
+via partial `syncUpdate`s — the iframe needs almost no change. Do **not** touch the
+fragile Drive/OAuth subsystems or the brittle IS parsers.
+
+## Components
+
+### 1. Schedule-first paint — `src/injector/syncService.ts` (content script)
+
+Decouple the schedule from the 8-way `Promise.allSettled` batch. The moment
+`fetchFullSemesterSchedule()` resolves, emit a **schedule-only** update:
+
+```
+sendToIframe(Messages.syncUpdate({ schedule, isSyncing: true, lastSync }))
+```
+
+before awaiting the rest of the batch. The existing post-batch `syncUpdate` (currently
+~line 163) stays unchanged for exams/subjects/study plan/etc.
+
+The iframe **already supports** partial schedule updates: `useAppLogic` (~line 117)
+does `if (r.schedule) useAppStore.getState().setSchedule(...)` on any update. So this is
+a content-script-only sequencing change.
+
+To make ordering testable, extract a small emit seam (e.g. a function that takes the
+schedule and emits the early update) rather than inlining the `sendToIframe` call.
+
+**Error handling:** if `fetchFullSemesterSchedule()` rejects, do not emit an early
+schedule update; fall through to the existing batch path, and let the first-run state
+(component 2) surface a retry rather than spinning forever.
+
+### 2. Honest first-run state — sync slice + Calendar (iframe)
+
+- **`isFirstSync` signal** (`src/store/slices/createSyncSlice.ts` or derived in the
+  calendar data hook): true when a sync is in progress **and** no schedule is present
+  in the store yet. Becomes false the instant a schedule arrives.
+- **Calendar cold state** (`src/components/WeeklyCalendar/`): while `isFirstSync` holds,
+  render a **branded "building your week"** state instead of the generic skeleton
+  (which reads as "broken" to a stranger). The instant the schedule arrives, render the
+  real week; let exams/files/etc. stream in behind with quiet per-section loading.
+- **Backstop:** the existing 10s `handshakeTimedOut` remains. Add a clear
+  "couldn't load your schedule — retry" path for the *failure* case (component 1's
+  reject branch), distinct from the still-loading case.
+
+### 3. Defer commitment asks — `src/components/Onboarding/WelcomeModal.tsx`
+
+- Step 1 (welcome + language picker) stays.
+- **Remove Outlook and Google Drive asks from the blocking first-run flow.**
+- **Google Drive** ask: already lives in the file drawer header
+  (`DriveBackupStatus.tsx`) — rely on that; no proactive first-run prompt.
+- **Outlook** ask: resurfaces as a **dismissible nudge inside the Calendar view**,
+  shown once the schedule has painted ("Want this on your phone? Sync to Outlook.").
+  Contextual, non-blocking, dismiss-once (persist dismissal in IDB `meta`, consistent
+  with `welcome_dismissed`).
+
+### 4. Honest copy — `src/i18n/locales/{cs,en}.json`
+
+- Remove / replace `onboarding.syncCoffeeBreak` ("Sync trvá přibližně 15 min.").
+- Add progressive, truthful status strings, e.g. *"Your schedule's ready — still
+  loading materials…"* and the calendar Outlook nudge strings (cs + en).
+
+## Data flow (cold start, new user)
+
+```
+install → open iframe
+  → useAppLogic: signalReady() + requestData('all')
+  → content script syncAllData() starts
+      → fetchFullSemesterSchedule() resolves FIRST
+          → sendToIframe(syncUpdate{ schedule, isSyncing:true })   ← NEW early emit
+              → iframe setSchedule() → isFirstSync flips false → real week paints  ✅ (~1–3s)
+      → rest of batch settles → sendToIframe(syncUpdate{ exams, subjects, ... })
+      → Phase 3 (files/classmates/zaznamnik) streams in behind
+  → Calendar shows dismissible Outlook nudge (post-paint)
+  → Drive ask remains available in file drawer (no first-run prompt)
+```
+
+## Testing (TDD — failing test first, per Iron Rules)
+
+- **`syncService`**: assert a schedule-only `syncUpdate` is emitted **before** the full
+  batch `syncUpdate`. (Drives the emit-seam extraction.)
+- **sync slice / calendar data**: assert `isFirstSync` derivation — syncing + no
+  schedule ⇒ true; schedule present ⇒ false.
+- **`WelcomeModal`**: assert no Drive/Outlook ask renders in the blocking first-run
+  path (step 2 no longer gates value).
+- **Calendar Outlook nudge**: assert it renders only after schedule present, and that
+  dismissal persists.
+
+## Out of scope (YAGNI)
+
+- Cached-shell / offline-instant first paint (Approach C) — returning-user payoff only.
+- Any change to Drive/OAuth or IS parsers.
+- Broader retention instrumentation / funnel analytics — a separate direction, not this
+  spec.
+
+## Risks & mitigations
+
+- **Schedule fetch is itself slow for some students.** Mitigation: the branded
+  "building your week" state is honest and non-broken; the 10s backstop and retry path
+  prevent a stuck appearance. This spec improves *perceived* and *actual* time-to-first
+  value but does not optimize the IS fetch itself.
+- **Removing onboarding asks lowers Outlook/Drive adoption.** Accepted trade-off:
+  retention of the core loop outranks attach-rate of secondary features at the event.
+  The contextual nudges recover discovery without blocking value.
+- **Partial-update races** (early schedule then batch overwrites). Low risk: the batch
+  update carries the same schedule; `setSchedule` is idempotent for identical data.

--- a/docs/superpowers/specs/2026-06-02-schedule-first-cold-start-design.md
+++ b/docs/superpowers/specs/2026-06-02-schedule-first-cold-start-design.md
@@ -122,6 +122,33 @@ install → open iframe
 - **Calendar Outlook nudge**: assert it renders only after schedule present, and that
   dismissal persists.
 
+## Visual design (decided)
+
+Storyboard mockup: `2026-06-02-schedule-first-cold-start-mockup.html` (companion file).
+Aesthetic direction: **calm competence** — restraint, not a bold redesign. Built entirely
+in DaisyUI semantic classes + motion/react (no custom CSS, no new fonts, Inter throughout,
+mendelu-dark default). MENDELU green (`#79be15`) is the single confident accent; everything
+else stays quiet. **The one memorable moment is the timetable assembling itself** — the wait
+reads as construction, not loading.
+
+The four frames of the journey:
+
+1. **Welcome (0s)** — one confident screen: logo, title, CZ/EN segmented toggle, single
+   "Jdeme na to →" primary button, reassurance caption ("nothing logged in, runs in your
+   browser"). **No Outlook/Drive ask.**
+2. **Building (0–2s)** — branded header with a pulsing green dot + "Sestavujeme tvůj
+   týden…", an honest thin progress bar, and a shimmering timetable skeleton. Never the
+   generic skeleton.
+3. **Your week (~2s) ✦** — the hook lands: real class cards **cascade in** (staggered
+   `rise`, lecture green / seminar blue / exam red) while an honest *"načítám materiály…"*
+   chip shows the rest still streaming. This is the "I'm keeping this" beat.
+4. **Post-paint nudge** — the deferred Outlook ask returns **in context** as a dismissible
+   card inside the calendar; Drive ask stays in the file drawer.
+
+Motion budget (one well-orchestrated moment, not scattered micro-interactions): ping dot
+on the building header, a single staggered cascade on first schedule paint, a breathing dot
+on the streaming chip. Respect `prefers-reduced-motion`.
+
 ## Out of scope (YAGNI)
 
 - Cached-shell / offline-instant first paint (Approach C) — returning-user payoff only.

--- a/docs/superpowers/specs/2026-06-02-schedule-first-cold-start-mockup.html
+++ b/docs/superpowers/specs/2026-06-02-schedule-first-cold-start-mockup.html
@@ -1,0 +1,204 @@
+<!doctype html>
+<html lang="cs" data-theme="dark">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>reIS — Schedule-First Cold Start (storyboard mockup)</title>
+<!--
+  DESIGN MOCKUP ONLY — not production code.
+  Production uses DaisyUI semantic classes (no custom CSS, Inter font, mendelu theme).
+  This file replicates the real reIS tokens (#79be15 primary, #00548f accent,
+  mendelu-dark base) with utility classes so the cold-start journey can be SEEN
+  and judged before implementation. Class names mirror their DaisyUI equivalents
+  (btn-primary, card, badge, toggle) so the mapping to real components is 1:1.
+-->
+<script src="https://cdn.tailwindcss.com"></script>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap" rel="stylesheet" />
+<script>
+  tailwind.config = {
+    theme: {
+      extend: {
+        fontFamily: { sans: ['Inter', 'sans-serif'] },
+        colors: {
+          primary: '#79be15', 'primary-content': '#ffffff',
+          accent: '#3b82f6', secondary: '#8DC843',
+          'base-100': '#1f2937', 'base-200': '#111827', 'base-300': '#0f172a',
+          'base-content': '#f3f4f6',
+          'lecture-bg': 'rgba(121,190,21,0.14)', 'lecture-bd': '#79be15',
+          'seminar-bg': 'rgba(59,130,246,0.14)', 'seminar-bd': '#3b82f6',
+          'exam-bg': 'rgba(220,38,38,0.14)', 'exam-bd': '#dc2626',
+        },
+        borderRadius: { box: '12px', field: '6px', selector: '8px' },
+        keyframes: {
+          shimmer: { '100%': { transform: 'translateX(100%)' } },
+          rise: { '0%': { opacity: 0, transform: 'translateY(8px)' }, '100%': { opacity: 1, transform: 'translateY(0)' } },
+          breathe: { '0%,100%': { opacity: .4 }, '50%': { opacity: 1 } },
+          grow: { '0%': { width: '0%' }, '100%': { width: '62%' } },
+        },
+        animation: {
+          rise: 'rise .5s cubic-bezier(.2,.7,.2,1) both',
+          breathe: 'breathe 1.8s ease-in-out infinite',
+          grow: 'grow 2.4s cubic-bezier(.3,.6,.3,1) infinite',
+        }
+      }
+    }
+  }
+</script>
+<style>
+  body { background:
+      radial-gradient(900px 500px at 20% -10%, rgba(121,190,21,.10), transparent 60%),
+      radial-gradient(800px 500px at 100% 110%, rgba(59,130,246,.10), transparent 55%),
+      #0b1220; }
+  .panel { box-shadow: 0 24px 60px -20px rgba(0,0,0,.6), 0 0 0 1px rgba(255,255,255,.04); }
+  .shimmer { position: relative; overflow: hidden; }
+  .shimmer::after { content:''; position:absolute; inset:0;
+    background: linear-gradient(90deg, transparent, rgba(255,255,255,.07), transparent);
+    transform: translateX(-100%); animation: shimmer 1.4s infinite; }
+  /* staggered cascade for resolved class cards */
+  .cascade > * { animation: rise .5s cubic-bezier(.2,.7,.2,1) both; }
+  .cascade > *:nth-child(1){ animation-delay:.05s } .cascade > *:nth-child(2){ animation-delay:.18s }
+  .cascade > *:nth-child(3){ animation-delay:.31s } .cascade > *:nth-child(4){ animation-delay:.44s }
+</style>
+</head>
+<body class="font-sans text-base-content min-h-screen px-6 py-10">
+
+  <header class="max-w-6xl mx-auto mb-10">
+    <div class="flex items-center gap-3">
+      <div class="w-9 h-9 rounded-selector bg-primary grid place-items-center font-black text-primary-content shadow-lg shadow-primary/30">r</div>
+      <div>
+        <h1 class="text-xl font-extrabold tracking-tight">Schedule-First Cold Start</h1>
+        <p class="text-sm text-base-content/50">The first 30 seconds, as a storyboard · mendelu-dark theme</p>
+      </div>
+    </div>
+  </header>
+
+  <!-- storyboard rail -->
+  <div class="max-w-6xl mx-auto grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-6">
+
+    <!-- ① WELCOME — asks deferred -->
+    <section class="flex flex-col gap-3">
+      <span class="text-xs font-bold uppercase tracking-widest text-base-content/40">① Open · 0s</span>
+      <div class="panel bg-base-100 rounded-box p-6 flex-1 flex flex-col">
+        <div class="flex-1 flex flex-col items-center text-center justify-center gap-4 py-6">
+          <div class="w-14 h-14 rounded-box bg-primary grid place-items-center font-black text-2xl text-primary-content shadow-lg shadow-primary/30 animate-rise">r</div>
+          <div>
+            <h2 class="text-2xl font-extrabold tracking-tight">Vítej v reISu!</h2>
+            <p class="text-sm text-base-content/60 mt-1 leading-relaxed">Vylepšená verze IS MENDELU.<br/>Od studentů pro studenty.</p>
+          </div>
+          <!-- segmented language toggle -->
+          <div class="inline-flex p-0.5 rounded-selector bg-base-300 border border-white/5">
+            <button class="px-4 py-1 text-xs font-bold rounded-field bg-primary text-primary-content shadow">CZ</button>
+            <button class="px-4 py-1 text-xs font-bold rounded-field text-base-content/50">EN</button>
+          </div>
+          <button class="w-full mt-1 py-2.5 rounded-field bg-primary text-primary-content font-bold tracking-wide shadow-lg shadow-primary/25 hover:brightness-105 transition">
+            Jdeme na to →
+          </button>
+          <p class="text-[11px] text-base-content/35">Žádné přihlašování. Vše běží u tebe v prohlížeči.</p>
+        </div>
+      </div>
+      <p class="text-xs text-base-content/45 leading-relaxed">One confident screen. <b class="text-base-content/70">No Outlook / Drive ask</b> — nothing is requested before value is shown.</p>
+    </section>
+
+    <!-- ② BUILDING YOUR WEEK -->
+    <section class="flex flex-col gap-3">
+      <span class="text-xs font-bold uppercase tracking-widest text-base-content/40">② Building · 0–2s</span>
+      <div class="panel bg-base-100 rounded-box p-4 flex-1 flex flex-col gap-3">
+        <!-- branded loading header -->
+        <div class="flex items-center gap-2.5 px-1">
+          <span class="relative flex h-2.5 w-2.5">
+            <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-primary opacity-60"></span>
+            <span class="relative inline-flex rounded-full h-2.5 w-2.5 bg-primary"></span>
+          </span>
+          <div>
+            <p class="text-sm font-bold leading-none">Sestavujeme tvůj týden…</p>
+            <p class="text-[11px] text-base-content/45 mt-1">Pondělí 2. června</p>
+          </div>
+        </div>
+        <!-- thin progress -->
+        <div class="h-1 rounded-full bg-base-300 overflow-hidden"><div class="h-full bg-primary/80 animate-grow"></div></div>
+        <!-- weekday strip -->
+        <div class="grid grid-cols-5 gap-1 text-center text-[10px] font-bold text-base-content/40">
+          <div class="py-1 rounded-field bg-primary/15 text-primary">Po</div><div>Út</div><div>St</div><div>Čt</div><div>Pá</div>
+        </div>
+        <!-- timetable skeleton (assembling) -->
+        <div class="flex-1 flex flex-col gap-2 mt-1">
+          <div class="shimmer h-14 rounded-field bg-base-300/70"></div>
+          <div class="shimmer h-10 rounded-field bg-base-300/70"></div>
+          <div class="shimmer h-16 rounded-field bg-base-300/70"></div>
+          <div class="shimmer h-10 rounded-field bg-base-300/70"></div>
+        </div>
+      </div>
+      <p class="text-xs text-base-content/45 leading-relaxed">Branded <b class="text-base-content/70">"building your week"</b>, never a broken-looking skeleton. The wait reads as construction.</p>
+    </section>
+
+    <!-- ③ YOUR WEEK PAINTS -->
+    <section class="flex flex-col gap-3">
+      <span class="text-xs font-bold uppercase tracking-widest text-base-content/40">③ Your week · ~2s ✦</span>
+      <div class="panel bg-base-100 rounded-box p-4 flex-1 flex flex-col gap-3 ring-1 ring-primary/30">
+        <div class="flex items-center justify-between px-1">
+          <div>
+            <p class="text-sm font-bold leading-none">Pondělí 2. června</p>
+            <p class="text-[11px] text-base-content/45 mt-1">tvůj rozvrh</p>
+          </div>
+          <!-- honest streaming chip -->
+          <span class="inline-flex items-center gap-1.5 text-[10px] font-semibold px-2 py-1 rounded-full bg-base-300 text-base-content/55">
+            <span class="w-1.5 h-1.5 rounded-full bg-primary animate-breathe"></span> načítám materiály…
+          </span>
+        </div>
+        <div class="grid grid-cols-5 gap-1 text-center text-[10px] font-bold text-base-content/40">
+          <div class="py-1 rounded-field bg-primary/15 text-primary">Po</div><div>Út</div><div>St</div><div>Čt</div><div>Pá</div>
+        </div>
+        <!-- resolved real class cards, staggered cascade -->
+        <div class="flex-1 flex flex-col gap-2 mt-1 cascade">
+          <div class="rounded-field bg-lecture-bg border-l-4 border-lecture-bd px-3 py-2">
+            <p class="text-xs font-bold">Matematika I</p>
+            <p class="text-[10px] text-base-content/55">8:00 · přednáška · Q01</p>
+          </div>
+          <div class="rounded-field bg-seminar-bg border-l-4 border-seminar-bd px-3 py-2">
+            <p class="text-xs font-bold">Programování</p>
+            <p class="text-[10px] text-base-content/55">10:00 · cvičení · T1.05</p>
+          </div>
+          <div class="rounded-field bg-lecture-bg border-l-4 border-lecture-bd px-3 py-2">
+            <p class="text-xs font-bold">Ekonomie</p>
+            <p class="text-[10px] text-base-content/55">13:00 · přednáška · Aula</p>
+          </div>
+          <!-- one still-streaming row -->
+          <div class="shimmer h-10 rounded-field bg-base-300/60"></div>
+        </div>
+      </div>
+      <p class="text-xs text-base-content/45 leading-relaxed">The <b class="text-primary">hook lands</b>: real classes cascade in while materials still stream behind an honest chip. This is the "I'm keeping this" moment.</p>
+    </section>
+
+    <!-- ④ OUTLOOK NUDGE -->
+    <section class="flex flex-col gap-3">
+      <span class="text-xs font-bold uppercase tracking-widest text-base-content/40">④ Post-paint · nudge</span>
+      <div class="panel bg-base-100 rounded-box p-4 flex-1 flex flex-col gap-3">
+        <div class="flex items-center justify-between px-1">
+          <p class="text-sm font-bold leading-none">Tvůj týden</p>
+          <span class="text-[11px] text-base-content/40">2.–6. 6.</span>
+        </div>
+        <!-- dismissible contextual nudge -->
+        <div class="relative rounded-field bg-accent/10 border border-accent/25 px-3 py-2.5 pr-8">
+          <button class="absolute top-2 right-2 text-base-content/35 hover:text-base-content/70 text-xs leading-none">✕</button>
+          <p class="text-xs font-bold flex items-center gap-1.5"><span>📱</span> Chceš rozvrh v mobilu?</p>
+          <p class="text-[11px] text-base-content/55 mt-0.5">Synchronizuj do kalendáře v Outlooku.</p>
+          <button class="mt-2 text-[11px] font-bold px-2.5 py-1 rounded-field bg-accent text-white">Nastavit sync</button>
+        </div>
+        <!-- the calm, fully-loaded week behind it -->
+        <div class="flex-1 flex flex-col gap-2 opacity-90">
+          <div class="rounded-field bg-lecture-bg border-l-4 border-lecture-bd px-3 py-2"><p class="text-xs font-bold">Matematika I</p><p class="text-[10px] text-base-content/55">8:00 · přednáška</p></div>
+          <div class="rounded-field bg-seminar-bg border-l-4 border-seminar-bd px-3 py-2"><p class="text-xs font-bold">Programování</p><p class="text-[10px] text-base-content/55">10:00 · cvičení</p></div>
+          <div class="rounded-field bg-exam-bg border-l-4 border-exam-bd px-3 py-2"><p class="text-xs font-bold">Statistika — zkouška</p><p class="text-[10px] text-base-content/55">14:00 · zápis otevřen</p></div>
+        </div>
+      </div>
+      <p class="text-xs text-base-content/45 leading-relaxed">The deferred Outlook ask returns <b class="text-base-content/70">in context</b>, dismissible. Drive ask stays in the file drawer. Asks earn their place after value.</p>
+    </section>
+
+  </div>
+
+  <footer class="max-w-6xl mx-auto mt-10 text-xs text-base-content/35 leading-relaxed border-t border-white/5 pt-5">
+    <p><b class="text-base-content/55">Design intent.</b> One memorable moment — the timetable assembling itself — carried entirely by DaisyUI semantic classes + motion/react in production (no custom CSS, no new fonts, Inter throughout). Green is the single confident accent; everything else is calm. The whole journey says <i>"this is fast, this is yours, this works"</i> before a stranger's attention is gone.</p>
+  </footer>
+
+</body>
+</html>

--- a/docs/superpowers/specs/2026-06-03-posthog-analytics-design.md
+++ b/docs/superpowers/specs/2026-06-03-posthog-analytics-design.md
@@ -89,7 +89,11 @@ component / store / content-script
   `distinct_id` for subsequent events, and flushes the buffer.
 - If identity never resolves in a session (pre-auth / cold start), events remain
   anonymous — still valid for in-session funnel analysis.
-- **Opt-out flag stored in Chrome Sync** (settings tier; follows devices).
+- Hashing reuses the existing precedent: `hashId` (SHA-256 hex) in
+  `src/api/feedback.ts`; identify timing mirrors the `trackDailyUsage` call in
+  `src/store/useAppStore.ts` (`getUserParams().then(p => …)`).
+- **Opt-out flag stored in IndexedDB `meta`** via the existing
+  `createErrorReportingSlice` (`errorReportingEnabled`) — *not* Chrome Sync.
   `distinct_id` derived fresh each load. No localStorage/cookies.
 
 ## 6. Event taxonomy
@@ -124,10 +128,12 @@ unions in `events.ts`; **never** pass IS-derived content strings.
 
 ## 8. Consent & PRIVACY.md
 
-- **Combined opt-out toggle, default on**, legitimate-interest basis — consistent
-  with the existing error-reporting opt-out. Surfaced as one **"Usage analytics &
-  diagnostics"** toggle in the profile/settings panel; it gates both this
-  analytics path and (going forward) error reporting.
+- **Combined opt-out toggle, default on**, legitimate-interest basis. We **reuse
+  the existing `errorReportingEnabled` flag** as the single combined gate (analytics
+  reads `useAppStore.getState().errorReportingEnabled`), preserving users' stored
+  opt-out choices — only the user-facing label changes to **"Usage analytics &
+  diagnostics"** in `ProfilePopup.tsx` and `MobileProfileSheet.tsx`. The internal
+  flag/IDB key keep their names to avoid a migration that would reset preferences.
 - **PRIVACY.md updates (required, part of implementation):**
   - Expand §3 ("Anonymous Usage Analytics") to describe behavioral product
     analytics via PostHog (EU), the explicit-events-only model, the hashed-ID

--- a/docs/superpowers/specs/2026-06-03-posthog-analytics-design.md
+++ b/docs/superpowers/specs/2026-06-03-posthog-analytics-design.md
@@ -1,0 +1,158 @@
+# PostHog Product Analytics — Design
+
+**Date:** 2026-06-03
+**Status:** Approved (design); pending implementation plan
+**Branch context:** complements `feat/schedule-first-cold-start` (activation funnel)
+
+## 1. Goal
+
+Add behavioral product analytics so we can answer four questions ahead of the
+Fall 2026 growth push:
+
+1. **Activation / onboarding funnel** — do new users reach the "aha" (schedule
+   painted) in their first session, and where do they drop off?
+2. **Feature usage / prioritization** — which surfaces actually get used, so we
+   invest in what matters and cut what doesn't.
+3. **Retention / stickiness** — who returns, how often, which features correlate
+   with returning.
+4. **Reliability / friction** — where users hit dead-ends, empty states, and
+   repeated failures (behavioral complement to the existing error telemetry).
+
+## 2. Non-negotiable constraints
+
+These are dictated by the existing privacy posture (`PRIVACY.md`, `CLAUDE.md`)
+and Iron Rules:
+
+- **Explicit events only. No autocapture, no session recording, ever.** We never
+  record raw DOM clicks or element text on IS Mendelu pages (which render student
+  names and grades).
+- **No PII leaves the device.** Property values are a fixed, typed set — never
+  IS-derived strings (names, file names, grades). Course *codes* are public and
+  allowed. PII-safety is structural (typed taxonomy), not regex scrubbing.
+- **No `localStorage` / `sessionStorage`** (Iron Rule). PostHog's default
+  persistence is never used; identity is derived fresh each load and the opt-out
+  flag lives in Chrome Sync.
+- **No new bundled secret.** PostHog's project ingestion key is public/write-only
+  by design, so no Supabase proxy is required (contrast: Google OAuth).
+- **Max 200 lines/file, direct imports, state in Zustand, test-first.**
+
+## 3. Chosen approach
+
+**Hand-rolled HTTP capture client** (chosen over the `posthog-js` SDK and over
+extending Supabase). Rationale: the SDK is ~60 KB of mostly-dead weight once
+autocapture/recording are off, and trusting SDK defaults to stay safe across
+upgrades is a standing risk. A hand-rolled client makes "no autocapture, ever"
+**structural** — by construction it can only send what we build. It mirrors this
+codebase's existing hand-rolled Supabase RPC + sanitize culture. PostHog's
+funnel/retention/cohort UI works fine as long as events + `distinct_id` are
+correct, which this guarantees.
+
+## 4. Architecture & data flow
+
+All analytics lives in the **iframe app** (chrome-extension origin), mirroring
+the existing `logError → sendTelemetry` single-call-site pattern.
+
+New files under `src/services/analytics/`:
+
+| File | Purpose |
+|------|---------|
+| `captureClient.ts` | Pure, stateless `postBatch(events)` → POST to PostHog `/batch`. Fully testable with mocked `fetch`. |
+| `analytics.ts` | The single call site: `initAnalytics()`, `track(event, props)`, `identify(hashedId)`, `setOptOut(bool)`. In-memory queue + flush on interval/size. < 200 lines. |
+| `events.ts` | Typed event-name union + per-event prop types (the taxonomy). Compile-time guard that no free-text/PII prop slips in. |
+
+**Init point:** iframe bootstrap (`hooks/useAppLogic.ts`), after IDB hydration.
+Events fired before identity resolves are buffered in memory.
+
+**Content-script events** (IS sync result, ISKAM, Drive backup) have no PostHog
+access — identical to telemetry today. They ride a new
+`Messages.telemetryEvent(event, props)` (and `IskamMessages` equivalent) over the
+**existing** postMessage bridge; `messageHandler.ts` / `iskamMessageHandler.ts`
+route it into `track()`. Exactly parallel to the current `telemetryError` bridge.
+
+```
+component / store / content-script
+        │  track(event, props)            (content script: postMessage bridge)
+        ▼
+   analytics.ts  ──buffer──▶ flush ──▶ captureClient.postBatch() ──▶ eu.i.posthog.com/batch
+        ▲
+   identify(hashedId)  (from sync slice, once student info known)
+```
+
+## 5. Identity (anon → hashed merge)
+
+- On load, generate a **memory-only anon UUID** (same spirit as the
+  error-reporter session id) and buffer events against it.
+- When the sync slice exposes student info, compute **SHA-256 of the student ID**
+  (reusing the existing daily-active hashing) and call `identify(hashedId)`.
+- `identify` emits PostHog's `$identify` event with `$anon_distinct_id =
+  <anon UUID>` to merge the anonymous session into the hashed person, sets
+  `distinct_id` for subsequent events, and flushes the buffer.
+- If identity never resolves in a session (pre-auth / cold start), events remain
+  anonymous — still valid for in-session funnel analysis.
+- **Opt-out flag stored in Chrome Sync** (settings tier; follows devices).
+  `distinct_id` derived fresh each load. No localStorage/cookies.
+
+## 6. Event taxonomy
+
+One event per *kind*, parameterized by properties — not N bespoke events — so
+charts and new features slot in without schema churn.
+
+| Event | Properties | Serves |
+|-------|-----------|--------|
+| `app_opened` | `host`, `cold_start`, `lang`, `theme`, `is_touch`, `is_narrow` | retention, daily-active, phone-vs-desktop |
+| `first_data_rendered` | `ms_since_open` | activation "aha" (schedule painted) |
+| `handshake_done` / `handshake_timed_out` | — | funnel + friction |
+| `feature_opened` | `feature: 'calendar'\|'exams'\|'file_drawer'\|'drive_backup'\|'notes_editor'\|'iskam'\|'success_rate'\|'erasmus'\|'tutoring'` | feature usage / prioritization |
+| `drive_backup_completed` | `files` (count) | feature usage |
+| `notes_card_created` | — | feature usage |
+| `file_opened` | — | feature usage |
+| `sync_failed` | `step` | friction |
+| `empty_state_shown` | `feature` | friction |
+
+**Every event** also carries `extension_version`, `browser_name`,
+`browser_version` (reused from telemetry context). Property value sets are fixed
+unions in `events.ts`; **never** pass IS-derived content strings.
+
+## 7. Config, hosting, permissions
+
+- **PostHog EU Cloud** — `https://eu.i.posthog.com` (EU data residency for EU
+  students).
+- Project ingestion key (`phc_…`, public/write-only) shipped via
+  `VITE_POSTHOG_KEY` + `VITE_POSTHOG_HOST`. No proxy/secret.
+- Add `https://eu.i.posthog.com/*` to `host_permissions` and CSP `connect-src`
+  in `wxt.config.ts`.
+
+## 8. Consent & PRIVACY.md
+
+- **Combined opt-out toggle, default on**, legitimate-interest basis — consistent
+  with the existing error-reporting opt-out. Surfaced as one **"Usage analytics &
+  diagnostics"** toggle in the profile/settings panel; it gates both this
+  analytics path and (going forward) error reporting.
+- **PRIVACY.md updates (required, part of implementation):**
+  - Expand §3 ("Anonymous Usage Analytics") to describe behavioral product
+    analytics via PostHog (EU), the explicit-events-only model, the hashed-ID
+    pseudonymous identity, and that no IS content is sent.
+  - Add **PostHog** (`eu.i.posthog.com`) to §"Third-Party Access".
+  - Add the combined analytics/diagnostics opt-out under §"User Control".
+
+## 9. Testing (TDD)
+
+Failing tests first, then implementation:
+
+- `captureClient`: payload shape (PostHog `/batch` schema), batching, `fetch`
+  error handling. Mocked `fetch`.
+- `analytics`: buffers events pre-identity; flushes on `identify`; emits the
+  anon→hashed `$identify` alias exactly once; `setOptOut(true)` drops all events
+  (queued and subsequent).
+- Bridge: `telemetryEvent` message routes into `track()` in both
+  `messageHandler` and `iskamMessageHandler`.
+
+Vitest + happy-dom. Then `npm run build`, `npm run typecheck`, `npm run lint`.
+
+## 10. Out of scope (YAGNI)
+
+- PostHog feature flags, A/B testing, surveys.
+- Session recording / heatmaps / autocapture.
+- Any per-component instrumentation beyond the taxonomy in §6 (add events later
+  as questions arise).
+- Server-side or content-script-direct ingestion (all egress is the iframe).

--- a/src/components/Onboarding/WelcomeModal.tsx
+++ b/src/components/Onboarding/WelcomeModal.tsx
@@ -1,21 +1,16 @@
 import { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'motion/react';
-import { Check, Info } from 'lucide-react';
+import { Check } from 'lucide-react';
 import { ReisLogo } from '../ReisLogo';
 import { IndexedDBService } from '../../services/storage';
 import { useTranslation } from '../../hooks/useTranslation';
-import { useOutlookSync } from '../../hooks/data/useOutlookSync';
-import { useDriveBackup } from '../../hooks/data/useDriveBackup';
 import { useAppStore } from '../../store/useAppStore';
 import { logError } from '../../utils/reportError';
 
 export function WelcomeModal() {
     const [isVisible, setIsVisible] = useState(false);
-    const [step, setStep] = useState<1 | 2>(1);
     const { t, language } = useTranslation();
     const setLanguage = useAppStore(state => state.setLanguage);
-    const { isEnabled, toggle, isLoading } = useOutlookSync();
-    const { connected: driveConnected, connect: driveConnect, busy: driveBusy } = useDriveBackup();
 
     useEffect(() => {
         async function checkWelcome() {
@@ -32,19 +27,12 @@ export function WelcomeModal() {
         checkWelcome();
     }, []);
 
-    const handleNext = () => {
-        if (isEnabled) {
-            handleDismiss();
-        } else {
-            setStep(2);
-        }
-    };
-
     const handleDismiss = () => {
         setIsVisible(false);
         IndexedDBService.set('meta', 'welcome_dismissed', true).catch(e => logError('WelcomeModal.dismiss', e));
     };
 
+    const handleNext = () => handleDismiss();
 
     return (
         <AnimatePresence>
@@ -56,144 +44,58 @@ export function WelcomeModal() {
                         exit={{ opacity: 0 }}
                         className="fixed inset-0 bg-black/60 backdrop-blur-md z-[200]"
                     />
-                    
+
                     <motion.div
                         initial={{ opacity: 0, scale: 0.9, y: 30 }}
                         animate={{ opacity: 1, scale: 1, y: 0 }}
                         exit={{ opacity: 0, scale: 0.9, y: 30 }}
                         transition={{ duration: 0.4, type: "spring", bounce: 0.3 }}
-                        className={`fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-[201] w-[calc(100%-2rem)] transition-all duration-300 ${step === 1 ? 'max-w-sm sm:max-w-lg' : 'max-w-sm md:max-w-2xl lg:max-w-3xl'}`}
+                        className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-[201] w-[calc(100%-2rem)] max-w-sm sm:max-w-lg"
                     >
                         <div className="bg-base-100 rounded-3xl shadow-2xl border border-base-200 p-6 sm:p-8 flex flex-col gap-4 max-h-[90dvh] overflow-y-auto">
                             <AnimatePresence mode="wait">
-                                {step === 1 ? (
-                                    <motion.div
-                                        key="step1"
-                                        initial={{ opacity: 0, x: -10 }}
-                                        animate={{ opacity: 1, x: 0 }}
-                                        exit={{ opacity: 0, x: 10 }}
-                                        className="text-center"
-                                    >
-                                        <div className="w-12 h-12 rounded-xl overflow-hidden mx-auto mb-4 shadow-md flex items-center justify-center">
-                                            <ReisLogo className="w-full h-full" />
-                                        </div>
-                                        <h2 className="text-xl font-bold text-base-content mb-2 tracking-tight">
-                                            {t('onboarding.welcome')}
-                                        </h2>
-                                        <p className="text-sm text-base-content/70 mb-5 leading-relaxed">
-                                            {t('onboarding.description')}
-                                        </p>
+                                <motion.div
+                                    key="step1"
+                                    initial={{ opacity: 0, x: -10 }}
+                                    animate={{ opacity: 1, x: 0 }}
+                                    exit={{ opacity: 0, x: 10 }}
+                                    className="text-center"
+                                >
+                                    <div className="w-12 h-12 rounded-xl overflow-hidden mx-auto mb-4 shadow-md flex items-center justify-center">
+                                        <ReisLogo className="w-full h-full" />
+                                    </div>
+                                    <h2 className="text-xl font-bold text-base-content mb-2 tracking-tight">
+                                        {t('onboarding.welcome')}
+                                    </h2>
+                                    <p className="text-sm text-base-content/70 mb-5 leading-relaxed">
+                                        {t('onboarding.description')}
+                                    </p>
 
-                                        <div className="flex justify-center mb-6">
-                                            <div className="join bg-base-300/50 p-0.5 rounded-lg border border-base-300">
-                                                <button 
-                                                    onClick={() => setLanguage('cz')} 
-                                                    className={`join-item btn btn-xs border-none h-6 min-h-0 w-12 ${language === 'cz' ? 'btn-primary shadow-sm' : 'btn-ghost opacity-50 hover:opacity-100'}`}
-                                                >
-                                                    CZ
-                                                </button>
-                                                <button 
-                                                    onClick={() => setLanguage('en')} 
-                                                    className={`join-item btn btn-xs border-none h-6 min-h-0 w-12 ${language === 'en' ? 'btn-primary shadow-sm' : 'btn-ghost opacity-50 hover:opacity-100'}`}
-                                                >
-                                                    EN
-                                                </button>
-                                            </div>
-                                        </div>
-
-                                        <button
-                                            onClick={handleNext}
-                                            className="btn btn-primary btn-md btn-wide rounded-xl shadow-md gap-2"
-                                        >
-                                            {t('onboarding.getStarted')}
-                                            <Check className="w-4 h-4" />
-                                        </button>
-                                    </motion.div>
-                                ) : (
-                                    <motion.div
-                                        key="step2"
-                                        initial={{ opacity: 0, scale: 0.95 }}
-                                        animate={{ opacity: 1, scale: 1 }}
-                                        exit={{ opacity: 0, scale: 0.95 }}
-                                        className="flex flex-col md:flex-row items-center md:items-stretch gap-8 lg:gap-12"
-                                    >
-                                        <div className="w-full md:w-1/2 flex items-center justify-center">
-                                            <div className="relative group">
-                                                <div className="absolute -inset-1 bg-gradient-to-r from-primary/20 to-accent/20 rounded-3xl blur opacity-75 group-hover:opacity-100 transition duration-1000 group-hover:duration-200"></div>
-                                                <img
-                                                    src="/calendar_phone.png"
-                                                    alt="Phone Sync"
-                                                    className="w-auto h-auto max-h-[38vh] sm:w-full sm:max-w-[280px] sm:max-h-none rounded-2xl shadow-2xl border border-white/10 relative z-10"
-                                                />
-                                            </div>
-                                        </div>
-                                        
-                                        <div className="w-full md:w-1/2 flex flex-col justify-center text-center md:text-left gap-6">
-                                            <div className="space-y-3">
-                                                <h3 className="text-2xl font-black text-base-content tracking-tight leading-none">{t('onboarding.syncTitle')}</h3>
-                                                <p className="text-sm text-base-content/70 font-medium leading-relaxed whitespace-pre-line">{t('onboarding.syncDescription')}</p>
-                                            </div>
-
-                                            <div className="space-y-4">
-                                                <div className="w-full flex items-center justify-between py-3.5 px-5 bg-base-200/80 backdrop-blur-sm rounded-2xl border border-base-300/50 shadow-inner">
-                                                    <div className="flex flex-col items-start translate-y-0.5">
-                                                        <span className="text-sm font-bold tracking-tight">{t('onboarding.syncToggle')}</span>
-                                                    </div>
-                                                    <input 
-                                                        type="checkbox" 
-                                                        className="toggle toggle-primary toggle-md"
-                                                        checked={!!isEnabled}
-                                                        onChange={toggle}
-                                                        disabled={isLoading}
-                                                    />
-                                                </div>
-
-                                                <AnimatePresence>
-                                                    {isEnabled && (
-                                                        <motion.div
-                                                            initial={{ opacity: 0, y: -10 }}
-                                                            animate={{ opacity: 1, y: 0 }}
-                                                            exit={{ opacity: 0, y: -10 }}
-                                                            className="w-full"
-                                                        >
-                                                            <div className="flex items-center gap-2 text-primary/80 px-1">
-                                                                <Info className="w-4 h-4" />
-                                                                <p className="text-xs italic font-semibold">
-                                                                    {t('onboarding.syncCoffeeBreak')}
-                                                                </p>
-                                                            </div>
-                                                        </motion.div>
-                                                    )}
-                                                </AnimatePresence>
-
-                                                <div className="w-full flex items-center justify-between gap-3 py-3.5 px-5 bg-base-200/80 backdrop-blur-sm rounded-2xl border border-base-300/50 shadow-inner">
-                                                    <div className="flex flex-col items-start text-left">
-                                                        <span className="text-sm font-bold tracking-tight">{t('onboarding.driveTitle')}</span>
-                                                        <span className="text-xs text-base-content/60 leading-snug">{t('onboarding.driveDescription')}</span>
-                                                    </div>
-                                                    {driveConnected ? (
-                                                        <span className="badge badge-success gap-1 shrink-0"><Check className="w-3 h-3" />{t('drive.connected')}</span>
-                                                    ) : (
-                                                        <button
-                                                            onClick={driveConnect}
-                                                            disabled={driveBusy || driveConnected === null}
-                                                            className="btn btn-primary btn-sm rounded-xl shrink-0"
-                                                        >
-                                                            {driveBusy ? <span className="loading loading-spinner loading-xs" /> : t('drive.connect')}
-                                                        </button>
-                                                    )}
-                                                </div>
-                                            </div>
-
+                                    <div className="flex justify-center mb-6">
+                                        <div className="join bg-base-300/50 p-0.5 rounded-lg border border-base-300">
                                             <button
-                                                onClick={handleDismiss}
-                                                className="btn btn-primary btn-lg w-full rounded-2xl font-bold tracking-wider shadow-xl shadow-primary/20 hover:scale-[1.02] active:scale-[0.98] transition-all"
+                                                onClick={() => setLanguage('cz')}
+                                                className={`join-item btn btn-xs border-none h-6 min-h-0 w-12 ${language === 'cz' ? 'btn-primary shadow-sm' : 'btn-ghost opacity-50 hover:opacity-100'}`}
                                             >
-                                                {t('common.close')}
+                                                CZ
+                                            </button>
+                                            <button
+                                                onClick={() => setLanguage('en')}
+                                                className={`join-item btn btn-xs border-none h-6 min-h-0 w-12 ${language === 'en' ? 'btn-primary shadow-sm' : 'btn-ghost opacity-50 hover:opacity-100'}`}
+                                            >
+                                                EN
                                             </button>
                                         </div>
-                                    </motion.div>
-                                )}
+                                    </div>
+
+                                    <button
+                                        onClick={handleNext}
+                                        className="btn btn-primary btn-md btn-wide rounded-xl shadow-md gap-2"
+                                    >
+                                        {t('onboarding.getStarted')}
+                                        <Check className="w-4 h-4" />
+                                    </button>
+                                </motion.div>
                             </AnimatePresence>
                         </div>
                     </motion.div>

--- a/src/components/Onboarding/__tests__/WelcomeModal.test.tsx
+++ b/src/components/Onboarding/__tests__/WelcomeModal.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+
+vi.mock('../../../services/storage', () => ({
+    IndexedDBService: { get: vi.fn().mockResolvedValue(undefined), set: vi.fn().mockResolvedValue(undefined) },
+}));
+vi.mock('../../../hooks/useTranslation', () => ({
+    useTranslation: () => ({ t: (k: string) => k, language: 'cz' }),
+}));
+vi.mock('../../../store/useAppStore', () => ({
+    useAppStore: (sel: (s: { setLanguage: () => void }) => unknown) => sel({ setLanguage: vi.fn() }),
+}));
+
+import { WelcomeModal } from '../WelcomeModal';
+
+describe('WelcomeModal', () => {
+    beforeEach(() => { vi.clearAllMocks(); vi.useFakeTimers(); });
+
+    it('shows welcome + language only, with no Outlook or Drive ask', async () => {
+        render(<WelcomeModal />);
+        await act(async () => { await Promise.resolve(); vi.advanceTimersByTime(900); });
+        expect(screen.getByText('onboarding.welcome')).toBeInTheDocument();
+        expect(screen.getByText('onboarding.getStarted')).toBeInTheDocument();
+        expect(screen.queryByText('onboarding.syncTitle')).not.toBeInTheDocument();
+        expect(screen.queryByText('onboarding.driveTitle')).not.toBeInTheDocument();
+        vi.useRealTimers();
+    });
+
+    it('has no step-2 commitment-ask machinery', async () => {
+        render(<WelcomeModal />);
+        await act(async () => { await Promise.resolve(); vi.advanceTimersByTime(900); });
+        expect(screen.queryByText('onboarding.syncToggle')).not.toBeInTheDocument();
+        expect(screen.queryByText('drive.connect')).not.toBeInTheDocument();
+        vi.useRealTimers();
+    });
+});

--- a/src/components/WeeklyCalendar/BuildingWeek.tsx
+++ b/src/components/WeeklyCalendar/BuildingWeek.tsx
@@ -1,0 +1,43 @@
+import { requestData } from '../../api/proxyClient';
+import { useTranslation } from '../../hooks/useTranslation';
+
+interface BuildingWeekProps {
+    /** True once the 10s handshake backstop fired with still no schedule. */
+    timedOut: boolean;
+}
+
+export function BuildingWeek({ timedOut }: BuildingWeekProps) {
+    const { t } = useTranslation();
+
+    if (timedOut) {
+        return (
+            <div className="flex flex-col items-center justify-center gap-3 py-16 text-center">
+                <p className="text-sm font-semibold text-base-content/70">{t('calendar.buildingWeekFailed')}</p>
+                <button className="btn btn-primary btn-sm rounded-field" onClick={() => requestData('all')}>
+                    {t('calendar.retry')}
+                </button>
+            </div>
+        );
+    }
+
+    return (
+        <div className="flex flex-col gap-4 p-4" aria-busy="true" aria-live="polite">
+            <div className="flex items-center gap-2.5">
+                <span className="relative flex h-2.5 w-2.5">
+                    <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-primary opacity-60 motion-reduce:hidden" />
+                    <span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-primary" />
+                </span>
+                <div>
+                    <p className="text-sm font-bold leading-none">{t('calendar.buildingWeek')}</p>
+                    <p className="mt-1 text-xs text-base-content/50">{t('calendar.buildingWeekSub')}</p>
+                </div>
+            </div>
+            <div className="flex flex-col gap-2">
+                <div className="skeleton h-14 rounded-field" />
+                <div className="skeleton h-10 rounded-field" />
+                <div className="skeleton h-16 rounded-field" />
+                <div className="skeleton h-10 rounded-field" />
+            </div>
+        </div>
+    );
+}

--- a/src/components/WeeklyCalendar/OutlookNudge.tsx
+++ b/src/components/WeeklyCalendar/OutlookNudge.tsx
@@ -1,0 +1,48 @@
+import { useState, useEffect } from 'react';
+import { X, Smartphone } from 'lucide-react';
+import { IndexedDBService } from '../../services/storage';
+import { useTranslation } from '../../hooks/useTranslation';
+import { useOutlookSync } from '../../hooks/data/useOutlookSync';
+import { logError } from '../../utils/reportError';
+
+export function OutlookNudge() {
+    const { t } = useTranslation();
+    const { isEnabled, toggle, isLoading } = useOutlookSync();
+    const [visible, setVisible] = useState(false);
+
+    useEffect(() => {
+        IndexedDBService.get('meta', 'outlook_nudge_dismissed')
+            .then(dismissed => { if (!dismissed) setVisible(true); })
+            .catch(e => logError('OutlookNudge.check', e));
+    }, []);
+
+    const dismiss = () => {
+        setVisible(false);
+        IndexedDBService.set('meta', 'outlook_nudge_dismissed', true).catch(e => logError('OutlookNudge.dismiss', e));
+    };
+
+    if (!visible || isEnabled) return null;
+
+    return (
+        <div className="relative mb-2 rounded-field border border-accent/25 bg-accent/10 px-3 py-2.5 pr-9">
+            <button
+                aria-label={t('common.close')}
+                className="btn btn-ghost btn-xs btn-circle absolute right-1.5 top-1.5"
+                onClick={dismiss}
+            >
+                <X className="h-3.5 w-3.5" />
+            </button>
+            <p className="flex items-center gap-1.5 text-xs font-bold">
+                <Smartphone className="h-3.5 w-3.5" /> {t('calendar.outlookNudgeTitle')}
+            </p>
+            <p className="mt-0.5 text-[11px] text-base-content/60">{t('calendar.outlookNudgeBody')}</p>
+            <button
+                className="btn btn-accent btn-xs mt-2 rounded-field"
+                disabled={isLoading}
+                onClick={toggle}
+            >
+                {t('calendar.outlookNudgeCta')}
+            </button>
+        </div>
+    );
+}

--- a/src/components/WeeklyCalendar/__tests__/BuildingWeek.test.tsx
+++ b/src/components/WeeklyCalendar/__tests__/BuildingWeek.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+const requestData = vi.fn();
+vi.mock('../../../api/proxyClient', () => ({ requestData: (t: string) => requestData(t) }));
+vi.mock('../../../hooks/useTranslation', () => ({
+    useTranslation: () => ({ t: (k: string) => k, language: 'en' }),
+}));
+
+import { BuildingWeek } from '../BuildingWeek';
+
+describe('BuildingWeek', () => {
+    it('shows the building message while loading (not timed out)', () => {
+        render(<BuildingWeek timedOut={false} />);
+        expect(screen.getByText('calendar.buildingWeek')).toBeInTheDocument();
+        expect(screen.queryByText('calendar.retry')).not.toBeInTheDocument();
+    });
+
+    it('shows a retry button after timeout and re-requests data on click', () => {
+        render(<BuildingWeek timedOut={true} />);
+        expect(screen.getByText('calendar.buildingWeekFailed')).toBeInTheDocument();
+        fireEvent.click(screen.getByText('calendar.retry'));
+        expect(requestData).toHaveBeenCalledWith('all');
+    });
+});

--- a/src/components/WeeklyCalendar/__tests__/OutlookNudge.test.tsx
+++ b/src/components/WeeklyCalendar/__tests__/OutlookNudge.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+
+vi.mock('../../../services/storage', () => ({
+    IndexedDBService: {
+        get: vi.fn().mockResolvedValue(undefined),
+        set: vi.fn().mockResolvedValue(undefined),
+    },
+}));
+vi.mock('../../../hooks/useTranslation', () => ({ useTranslation: () => ({ t: (k: string) => k, language: 'en' }) }));
+const toggle = vi.fn();
+vi.mock('../../../hooks/data/useOutlookSync', () => ({ useOutlookSync: () => ({ isEnabled: false, toggle, isLoading: false }) }));
+
+import { IndexedDBService } from '../../../services/storage';
+import { OutlookNudge } from '../OutlookNudge';
+
+const idb = IndexedDBService as unknown as { get: ReturnType<typeof vi.fn>; set: ReturnType<typeof vi.fn> };
+
+describe('OutlookNudge', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('renders the nudge when not previously dismissed', async () => {
+        idb.get.mockResolvedValue(undefined);
+        render(<OutlookNudge />);
+        expect(await screen.findByText('calendar.outlookNudgeTitle')).toBeInTheDocument();
+    });
+
+    it('persists dismissal and hides on close', async () => {
+        idb.get.mockResolvedValue(undefined);
+        render(<OutlookNudge />);
+        const close = await screen.findByLabelText('common.close');
+        await act(async () => { fireEvent.click(close); });
+        expect(idb.set).toHaveBeenCalledWith('meta', 'outlook_nudge_dismissed', true);
+        await waitFor(() => expect(screen.queryByText('calendar.outlookNudgeTitle')).not.toBeInTheDocument());
+    });
+
+    it('does not render when already dismissed', async () => {
+        idb.get.mockResolvedValue(true);
+        render(<OutlookNudge />);
+        await act(async () => { await Promise.resolve(); });
+        expect(screen.queryByText('calendar.outlookNudgeTitle')).not.toBeInTheDocument();
+    });
+});

--- a/src/components/WeeklyCalendar/index.tsx
+++ b/src/components/WeeklyCalendar/index.tsx
@@ -16,6 +16,7 @@ import { useHintStatus } from '../../hooks/ui/useHintStatus';
 import { useIsMobile } from '../../hooks/ui/useIsMobile';
 import { useTranslation } from '../../hooks/useTranslation';
 import { BuildingWeek } from './BuildingWeek';
+import { OutlookNudge } from './OutlookNudge';
 import type { BlockLesson, CalendarCustomEvent } from '../../types/calendarTypes';
 
 const TOTAL_HOURS = 14;
@@ -128,6 +129,7 @@ export function WeeklyCalendar({ initialDate = new Date(), onPrevWeek, onNextWee
     if (isMobile) {
         return (
             <div className="flex h-full overflow-hidden flex-col font-inter bg-base-100">
+                <OutlookNudge />
                 <DailyView
                     weekDates={weekDates}
                     lessonsByDay={lessonsByDay}
@@ -178,6 +180,7 @@ export function WeeklyCalendar({ initialDate = new Date(), onPrevWeek, onNextWee
 
     return (
         <div className="flex h-full overflow-hidden flex-col font-inter bg-base-100">
+            <OutlookNudge />
             {/* Study Jam Time Selection Hint Banner */}
             <AnimatePresence>
                 {isSelectingTime && (

--- a/src/components/WeeklyCalendar/index.tsx
+++ b/src/components/WeeklyCalendar/index.tsx
@@ -15,6 +15,7 @@ import { CustomEventModal } from '../CustomEventModal';
 import { useHintStatus } from '../../hooks/ui/useHintStatus';
 import { useIsMobile } from '../../hooks/ui/useIsMobile';
 import { useTranslation } from '../../hooks/useTranslation';
+import { BuildingWeek } from './BuildingWeek';
 import type { BlockLesson, CalendarCustomEvent } from '../../types/calendarTypes';
 
 const TOTAL_HOURS = 14;
@@ -27,7 +28,7 @@ export function WeeklyCalendar({ initialDate = new Date(), onPrevWeek, onNextWee
     const pendingTimeSelection = useAppStore((state) => state.pendingTimeSelection);
     const setPendingTimeSelection = useAppStore((state) => state.setPendingTimeSelection);
     const isMobile = useIsMobile();
-    const { weekDates, lessonsByDay, holidaysByDay, todayIndex, showSkeleton: dataLoading, weekdayScheduleData, isOutsideTeachingPeriod } = useCalendarData(initialDate);
+    const { weekDates, lessonsByDay, holidaysByDay, todayIndex, showSkeleton: dataLoading, scheduleData, weekdayScheduleData, isOutsideTeachingPeriod } = useCalendarData(initialDate);
     const { t } = useTranslation();
     const [selected, setSelected] = useState<BlockLesson | null>(null);
     const { isSeen, markSeen } = useHintStatus('calendar_event_click');
@@ -37,9 +38,13 @@ export function WeeklyCalendar({ initialDate = new Date(), onPrevWeek, onNextWee
     const addCalendarCustomEvent = useAppStore(state => state.addCalendarCustomEvent);
     const updateCalendarCustomEvent = useAppStore(state => state.updateCalendarCustomEvent);
     const removeCalendarCustomEvent = useAppStore(state => state.removeCalendarCustomEvent);
+    const handshakeTimedOut = useAppStore((state) => state.syncStatus.handshakeTimedOut);
+    const isSyncing = useAppStore((state) => state.syncStatus.isSyncing);
 
     // Show skeletons if either data is loading (initial) or language is still being determined
     const showSkeleton = dataLoading || isLanguageLoading;
+
+    const scheduleLoadFailed = !!handshakeTimedOut && !isSyncing && scheduleData.length === 0;
 
     const targetEventPosition = useMemo(() => {
         if (showSkeleton || isSeen) return null;
@@ -111,6 +116,14 @@ export function WeeklyCalendar({ initialDate = new Date(), onPrevWeek, onNextWee
         setSelected(lesson);
         if (!isSeen) markSeen();
     };
+
+    if (dataLoading || scheduleLoadFailed) {
+        return (
+            <div className="h-full">
+                <BuildingWeek timedOut={scheduleLoadFailed} />
+            </div>
+        );
+    }
 
     if (isMobile) {
         return (

--- a/src/components/WeeklyCalendar/index.tsx
+++ b/src/components/WeeklyCalendar/index.tsx
@@ -29,7 +29,7 @@ export function WeeklyCalendar({ initialDate = new Date(), onPrevWeek, onNextWee
     const pendingTimeSelection = useAppStore((state) => state.pendingTimeSelection);
     const setPendingTimeSelection = useAppStore((state) => state.setPendingTimeSelection);
     const isMobile = useIsMobile();
-    const { weekDates, lessonsByDay, holidaysByDay, todayIndex, showSkeleton: dataLoading, scheduleData, weekdayScheduleData, isOutsideTeachingPeriod } = useCalendarData(initialDate);
+    const { weekDates, lessonsByDay, holidaysByDay, todayIndex, showSkeleton: dataLoading, weekdayScheduleData, isOutsideTeachingPeriod, hasAnySchedule } = useCalendarData(initialDate);
     const { t } = useTranslation();
     const [selected, setSelected] = useState<BlockLesson | null>(null);
     const { isSeen, markSeen } = useHintStatus('calendar_event_click');
@@ -45,7 +45,7 @@ export function WeeklyCalendar({ initialDate = new Date(), onPrevWeek, onNextWee
     // Show skeletons if either data is loading (initial) or language is still being determined
     const showSkeleton = dataLoading || isLanguageLoading;
 
-    const scheduleLoadFailed = !!handshakeTimedOut && !isSyncing && scheduleData.length === 0;
+    const scheduleLoadFailed = !!handshakeTimedOut && !isSyncing && !hasAnySchedule;
 
     const targetEventPosition = useMemo(() => {
         if (showSkeleton || isSeen) return null;

--- a/src/components/WeeklyCalendar/useCalendarData.ts
+++ b/src/components/WeeklyCalendar/useCalendarData.ts
@@ -180,7 +180,8 @@ export function useCalendarData(initialDate: Date) {
         weekdayScheduleData,
         isOutsideTeachingPeriod,
         isScheduleLoaded,
-        isExamsLoaded
+        isExamsLoaded,
+        hasAnySchedule: (storedSchedule?.length ?? 0) > 0,
     };
 }
 

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -191,7 +191,6 @@
     "buildingWeekSub": "Tvůj rozvrh bude hotový za pár vteřin.",
     "buildingWeekFailed": "Rozvrh se nepodařilo načíst.",
     "retry": "Zkusit znovu",
-    "loadingMaterials": "načítám materiály…",
     "outlookNudgeTitle": "Chceš rozvrh v mobilu?",
     "outlookNudgeBody": "Synchronizuj rozvrh do kalendáře v Outlooku.",
     "outlookNudgeCta": "Nastavit sync"

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -186,7 +186,15 @@
     "selectedTime": "Vybráno: {time}",
     "clickFreeSlot": "Klikněte na volné místo v kalendáři",
     "pickTime": "Vyber čas:",
-    "publicHoliday": "Státní svátek"
+    "publicHoliday": "Státní svátek",
+    "buildingWeek": "Sestavujeme tvůj týden…",
+    "buildingWeekSub": "Tvůj rozvrh bude hotový za pár vteřin.",
+    "buildingWeekFailed": "Rozvrh se nepodařilo načíst.",
+    "retry": "Zkusit znovu",
+    "loadingMaterials": "načítám materiály…",
+    "outlookNudgeTitle": "Chceš rozvrh v mobilu?",
+    "outlookNudgeBody": "Synchronizuj rozvrh do kalendáře v Outlooku.",
+    "outlookNudgeCta": "Nastavit sync"
   },
   "exams": {
     "title": "Moje zkoušky",
@@ -487,7 +495,6 @@
     "syncTitle": "Sync do mobilu (Outlook)",
     "syncDescription": "1. Otevři Outlook na mobilu\n2. Přejdi na záložku \"Kalendář\"",
     "syncToggle": "Aktivovat Sync",
-    "syncCoffeeBreak": "Sync trvá přibližně 15 min.",
     "driveTitle": "Zálohovat soubory na Disk",
     "driveDescription": "Zrcadli studijní materiály z tohoto semestru na svůj Google Disk."
   },

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -156,7 +156,6 @@
     "buildingWeekSub": "Your schedule will be ready in a few seconds.",
     "buildingWeekFailed": "Couldn't load your schedule.",
     "retry": "Try again",
-    "loadingMaterials": "loading materials…",
     "outlookNudgeTitle": "Want this on your phone?",
     "outlookNudgeBody": "Sync your schedule to your Outlook calendar.",
     "outlookNudgeCta": "Set up sync"

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -151,7 +151,15 @@
     "selectedTime": "Selected: {time}",
     "clickFreeSlot": "Click a free slot in the calendar",
     "pickTime": "Pick a time:",
-    "publicHoliday": "Public holiday"
+    "publicHoliday": "Public holiday",
+    "buildingWeek": "Building your week…",
+    "buildingWeekSub": "Your schedule will be ready in a few seconds.",
+    "buildingWeekFailed": "Couldn't load your schedule.",
+    "retry": "Try again",
+    "loadingMaterials": "loading materials…",
+    "outlookNudgeTitle": "Want this on your phone?",
+    "outlookNudgeBody": "Sync your schedule to your Outlook calendar.",
+    "outlookNudgeCta": "Set up sync"
   },
   "exams": {
     "title": "My Exams",
@@ -487,7 +495,6 @@
     "syncTitle": "Sync to Phone (Outlook)",
     "syncDescription": "1. Open Outlook on your phone\n2. Go to the \"Calendar\" tab",
     "syncToggle": "Activate Sync",
-    "syncCoffeeBreak": "Sync takes about 15 min.",
     "driveTitle": "Back up files to Drive",
     "driveDescription": "Mirror this semester's study materials to your Google Drive."
   },

--- a/src/injector/__tests__/scheduleFirst.test.ts
+++ b/src/injector/__tests__/scheduleFirst.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { SyncUpdateMessage } from '../../types/messages';
+
+vi.mock('../iframeManager', () => ({ sendToIframe: vi.fn() }));
+
+import { sendToIframe } from '../iframeManager';
+import { emitScheduleFirst } from '../syncService';
+
+describe('emitScheduleFirst', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('sends a schedule-only REIS_SYNC_UPDATE with isSyncing true', () => {
+        const schedule = [{ id: 'x' }];
+        emitScheduleFirst(schedule, 1234);
+        expect(sendToIframe).toHaveBeenCalledTimes(1);
+        const msg = vi.mocked(sendToIframe).mock.calls[0][0] as SyncUpdateMessage;
+        expect(msg.type).toBe('REIS_SYNC_UPDATE');
+        expect(msg.data.schedule).toBe(schedule);
+        expect(msg.data.isSyncing).toBe(true);
+        expect(msg.data.lastSync).toBe(1234);
+        expect(msg.data.subjects).toBeUndefined();
+        expect(msg.data.exams).toBeUndefined();
+    });
+
+    it('does not emit when schedule is empty', () => {
+        emitScheduleFirst([], 1234);
+        expect(sendToIframe).not.toHaveBeenCalled();
+    });
+});

--- a/src/injector/syncService.ts
+++ b/src/injector/syncService.ts
@@ -34,9 +34,9 @@ export let cachedData: SyncedData = { lastSync: 0 };
 
 // Emit the student's schedule the instant it resolves — before the rest of the
 // sync batch settles — so the calendar paints in ~1–3s on first open.
-export function emitScheduleFirst(schedule: unknown[], lastSync: number) {
+export function emitScheduleFirst(schedule: unknown[] | undefined, lastSync: number) {
     if (!schedule || schedule.length === 0) return;
-    sendToIframe(Messages.syncUpdate({ schedule: schedule as never, isSyncing: true, lastSync }));
+    sendToIframe(Messages.syncUpdate({ schedule, isSyncing: true, lastSync }));
 }
 export let isSyncing = false;
 
@@ -116,7 +116,7 @@ export async function syncAllData() {
         // before waiting for the rest of the batch to settle.
         const earlyLastSync = Date.now();
         const schedulePromise = fetchFullSemesterSchedule().then((s) => {
-            if (s) emitScheduleFirst(s as unknown[], earlyLastSync);
+            emitScheduleFirst(s as unknown[] | undefined, earlyLastSync);
             return s;
         });
         const [fullSchedule, exams, subjects, studyPlan, studyStats, cvicneTests, odevzdavarnyResult, pastSubjects] = await Promise.allSettled([

--- a/src/injector/syncService.ts
+++ b/src/injector/syncService.ts
@@ -31,6 +31,13 @@ import type { ParsedFile, SubjectsData } from "../types/documents";
 
 const limit = pLimit(3);
 export let cachedData: SyncedData = { lastSync: 0 };
+
+// Emit the student's schedule the instant it resolves — before the rest of the
+// sync batch settles — so the calendar paints in ~1–3s on first open.
+export function emitScheduleFirst(schedule: unknown[], lastSync: number) {
+    if (!schedule || schedule.length === 0) return;
+    sendToIframe(Messages.syncUpdate({ schedule: schedule as never, isSyncing: true, lastSync }));
+}
 export let isSyncing = false;
 
 /** Latest notes snapshot pushed from the iframe (it owns the notes IDB). */
@@ -105,8 +112,15 @@ export async function syncAllData() {
             : Promise.resolve(null);
 
         // Phase 2b: Full schedule + exams in parallel (subjects/studyPlan/studyStats re-uses already-started promises)
+        // Start schedule fetch early so we can emit it the moment it resolves,
+        // before waiting for the rest of the batch to settle.
+        const earlyLastSync = Date.now();
+        const schedulePromise = fetchFullSemesterSchedule().then((s) => {
+            if (s) emitScheduleFirst(s as unknown[], earlyLastSync);
+            return s;
+        });
         const [fullSchedule, exams, subjects, studyPlan, studyStats, cvicneTests, odevzdavarnyResult, pastSubjects] = await Promise.allSettled([
-            fetchFullSemesterSchedule(),
+            schedulePromise,
             fetchDualLanguageExams(),
             subjectsPromise,
             studyPlanPromise,


### PR DESCRIPTION
## Summary

Make a brand-new student see their **real class schedule within ~2s of first open**, with no commitment ask before value — built for the Fall 2026 campus event that could bring 500+ new users at once.

- **Schedule-first paint** (`syncService.ts`): emit a schedule-only `REIS_SYNC_UPDATE` the instant the schedule resolves, before the rest of the 8-way sync batch settles. The iframe already applies partial schedule updates, so the calendar paints early. Idempotent with the later full update.
- **Branded "building your week" state** (`BuildingWeek.tsx`): replaces the generic skeleton on first run so the wait reads as construction, not "broken". Includes a retry affordance, gated so a healthy long sync never shows a false "couldn't load".
- **Deferred commitment asks** (`WelcomeModal.tsx`): collapsed to one welcome screen; the Outlook + Google Drive asks no longer block a value-less new user (204→101 lines).
- **Dismissible Outlook nudge** (`OutlookNudge.tsx`): the Outlook ask resurfaces in-calendar *after* the schedule paints; dismissal persists.
- **Honest copy**: removed the "sync takes ~15 min" coffee-break framing; progressive first-run strings (cs/en).
- **Regression fix**: schedule-load failure now keys off a session-level "schedule never arrived" signal, not the per-week filtered list — so returning users on a genuinely empty week keep the gentle empty-week overlay.

Spec, storyboard mockup, and implementation plan under `docs/superpowers/`.

## Test Plan
- [x] `npm run test:run` — 588 pass (9 new tests: schedule-first emit, BuildingWeek, OutlookNudge, WelcomeModal)
- [x] `npm run build` — clean
- [ ] Manual smoke on `is.mendelu.cz` with a fresh profile: one-screen welcome (no Drive/Outlook ask) → "building your week" → schedule paints before files finish → Outlook nudge appears after paint and dismisses permanently
- [ ] Verify an existing user navigating to an empty/future week sees the normal empty-week overlay, not a failure

## Notes
- Drive/OAuth internals and IS parsers untouched.
- Pre-existing `tsc` errors in Erasmus/Exam files are on `main`, unrelated to this branch.
- `aa20447` incidentally includes pre-existing `.claude/settings.json` + `.gitignore` changes (unrelated tooling config), left in by request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Simplified onboarding with single-screen welcome flow
  * Added "Building Your Week" loading indicator with retry option for schedule load failures
  * Added post-load reminder to sync calendar with Outlook

* **Documentation**
  * Added specification for optimized initial data load experience
  * Added specification for product analytics implementation

* **Tests**
  * Added test coverage for onboarding and calendar UI components

* **Chores**
  * Updated localization strings
  * Configuration and build system updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->