### PR TITLE
fix(sync): faster first paint + eliminate data-override gaps in the sync pipeline

### DIFF
--- a/src/components/ExamPanel/__tests__/useExamsData.test.ts
+++ b/src/components/ExamPanel/__tests__/useExamsData.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { shouldShowExamsSkeleton } from '../useExamsData';
+
+const base = {
+    examsCount: 0,
+    status: 'success' as const,
+    handshakeDone: true,
+    handshakeTimedOut: false,
+    isSyncing: false,
+    examsRefreshing: false,
+};
+
+describe('shouldShowExamsSkeleton', () => {
+    it('shows the empty state (no skeleton) once everything settled with no exams and no refresh', () => {
+        expect(shouldShowExamsSkeleton(base)).toBe(false);
+    });
+
+    it('keeps the skeleton up while a panel-triggered refresh is in flight, even after sync settled (the open-panel flash bug)', () => {
+        // status success, handshake done, not syncing — but the panel just fired its
+        // mount refresh. Without examsRefreshing in the rule this falls through to
+        // "nothing to display".
+        expect(shouldShowExamsSkeleton({ ...base, examsRefreshing: true })).toBe(true);
+    });
+
+    it('shows the skeleton while initially loading / before handshake / while syncing', () => {
+        expect(shouldShowExamsSkeleton({ ...base, status: 'loading' })).toBe(true);
+        expect(shouldShowExamsSkeleton({ ...base, status: 'idle' })).toBe(true);
+        expect(shouldShowExamsSkeleton({ ...base, handshakeDone: false })).toBe(true);
+        expect(shouldShowExamsSkeleton({ ...base, isSyncing: true })).toBe(true);
+    });
+
+    it('never shows the skeleton once exams are present', () => {
+        expect(shouldShowExamsSkeleton({ ...base, examsCount: 3, examsRefreshing: true, isSyncing: true })).toBe(false);
+    });
+
+    it('shows the empty state after the handshake timed out with no exams', () => {
+        expect(shouldShowExamsSkeleton({ ...base, handshakeDone: false, handshakeTimedOut: true })).toBe(false);
+    });
+});

--- a/src/components/ExamPanel/useExamsData.ts
+++ b/src/components/ExamPanel/useExamsData.ts
@@ -1,6 +1,30 @@
 import { useMemo } from 'react';
 import { useAppStore } from '../../store/useAppStore';
+import type { Status } from '../../store/types';
 import type { ExamSubject, ExamSection } from '../../types/exams';
+
+/**
+ * Decide whether the exams panel shows its loading skeleton (vs. the
+ * "nothing to display" empty state). Pure so it can be unit-tested without a
+ * store. The `examsRefreshing` term is what keeps the skeleton up while a
+ * panel-triggered refresh is in flight: on open the panel mounts and fires its
+ * own refresh after the background sync has already settled (status 'success',
+ * handshake done, not syncing), so without it an empty cache would flash the
+ * empty state before the freshly-fetched exams arrive.
+ */
+export function shouldShowExamsSkeleton(opts: {
+    examsCount: number;
+    status: Status;
+    handshakeDone: boolean;
+    handshakeTimedOut: boolean;
+    isSyncing: boolean;
+    examsRefreshing: boolean;
+}): boolean {
+    return opts.examsCount === 0 && (
+        opts.status === 'loading' || opts.status === 'idle' ||
+        (!opts.handshakeDone && !opts.handshakeTimedOut) || opts.isSyncing || opts.examsRefreshing
+    );
+}
 
 export function useExamsData() {
     const exams = useAppStore(s => s.exams.data);
@@ -8,6 +32,7 @@ export function useExamsData() {
     const handshakeDone = useAppStore(s => s.syncStatus.handshakeDone);
     const handshakeTimedOut = useAppStore(s => s.syncStatus.handshakeTimedOut);
     const isSyncing = useAppStore(s => s.syncStatus.isSyncing);
+    const examsRefreshing = useAppStore(s => s.examsRefreshing);
 
     const sections = useMemo(() => {
         const res: { subject: ExamSubject; section: ExamSection }[] = [];
@@ -19,10 +44,14 @@ export function useExamsData() {
         return res;
     }, [exams]);
 
-    const showSkeleton = exams.length === 0 && (
-        status === 'loading' || status === 'idle' ||
-        (!handshakeDone && !handshakeTimedOut) || isSyncing
-    );
+    const showSkeleton = shouldShowExamsSkeleton({
+        examsCount: exams.length,
+        status,
+        handshakeDone: !!handshakeDone,
+        handshakeTimedOut: !!handshakeTimedOut,
+        isSyncing,
+        examsRefreshing,
+    });
 
     return { exams, showSkeleton, sections };
 }

--- a/src/components/ExamPanel/useExamsData.ts
+++ b/src/components/ExamPanel/useExamsData.ts
@@ -47,8 +47,8 @@ export function useExamsData() {
     const showSkeleton = shouldShowExamsSkeleton({
         examsCount: exams.length,
         status,
-        handshakeDone: !!handshakeDone,
-        handshakeTimedOut: !!handshakeTimedOut,
+        handshakeDone: handshakeDone ?? false,
+        handshakeTimedOut: handshakeTimedOut ?? false,
         isSyncing,
         examsRefreshing,
     });

--- a/src/hooks/useAppLogic.ts
+++ b/src/hooks/useAppLogic.ts
@@ -128,7 +128,7 @@ export function useAppLogic() {
                     await IndexedDBService.set('study_plan', 'current', r.studyPlan);
                     useAppStore.getState().setStudyPlan(r.studyPlan);
                 }
-                if (r.studyStats) {
+                if (r.studyStats && typeof r.studyStats === 'object') {
                     await IndexedDBService.set('meta', 'study_stats', r.studyStats);
                     useAppStore.getState().setStudyStats(r.studyStats as StudyStats);
                 }

--- a/src/hooks/useAppLogic.ts
+++ b/src/hooks/useAppLogic.ts
@@ -15,7 +15,7 @@ import { sendTelemetry } from '../services/errorReporter/telemetry';
 import { logError } from '../utils/reportError';
 
 import { isDualLanguageStudyPlan } from '../types/studyPlan';
-import type { DualLanguageStudyPlan } from '../types/studyPlan';
+import type { DualLanguageStudyPlan, StudyStats } from '../types/studyPlan';
 import type { BlockLesson } from '../types/calendarTypes';
 import type { ExamSubject } from '../types/exams';
 import type { SubjectsData, ParsedFile, SyllabusRequirements, SubjectAttendance } from '../types/documents';
@@ -124,8 +124,14 @@ export function useAppLogic() {
                 }
 
 
-                if (r.studyPlan && isDualLanguageStudyPlan(r.studyPlan)) await IndexedDBService.set('study_plan', 'current', r.studyPlan);
-                if (r.studyStats) await IndexedDBService.set('meta', 'study_stats', r.studyStats);
+                if (r.studyPlan && isDualLanguageStudyPlan(r.studyPlan)) {
+                    await IndexedDBService.set('study_plan', 'current', r.studyPlan);
+                    useAppStore.getState().setStudyPlan(r.studyPlan);
+                }
+                if (r.studyStats) {
+                    await IndexedDBService.set('meta', 'study_stats', r.studyStats);
+                    useAppStore.getState().setStudyStats(r.studyStats as StudyStats);
+                }
                 if (r.cvicneTests?.length) {
                     const userParams = await IndexedDBService.get('meta', 'reis_user_params');
                     if (userParams?.studium) {
@@ -155,6 +161,10 @@ export function useAppLogic() {
                         });
                     }
                     await IndexedDBService.set('subjects', 'current', r.subjects);
+                    // Paint immediately off the early push instead of waiting for the
+                    // end-of-sync triggerRefresh → fetchSubjects IDB round-trip. Guarded
+                    // setter keeps a populated list if a later push arrives empty.
+                    useAppStore.getState().setSubjects(r.subjects);
                 }
 
                 if (r.attendance) {

--- a/src/injector/syncService.ts
+++ b/src/injector/syncService.ts
@@ -337,8 +337,12 @@ export function stopSyncService() {
 
 export async function refreshExams(): Promise<void> {
     const fresh = await fetchDualLanguageExams();
+    // Only overwrite the content-side cache with a non-empty result.
     if (fresh.length > 0) {
         cachedData = { ...cachedData, exams: fresh };
-        sendToIframe(Messages.syncUpdate({ exams: fresh, isSyncing, lastSync: cachedData.lastSync }));
     }
+    // Always push: a non-empty result replaces the list; an empty result is a
+    // no-op in the guarded setExams when exams already exist, but still clears
+    // the panel's "refreshing" spinner for students who genuinely have no exams.
+    sendToIframe(Messages.syncUpdate({ exams: fresh, isSyncing, lastSync: cachedData.lastSync }));
 }

--- a/src/store/guards.test.ts
+++ b/src/store/guards.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { isEmptyCollection, wouldWipePopulated } from './guards';
+
+describe('isEmptyCollection', () => {
+    it('treats null/undefined as empty', () => {
+        expect(isEmptyCollection(null)).toBe(true);
+        expect(isEmptyCollection(undefined)).toBe(true);
+    });
+
+    it('treats [] and {} as empty', () => {
+        expect(isEmptyCollection([])).toBe(true);
+        expect(isEmptyCollection({})).toBe(true);
+    });
+
+    it('treats populated array/record as non-empty', () => {
+        expect(isEmptyCollection([1])).toBe(false);
+        expect(isEmptyCollection({ a: 1 })).toBe(false);
+    });
+});
+
+describe('wouldWipePopulated', () => {
+    it('skips when incoming is empty but the store is populated', () => {
+        expect(wouldWipePopulated([], [1, 2])).toBe(true);
+        expect(wouldWipePopulated({}, { a: 1 })).toBe(true);
+    });
+
+    it('does not skip a null/undefined push without crashing (null-hardened)', () => {
+        expect(wouldWipePopulated(null, { a: 1 })).toBe(true);
+        expect(wouldWipePopulated(undefined, [1])).toBe(true);
+    });
+
+    it('allows the update when incoming has data', () => {
+        expect(wouldWipePopulated([1], [2, 3])).toBe(false);
+        expect(wouldWipePopulated({ a: 1 }, { b: 2 })).toBe(false);
+    });
+
+    it('allows an empty update when the store is also empty (first-load / no crash on null current)', () => {
+        expect(wouldWipePopulated([], [])).toBe(false);
+        expect(wouldWipePopulated({}, null)).toBe(false);
+        expect(wouldWipePopulated(null, undefined)).toBe(false);
+    });
+});

--- a/src/store/guards.ts
+++ b/src/store/guards.ts
@@ -1,0 +1,22 @@
+/**
+ * Gap guards shared by sync-driven store setters.
+ *
+ * A transient or failed IS Mendelu fetch can resolve to an empty array / empty
+ * record. Writing that straight into the store would wipe whatever is currently
+ * on screen, producing a flash of no-data before the next sync repopulates it.
+ *
+ * `wouldWipePopulated` returns true when the incoming value is empty but the
+ * store already holds data — the setter should then skip the update and keep
+ * the populated value until real new data arrives to replace it.
+ */
+
+type Collection = readonly unknown[] | Record<string, unknown> | null | undefined;
+
+export function isEmptyCollection(value: Collection): boolean {
+    if (!value) return true;
+    return Array.isArray(value) ? value.length === 0 : Object.keys(value).length === 0;
+}
+
+export function wouldWipePopulated(incoming: Collection, current: Collection): boolean {
+    return isEmptyCollection(incoming) && !isEmptyCollection(current);
+}

--- a/src/store/slices/__tests__/createScheduleSlice.test.ts
+++ b/src/store/slices/__tests__/createScheduleSlice.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createScheduleSlice } from '../createScheduleSlice';
+import type { BlockLesson } from '../../../types/calendarTypes';
+
+vi.mock('../../../services/storage', () => ({
+    IndexedDBService: { get: vi.fn(), set: vi.fn() },
+}));
+vi.mock('../../../utils/reportError', () => ({ logError: vi.fn() }));
+
+const lesson = (id: string) => ({ id } as unknown as BlockLesson);
+
+describe('createScheduleSlice.setSchedule', () => {
+    let set: ReturnType<typeof vi.fn>;
+    let get: ReturnType<typeof vi.fn>;
+    let slice: ReturnType<typeof createScheduleSlice>;
+
+    beforeEach(() => {
+        set = vi.fn((fn) => {
+            const result = typeof fn === 'function' ? fn(slice) : fn;
+            Object.assign(slice, result);
+        });
+        get = vi.fn(() => slice);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        slice = createScheduleSlice(set, get, {} as unknown as any);
+    });
+
+    it('replaces schedule with incoming non-empty data', () => {
+        slice.setSchedule([lesson('a')]);
+        expect(slice.schedule.data).toEqual([lesson('a')]);
+    });
+
+    it('does NOT wipe populated schedule when incoming is empty (gap guard)', () => {
+        slice.setSchedule([lesson('a'), lesson('b')]);
+        slice.setSchedule([]);
+        expect(slice.schedule.data).toHaveLength(2);
+    });
+
+    it('accepts an empty array when the store is already empty', () => {
+        slice.setSchedule([]);
+        expect(slice.schedule.data).toEqual([]);
+    });
+});

--- a/src/store/slices/__tests__/createStudyPlanSlice.test.ts
+++ b/src/store/slices/__tests__/createStudyPlanSlice.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createStudyPlanSlice } from '../createStudyPlanSlice';
+import type { DualLanguageStudyPlan, StudyStats } from '../../../types/studyPlan';
+
+vi.mock('../../../services/storage', () => ({
+    IndexedDBService: { get: vi.fn(), set: vi.fn() },
+}));
+
+const dualPlan = { cz: { semesters: [] }, en: { semesters: [] } } as unknown as DualLanguageStudyPlan;
+const stats = { totalCredits: 42 } as unknown as StudyStats;
+
+describe('createStudyPlanSlice setters', () => {
+    let set: ReturnType<typeof vi.fn>;
+    let get: ReturnType<typeof vi.fn>;
+    let slice: ReturnType<typeof createStudyPlanSlice>;
+
+    beforeEach(() => {
+        set = vi.fn((fn) => {
+            const result = typeof fn === 'function' ? fn(slice) : fn;
+            Object.assign(slice, result);
+        });
+        get = vi.fn(() => slice);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        slice = createStudyPlanSlice(set, get, {} as unknown as any);
+    });
+
+    it('setStudyPlan stores the dual-language plan and marks it loaded', () => {
+        slice.setStudyPlan(dualPlan);
+        expect(slice.studyPlanDual).toBe(dualPlan);
+        expect(slice.studyPlanLoaded).toBe(true);
+    });
+
+    it('setStudyStats stores the stats', () => {
+        slice.setStudyStats(stats);
+        expect(slice.studyStats).toBe(stats);
+    });
+
+    it('setStudyStats ignores a null/undefined push (keeps prior stats)', () => {
+        slice.setStudyStats(stats);
+        slice.setStudyStats(null as unknown as StudyStats);
+        expect(slice.studyStats).toBe(stats);
+    });
+});

--- a/src/store/slices/__tests__/createSubjectsSlice.test.ts
+++ b/src/store/slices/__tests__/createSubjectsSlice.test.ts
@@ -6,7 +6,7 @@ import { IndexedDBService } from '../../../services/storage';
 vi.mock('../../../services/storage', () => ({
     IndexedDBService: {
         get: vi.fn(),
-        set: vi.fn()
+        set: vi.fn(() => Promise.resolve())
     }
 }));
 
@@ -18,7 +18,7 @@ describe('createSubjectsSlice', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         set = vi.fn((fn) => {
-            const result = typeof fn === 'function' ? fn({ subjects: null, subjectsLoading: false }) : fn;
+            const result = typeof fn === 'function' ? fn(slice) : fn;
             Object.assign(slice, result);
         });
         get = vi.fn(() => slice);
@@ -49,5 +49,52 @@ describe('createSubjectsSlice', () => {
 
         expect(slice.subjectsLoading).toBe(false);
         expect(slice.subjects).toBeNull();
+    });
+
+    describe('setSubjects', () => {
+        const subjects = (codes: string[]) => ({
+            version: 1,
+            lastUpdated: 'now',
+            data: Object.fromEntries(codes.map(c => [c, { code: c }])),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        }) as any;
+
+        it('replaces subjects with incoming populated data', () => {
+            slice.setSubjects(subjects(['ABC']));
+            expect(Object.keys(slice.subjects!.data)).toEqual(['ABC']);
+        });
+
+        it('does NOT wipe populated subjects when incoming is empty/null (gap guard)', () => {
+            slice.setSubjects(subjects(['ABC', 'DEF']));
+            slice.setSubjects(null);
+            expect(Object.keys(slice.subjects!.data)).toHaveLength(2);
+            slice.setSubjects(subjects([]));
+            expect(Object.keys(slice.subjects!.data)).toHaveLength(2);
+        });
+    });
+
+    describe('setAttendance', () => {
+        const att = { ABC: [{ date: '1.1.' }] } as unknown as Parameters<typeof slice.setAttendance>[0];
+
+        it('stores incoming attendance', () => {
+            slice.setAttendance(att);
+            expect(slice.attendance).toEqual(att);
+        });
+
+        it('does NOT wipe populated attendance when incoming is empty (gap guard)', () => {
+            slice.setAttendance(att);
+            slice.setAttendance({});
+            expect(Object.keys(slice.attendance)).toHaveLength(1);
+        });
+    });
+
+    describe('setPastAttendance', () => {
+        const att = { ABC: [{ date: '1.1.' }] } as unknown as Parameters<typeof slice.setPastAttendance>[0];
+
+        it('does NOT wipe populated past attendance when incoming is empty (gap guard)', () => {
+            slice.setPastAttendance(att);
+            slice.setPastAttendance({});
+            expect(Object.keys(slice.pastAttendance)).toHaveLength(1);
+        });
     });
 });

--- a/src/store/slices/createExamSlice.ts
+++ b/src/store/slices/createExamSlice.ts
@@ -10,6 +10,7 @@ import {
     type FetchExamClassmatesResult,
 } from './exams/fetchExamClassmatesForTermin';
 import { fetchTermNote } from '../../api/terminyInfo';
+import { wouldWipePopulated } from '../guards';
 
 const NOTE_TTL_MS = 6 * 60 * 60 * 1000; // 6 hours on success
 const NOTE_ERROR_TTL_MS = 5 * 60 * 1000; // 5 minutes after error — prevents remount-refetch storm
@@ -269,7 +270,7 @@ export const createExamSlice: AppSlice<ExamSlice> = (set, get) => ({
     // A transient/failed IS fetch resolves to [] (see fetchExamData), and a
     // sync push would otherwise wipe the currently-displayed exams. Keep old
     // data on screen until real new data is available to replace it.
-    if (data.length === 0 && get().exams.data.length > 0) return;
+    if (wouldWipePopulated(data, get().exams.data)) return;
     set((state) => ({
         exams: { ...state.exams, data },
         lastExamsFetchedAt: Date.now(),

--- a/src/store/slices/createScheduleSlice.ts
+++ b/src/store/slices/createScheduleSlice.ts
@@ -1,6 +1,7 @@
 import type { ScheduleSlice, AppSlice } from '../types';
 import { IndexedDBService } from '../../services/storage';
 import { logError } from '../../utils/reportError';
+import { wouldWipePopulated } from '../guards';
 
 export const createScheduleSlice: AppSlice<ScheduleSlice> = (set, get) => ({
   schedule: {
@@ -35,7 +36,7 @@ export const createScheduleSlice: AppSlice<ScheduleSlice> = (set, get) => ({
     // A transient/failed IS fetch can resolve to [], and a sync push would
     // otherwise wipe the currently-displayed schedule. Keep old data on screen
     // until real new data is available to replace it (mirrors setExams).
-    if ((!data || data.length === 0) && get().schedule.data.length > 0) return;
+    if (wouldWipePopulated(data, get().schedule.data)) return;
     set((state) => ({
       schedule: { ...state.schedule, data: data || [] },
     }));

--- a/src/store/slices/createScheduleSlice.ts
+++ b/src/store/slices/createScheduleSlice.ts
@@ -32,6 +32,10 @@ export const createScheduleSlice: AppSlice<ScheduleSlice> = (set, get) => ({
     }
   },
   setSchedule: (data) => {
+    // A transient/failed IS fetch can resolve to [], and a sync push would
+    // otherwise wipe the currently-displayed schedule. Keep old data on screen
+    // until real new data is available to replace it (mirrors setExams).
+    if ((!data || data.length === 0) && get().schedule.data.length > 0) return;
     set((state) => ({
       schedule: { ...state.schedule, data: data || [] },
     }));

--- a/src/store/slices/createStudyPlanSlice.ts
+++ b/src/store/slices/createStudyPlanSlice.ts
@@ -27,4 +27,14 @@ export const createStudyPlanSlice: AppSlice<StudyPlanSlice> = (set) => ({
             // Ignore if stats fail to load from IDB
         }
     },
+    // Direct setters let a sync push paint immediately instead of waiting for the
+    // end-of-sync triggerRefresh → fetchStudyPlan/fetchStudyStats round-trip.
+    setStudyPlan: (plan) => {
+        if (!plan) return;
+        set({ studyPlanDual: plan, studyPlanLoaded: true });
+    },
+    setStudyStats: (stats) => {
+        if (!stats) return;
+        set({ studyStats: stats });
+    },
 });

--- a/src/store/slices/createSubjectsSlice.ts
+++ b/src/store/slices/createSubjectsSlice.ts
@@ -2,6 +2,7 @@ import type { SubjectsSlice, AppSlice, CourseDeadline } from '../types';
 import type { SubjectAttendance } from '../../types/documents';
 import { IndexedDBService } from '../../services/storage';
 import { logError } from '../../utils/reportError';
+import { wouldWipePopulated } from '../guards';
 
 export const createSubjectsSlice: AppSlice<SubjectsSlice> = (set, get) => ({
     subjects: null,
@@ -37,19 +38,17 @@ export const createSubjectsSlice: AppSlice<SubjectsSlice> = (set, get) => ({
         // A partial/failed sync can push empty (or null) subjects; that would
         // wipe the visible subject list. Keep the populated list until real data
         // arrives to replace it.
-        const incomingCount = data?.data ? Object.keys(data.data).length : 0;
-        const currentCount = get().subjects?.data ? Object.keys(get().subjects!.data).length : 0;
-        if (incomingCount === 0 && currentCount > 0) return;
+        if (wouldWipePopulated(data?.data, get().subjects?.data)) return;
         set({ subjects: data });
     },
     setAttendance: (data) => {
         // Empty {} from a transient fetch must not wipe populated attendance.
-        if (Object.keys(data).length === 0 && Object.keys(get().attendance).length > 0) return;
+        if (wouldWipePopulated(data, get().attendance)) return;
         set({ attendance: data });
         IndexedDBService.set('meta', 'current_attendance', data).catch(() => {});
     },
     setPastAttendance: (data) => {
-        if (Object.keys(data).length === 0 && Object.keys(get().pastAttendance).length > 0) return;
+        if (wouldWipePopulated(data, get().pastAttendance)) return;
         set({ pastAttendance: data });
     },
     setCourseNickname: (courseCode, nickname) => {

--- a/src/store/slices/createSubjectsSlice.ts
+++ b/src/store/slices/createSubjectsSlice.ts
@@ -33,11 +33,25 @@ export const createSubjectsSlice: AppSlice<SubjectsSlice> = (set, get) => ({
             set({ subjectsLoading: false });
         }
     },
+    setSubjects: (data) => {
+        // A partial/failed sync can push empty (or null) subjects; that would
+        // wipe the visible subject list. Keep the populated list until real data
+        // arrives to replace it.
+        const incomingCount = data?.data ? Object.keys(data.data).length : 0;
+        const currentCount = get().subjects?.data ? Object.keys(get().subjects!.data).length : 0;
+        if (incomingCount === 0 && currentCount > 0) return;
+        set({ subjects: data });
+    },
     setAttendance: (data) => {
+        // Empty {} from a transient fetch must not wipe populated attendance.
+        if (Object.keys(data).length === 0 && Object.keys(get().attendance).length > 0) return;
         set({ attendance: data });
         IndexedDBService.set('meta', 'current_attendance', data).catch(() => {});
     },
-    setPastAttendance: (data) => set({ pastAttendance: data }),
+    setPastAttendance: (data) => {
+        if (Object.keys(data).length === 0 && Object.keys(get().pastAttendance).length > 0) return;
+        set({ pastAttendance: data });
+    },
     setCourseNickname: (courseCode, nickname) => {
         const currentNicknames = get().courseNicknames;
         const newNicknames = { ...currentNicknames };

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -32,7 +32,7 @@ export interface ScheduleSlice {
     weekStart: Date | null;
   };
   fetchSchedule: () => Promise<void>;
-  setSchedule: (data: BlockLesson[]) => void;
+  setSchedule: (data: BlockLesson[] | undefined) => void;
 }
 
 export interface ExamSlice {
@@ -126,6 +126,7 @@ export interface SubjectsSlice {
     attendance: Record<string, SubjectAttendance[]>;
     pastAttendance: Record<string, SubjectAttendance[]>;
     fetchSubjects: () => Promise<void>;
+    setSubjects: (data: SubjectsData | null) => void;
     setAttendance: (data: Record<string, SubjectAttendance[]>) => void;
     setPastAttendance: (data: Record<string, SubjectAttendance[]>) => void;
     setCourseNickname: (courseCode: string, nickname: string | null) => void;
@@ -209,6 +210,8 @@ export interface StudyPlanSlice {
     studyStats: StudyStats | null;
     fetchStudyPlan: () => Promise<void>;
     fetchStudyStats: () => Promise<void>;
+    setStudyPlan: (plan: DualLanguageStudyPlan | null) => void;
+    setStudyStats: (stats: StudyStats | null) => void;
 }
 
 export interface ErasmusStudentInfo {


### PR DESCRIPTION
## Summary

Tightens the `is.mendelu.cz → IDB → iframe → components` pipeline so information appears sooner and never flashes empty mid-sync. Three focused commits.

### 1. Faster first paint + gap guards (`6adee4e`)
- **Latency:** `subjects`, `studyPlan` and `studyStats` were written to IDB on the early Phase-2 push but only reached the store via the end-of-sync `triggerRefresh → fetchX` round-trip — so on a cold start they stayed blank until the slow per-subject Phase 3 finished. The iframe handler now calls guarded setters directly on the push, painting them immediately.
- **Gaps:** added "empty never overwrites populated" guards to `setSchedule`, `setAttendance`, `setPastAttendance` and a new `setSubjects`, mirroring the existing `setExams` guard. A transient/failed fetch can no longer wipe what's on screen.

### 2. Unify the gap guards (`111273d`)
The guard had been hand-copied across five setters with three inconsistent emptiness checks. Replaced all of them (including the pre-existing `setExams` copy) with one shared, tested `wouldWipePopulated` predicate in `src/store/guards.ts`. The helper also null-hardens the check (removes an `Object.keys(null)` path). Zaznamnik's per-key merge guard is intentionally left alone — it's different semantics.

### 3. Exams skeleton/empty-state flash (`e355938`)
Opening the exams panel fires its own refresh on mount, but the skeleton rule ignored the `examsRefreshing` flag — so with an empty cache it flashed "nothing to display" before the freshly-fetched exams arrived. Extracted the decision into a pure, tested `shouldShowExamsSkeleton()` that now accounts for an in-flight refresh; `refreshExams` always pushes its result so the spinner also clears for students who genuinely have no exams.

## Test Plan
- [x] `npm run test:run` — all suites pass except the 5 pre-existing ISKAM parser tests, which fail only because `.agent/fixtures` (gitignored) isn't present in CI/the container; unrelated to this branch.
- [x] `npm run typecheck` — no new errors (3 pre-existing Erasmus/exam-mock errors exist on `main`).
- [x] `npm run lint` — clean on all touched files.
- [x] New tests written first (TDD): guard behaviour for schedule/subjects/study-plan slices, the `wouldWipePopulated` helper (incl. null cases), and `shouldShowExamsSkeleton`.

## Notes
- No IS parsers, Drive/OAuth internals, or ISKAM code touched.

https://claude.ai/code/session_01LYsX8nQjuTCZHFQVh7bn5k

---
_Generated by [Claude Code](https://claude.ai/code/session_01LYsX8nQjuTCZHFQVh7bn5k)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced loading skeleton visibility during exam refresh operations
  * Added data protection to prevent UI data loss from transient failed synchronization

* **Bug Fixes**
  * Improved handling of empty data results to preserve existing UI state instead of clearing populated content

* **Tests**
  * Added test coverage for exam loading states, data guard logic, and state management operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->