### PR TITLE
feat: show enrolled subjects in Předměty view for Erasmus students (no KontrolaPlanu)

### DIFF
--- a/docs/superpowers/plans/2026-07-01-is-stranky-search.md
+++ b/docs/superpowers/plans/2026-07-01-is-stranky-search.md
@@ -1,0 +1,693 @@
+# IS stránky search Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the Sidebar's page-pinning feature (pin up to 6 pages into the "Student" flyout) with a row labeled "IS stránky" that opens the existing `IsPortalPopover` search-and-launch component, then delete all now-dead pinning code (slice, storage, UI).
+
+**Architecture:** No new components. The Sidebar's `+ Přidat` row (desktop `NavItem.tsx`, mobile `MobileNavSheet.tsx`) is repointed from `PagePinnerModal` to `IsPortalPopover` (already used by the global header search's grid-icon launcher at `src/components/SearchBar/index.tsx` and `MobileSearchOverlay.tsx`). `PagePinnerModal.tsx`, `createPinnedPagesSlice.ts`, and every `pinnedPages`/`isPinned` read site are deleted.
+
+**Tech Stack:** React 19, Zustand (slice pattern), TypeScript strict, Vitest, lucide-react icons.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-01-is-stranky-search-design.md` (read this first — it documents why `IsPortalPopover` is reused instead of building a new modal).
+- This plan is a removal + rewire of existing, already-shipped behavior (`IsPortalPopover` is unmodified and untouched by this plan). No new pure logic is introduced, so tasks are verified with `npm run typecheck` / `npm run lint` / `npm run test:run` / `npm run build` rather than new failing tests — CLAUDE.md's test-first rule applies to new behavior, and there is none here.
+- Max 200 lines per file (CLAUDE.md Iron Rule) — no file touched in this plan grows; several shrink.
+- No proxy/re-export files, no `useEffect` for data fetching (CLAUDE.md Iron Rules) — not relevant to these changes but don't introduce any.
+- `IsPortalPopover` props are `{ isOpen: boolean; onClose: () => void }` (not `open`/`onClose` like the deleted `PagePinnerModal`) — every call site must use `isOpen`.
+- Commit after each task.
+
+---
+
+### Task 1: Repoint desktop Sidebar trigger to `IsPortalPopover`
+
+**Files:**
+- Modify: `src/components/Sidebar/NavItem.tsx`
+
+**Interfaces:**
+- Consumes: `IsPortalPopover` from `src/components/SearchBar/IsPortalPopover.tsx` — `IsPortalPopoverProps { isOpen: boolean; onClose: () => void }` (existing, unmodified).
+- Produces: nothing new — this task only removes the `pinnedPages`/`unpinPage`/pin-hint state this file used to own.
+
+- [ ] **Step 1: Replace the file contents**
+
+Replace `src/components/Sidebar/NavItem.tsx` in full with:
+
+```tsx
+import { useState } from 'react';
+import { motion, AnimatePresence } from 'motion/react';
+import { ChevronRight, ExternalLink, Search } from 'lucide-react';
+import type { MenuItem } from '../menuConfig';
+import type { AppView } from '../../types/app';
+import { useAppStore } from '../../store/useAppStore';
+import { useTranslation } from '../../hooks/useTranslation';
+import { IsPortalPopover } from '../SearchBar/IsPortalPopover';
+
+interface NavItemProps {
+  item: MenuItem;
+  isActive: boolean;
+  isHovered: boolean;
+  onMouseEnter: () => void;
+  onMouseLeave: () => void;
+  onClick: () => void;
+  onViewChange: (view: AppView) => void;
+  onOpenSubject?: (courseCode: string, courseName?: string, courseId?: string) => void;
+}
+
+export function NavItem({ item, isActive, isHovered, onMouseEnter, onMouseLeave, onClick, onViewChange, onOpenSubject }: NavItemProps) {
+  const [portalOpen, setPortalOpen] = useState(false);
+  const setIsEduroamOpen = useAppStore(s => s.setIsEduroamOpen);
+  const { t } = useTranslation();
+
+  return (
+    <div
+      className="relative group"
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+    >
+      <button
+        onClick={onClick}
+        className={`relative w-14 h-auto min-h-[56px] py-2 rounded-xl flex flex-col items-center justify-center transition-all duration-200 mx-auto
+          ${isActive
+            ? 'bg-primary/10 text-primary shadow-sm'
+            : 'text-base-content/50 hover:bg-base-100 hover:text-base-content hover:shadow-sm'
+          }`}
+      >
+        {item.href && !item.expandable && item.id !== 'dashboard' && (
+          <ExternalLink className="absolute top-1 right-1 w-2.5 h-2.5 text-base-content/30" />
+        )}
+        <div className="relative flex items-center justify-center">
+          {item.icon}
+          {item.badge !== undefined && (
+            <span className={`absolute -top-2 -right-3 font-bold px-1 rounded text-[10px] leading-[14px] shadow-sm transition-all duration-300
+              ${item.badge > 0 
+                ? 'bg-neutral text-neutral-content scale-110 shadow-neutral/20' 
+                : 'bg-base-content/10 text-base-content/50'
+              }`}>
+              {item.badge}
+            </span>
+          )}
+        </div>
+        <span className="text-[10px] mt-1 font-medium w-full text-center px-1 leading-tight">
+          {item.label}
+        </span>
+      </button>
+
+      {/* Popup Menu for expandable items */}
+      <AnimatePresence>
+        {isHovered && item.expandable && (
+          <motion.div
+            initial={{ opacity: 0, x: 10, scale: 0.95 }}
+            animate={{ opacity: 1, x: 0, scale: 1 }}
+            exit={{ opacity: 0, x: 10, scale: 0.95 }}
+            transition={{ duration: 0.15, ease: "easeOut" }}
+            className={`absolute left-14 -top-4 bg-base-100 rounded-xl shadow-popover-heavy border border-base-300 p-2 z-50 ${
+                item.id === 'subjects' && item.children && item.children.length > 4 ? 'w-[500px] max-w-[calc(100vw-5rem)]' : 'w-64 max-w-[calc(100vw-5rem)]'
+            }`}
+          >
+            <div className={`gap-0.5 ${
+                item.id === 'subjects' && item.children && item.children.length > 4 ? 'grid grid-cols-2' : 'flex flex-col'
+            }`}>
+              {!item.children || item.children.length === 0 ? (
+                Array.from({ length: 4 }).map((_, i) => (
+                  <div key={i} className="flex items-center gap-3 px-3 py-2">
+                    <div className="skeleton w-4 h-4 rounded" />
+                    <div className="skeleton h-3 rounded flex-1" />
+                  </div>
+                ))
+              ) : item.children.map((child) => (
+                <a
+                  key={child.id}
+                  href={child.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={(e) => {
+                    if (child.id === 'zapisy-zkousky') {
+                      e.preventDefault();
+                      onViewChange('exams');
+                    } else if (child.id === 'studijni-plany') {
+                      e.preventDefault();
+                      onViewChange('subjects');
+                    } else if (child.isSubject && child.courseCode) {
+                      e.preventDefault();
+                      onOpenSubject?.(child.courseCode, child.label, child.subjectId);
+                    } else if (child.id === 'eduroam') {
+                      e.preventDefault();
+                      setIsEduroamOpen(true);
+                    } else if (child.isFeature) {
+                       e.preventDefault();
+                    }
+                  }}
+                  className="flex items-center gap-3 px-3 py-2 rounded-lg text-sm text-base-content/70 hover:bg-base-200 hover:text-primary transition-colors group/item cursor-pointer"
+                >
+                  <span className="text-base-content/50 group-hover/item:text-primary transition-colors">
+                    {child.icon || <ChevronRight className="w-4 h-4" />}
+                  </span>
+                  <div className="flex-1 flex flex-col min-w-0">
+                    <span className="font-medium truncate">{child.label}</span>
+                    {child.subtitle && (
+                      <span className="text-[10px] text-base-content/40 truncate">{child.subtitle}</span>
+                    )}
+                  </div>
+                  {!child.isFeature && !child.isSubject && (
+                    <ExternalLink className="w-3 h-3 text-base-content/30 group-hover/item:text-base-content/50" />
+                  )}
+                </a>
+              ))}
+            </div>
+
+            {item.id === 'is' && (
+              <button
+                onClick={(e) => { e.stopPropagation(); setPortalOpen(true); }}
+                className="flex items-center gap-2 w-full px-3 py-2 rounded-lg text-sm text-base-content/40 hover:bg-base-200 hover:text-primary transition-colors relative"
+              >
+                <Search className="w-4 h-4" />
+                <span>{t('sidebar.addPin')}</span>
+              </button>
+            )}
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      <IsPortalPopover isOpen={portalOpen} onClose={() => setPortalOpen(false)} />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npm run typecheck`
+Expected: fails right now (PagePinnerModal still imported by MobileNavSheet.tsx, pinnedPages still referenced in MainItems.tsx/menuConfig.tsx/useMenuItems.ts/store — those are fixed in later tasks). Confirm the only errors reported are in those other files, not in `NavItem.tsx`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/Sidebar/NavItem.tsx
+git commit -m "feat(sidebar): repoint desktop IS flyout trigger to IsPortalPopover"
+```
+
+---
+
+### Task 2: Repoint mobile Sidebar trigger to `IsPortalPopover`
+
+**Files:**
+- Modify: `src/components/MobileNav/MobileNavSheet.tsx`
+
+**Interfaces:**
+- Consumes: same `IsPortalPopover` as Task 1.
+
+- [ ] **Step 1: Replace the file contents**
+
+Replace `src/components/MobileNav/MobileNavSheet.tsx` in full with:
+
+```tsx
+import { motion, AnimatePresence } from 'motion/react';
+import { ExternalLink, Search } from 'lucide-react';
+import { useState } from 'react';
+import type { MenuItem } from '../menuConfig';
+import type { AppView } from '../../types/app';
+import { useAppStore } from '../../store/useAppStore';
+import { useTranslation } from '../../hooks/useTranslation';
+import { IsPortalPopover } from '../SearchBar/IsPortalPopover';
+
+interface MobileNavSheetProps {
+  item: MenuItem | null;
+  onClose: () => void;
+  onViewChange: (view: AppView) => void;
+  onOpenSubject?: (courseCode: string, courseName?: string, courseId?: string) => void;
+  onOpenProfile?: () => void;
+}
+
+export function MobileNavSheet({ item, onClose, onViewChange, onOpenSubject, onOpenProfile }: MobileNavSheetProps) {
+  const [portalOpen, setPortalOpen] = useState(false);
+  const setIsEduroamOpen = useAppStore(s => s.setIsEduroamOpen);
+  const { t } = useTranslation();
+
+  if (!item) return null;
+
+  const handleChildClick = (child: NonNullable<MenuItem['children']>[number]) => {
+    if (child.id === 'zapisy-zkousky') {
+      onViewChange('exams');
+    } else if (child.id === 'studijni-plany') {
+      onViewChange('subjects');
+    } else if (child.isSubject && child.courseCode) {
+      onOpenSubject?.(child.courseCode, child.label, child.subjectId);
+    } else if (child.id === 'eduroam') {
+      setIsEduroamOpen(true);
+    } else if (child.id === 'profile-action') {
+      onOpenProfile?.();
+    } else if (child.href) {
+      window.open(child.href, '_blank');
+    }
+    onClose();
+  };
+
+  return (
+    <>
+      <AnimatePresence>
+        {item && (
+          <>
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              className="fixed inset-0 bg-black/40 z-50"
+              onClick={onClose}
+            />
+            <motion.div
+              initial={{ y: '100%' }}
+              animate={{ y: 0 }}
+              exit={{ y: '100%' }}
+              transition={{ type: 'spring', damping: 25, stiffness: 300 }}
+              className="fixed bottom-0 left-0 right-0 z-50 bg-base-100 rounded-t-2xl shadow-lg max-h-[70vh] flex flex-col"
+            >
+              <div className="flex items-center justify-center pt-3 pb-1">
+                <div className="w-10 h-1 rounded-full bg-base-300" />
+              </div>
+              <div className="px-4 pb-2 pt-1">
+                <h3 className="font-bold text-base">{item.popupLabel || item.label}</h3>
+              </div>
+              <div className="flex-1 overflow-y-auto px-2 pb-4">
+                {!item.children || item.children.length === 0 ? (
+                  <div className="flex flex-col gap-1 p-2">
+                    {Array.from({ length: 4 }).map((_, i) => (
+                      <div key={i} className="flex items-center gap-3 px-3 py-3">
+                        <div className="skeleton w-4 h-4 rounded" />
+                        <div className="skeleton h-3 rounded flex-1" />
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <div className="flex flex-col gap-0.5">
+                    {item.children.map(child => (
+                      <div key={child.id} className="flex items-center gap-3 px-3 py-3 rounded-lg text-sm text-base-content/70 hover:bg-base-200 active:bg-base-200 transition-colors w-full">
+                        <button
+                          onClick={() => handleChildClick(child)}
+                          className="flex items-center gap-3 flex-1 min-w-0 text-left"
+                        >
+                          {child.icon ? (
+                            <span className="text-base-content/50">
+                              {child.icon}
+                            </span>
+                          ) : null}
+                          <div className="flex-1 flex flex-col min-w-0">
+                            <span className="font-medium truncate">{child.label}</span>
+                            {child.subtitle && (
+                              <span className="text-[10px] text-base-content/40 truncate">{child.subtitle}</span>
+                            )}
+                          </div>
+                          {!child.isFeature && !child.isSubject && (
+                            <ExternalLink className="w-3 h-3 text-base-content/30" />
+                          )}
+                        </button>
+                      </div>
+                    ))}
+
+                    {item.id === 'is' && (
+                        <button
+                          onClick={(e) => { e.stopPropagation(); setPortalOpen(true); }}
+                          className="flex items-center gap-3 px-3 py-3 rounded-lg text-sm text-base-content/40 hover:bg-base-200 hover:text-primary transition-colors w-full text-left"
+                        >
+                          <Search className="w-4 h-4" />
+                          <span>{t('sidebar.addPin')}</span>
+                        </button>
+                    )}
+                  </div>
+                )}
+              </div>
+            </motion.div>
+          </>
+        )}
+      </AnimatePresence>
+
+      <IsPortalPopover isOpen={portalOpen} onClose={() => setPortalOpen(false)} />
+    </>
+  );
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npm run typecheck`
+Expected: still fails (same pre-existing reasons as Task 1, fixed in Task 4) but no new errors from `MobileNavSheet.tsx`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/MobileNav/MobileNavSheet.tsx
+git commit -m "feat(sidebar): repoint mobile IS flyout trigger to IsPortalPopover"
+```
+
+---
+
+### Task 3: Delete the pinning modal, slice, and its store registration
+
+**Files:**
+- Delete: `src/components/Sidebar/PagePinnerModal.tsx`
+- Delete: `src/store/slices/createPinnedPagesSlice.ts`
+- Modify: `src/store/useAppStore.ts`
+- Modify: `src/store/types.ts`
+- Modify: `src/hooks/useAppLogic.ts:118-122`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: nothing — pure deletion. After this task, `pinnedPages`, `pinPage`, `unpinPage`, `migratePinnedIds`, and the `PinnedPage`/`PinnedPagesSlice` types no longer exist anywhere in the codebase.
+
+- [ ] **Step 1: Delete the two files**
+
+```bash
+git rm src/components/Sidebar/PagePinnerModal.tsx src/store/slices/createPinnedPagesSlice.ts
+```
+
+- [ ] **Step 2: Remove the slice from `useAppStore.ts`**
+
+In `src/store/useAppStore.ts`, delete this import line:
+
+```ts
+import { createPinnedPagesSlice } from './slices/createPinnedPagesSlice';
+```
+
+and delete this line from inside `create<AppState>()((...a) => ({ ... }))`:
+
+```ts
+  ...createPinnedPagesSlice(...a),
+```
+
+- [ ] **Step 3: Remove `PinnedPagesSlice` from `store/types.ts`**
+
+Delete the import line:
+
+```ts
+import type { PinnedPage } from './slices/createPinnedPagesSlice';
+```
+
+Delete the interface block:
+
+```ts
+export interface PinnedPagesSlice {
+  pinnedPages: PinnedPage[];
+  loadPinnedPages: () => Promise<void>;
+  pinPage: (page: PinnedPage) => Promise<void>;
+  unpinPage: (id: string) => Promise<void>;
+  migratePinnedIds: (navPages: PageCategory[]) => Promise<void>;
+}
+```
+
+In the `AppState` type union (single line, search for `export type AppState =`), remove ` & PinnedPagesSlice` from the middle of the chain (it currently sits between `ErasmusSlice &` and `MenuSlice &`).
+
+- [ ] **Step 4: Remove the `migratePinnedIds` call in `useAppLogic.ts`**
+
+In `src/hooks/useAppLogic.ts`, this block:
+
+```ts
+            if (d.type === 'REIS_NAV_MENU') {
+                useAppStore.getState().setNavPages(d.categories);
+                useAppStore.getState().migratePinnedIds(d.categories);
+                return;
+            }
+```
+
+becomes:
+
+```ts
+            if (d.type === 'REIS_NAV_MENU') {
+                useAppStore.getState().setNavPages(d.categories);
+                return;
+            }
+```
+
+- [ ] **Step 5: Typecheck**
+
+Run: `npm run typecheck`
+Expected: remaining errors are only in `MainItems.tsx`, `menuConfig.tsx`, `useMenuItems.ts` (still reference `pinnedPages`/`PinnedPage` — fixed in Task 4). No errors in `useAppStore.ts`, `store/types.ts`, or `useAppLogic.ts`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A src/store/useAppStore.ts src/store/types.ts src/hooks/useAppLogic.ts
+git commit -m "refactor(store): delete page-pinning slice and modal"
+```
+
+---
+
+### Task 4: Strip `pinnedPages`/`isPinned` plumbing from the menu config
+
+**Files:**
+- Modify: `src/components/Menu/MainItems.tsx`
+- Modify: `src/components/menuConfig.tsx`
+- Modify: `src/hooks/ui/useMenuItems.ts`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `mainItems(sid, oid, t, lang)` and `getMainMenuItems(sid, oid, t, lang)` — both drop their trailing `pinnedPages`/`navPages` parameters. Any other call site must be updated to match (none exist outside these three files — verified by grep during planning).
+
+- [ ] **Step 1: Replace `MainItems.tsx`**
+
+Replace `src/components/Menu/MainItems.tsx` in full with:
+
+```tsx
+import { Home, Book, CalendarCheck, LayoutDashboard, ClipboardList, PenTool, User, Wifi, Map } from 'lucide-react';
+import type { MenuItem } from '../menuConfig';
+
+export const mainItems = (sid: string, oid: string, t: (key: string) => string, lang: string = 'cz'): MenuItem[] => [
+    { id: 'dashboard', label: t('sidebar.dashboard'), icon: <Home className="w-5 h-5" />, href: `https://is.mendelu.cz/auth/?lang=${lang}` },
+    { id: 'exams', label: t('sidebar.exams'), icon: <CalendarCheck className="w-5 h-5" /> },
+    { id: 'subjects', label: t('sidebar.subjects'), icon: <Book className="w-5 h-5" /> },
+    { id: 'map', label: t('sidebar.map'), icon: <Map className="w-5 h-5" /> },
+    {
+        id: 'is',
+        label: t('sidebar.is'),
+        icon: <User className="w-5 h-5" />,
+        expandable: true,
+        children: [
+            { id: 'eduroam', label: t('sidebar.eduroam'), icon: <Wifi className="w-4 h-4" />, isFeature: true },
+            { id: 'portal-studenta', label: t('sidebar.portal'), icon: <LayoutDashboard className="w-4 h-4" />, href: `https://is.mendelu.cz/auth/student/moje_studium.pl?lang=${lang}` },
+            { id: 'zaznamniky', label: t('sidebar.notebooks'), icon: <ClipboardList className="w-4 h-4" />, href: `https://is.mendelu.cz/auth/student/list.pl?studium=${sid};obdobi=${oid};lang=${lang}` },
+            { id: 'testy', label: t('sidebar.tests'), icon: <PenTool className="w-4 h-4" />, href: `https://is.mendelu.cz/auth/elis/ot/psani_testu.pl?_m=205;lang=${lang}` },
+        ]
+    },
+];
+```
+
+- [ ] **Step 2: Replace `menuConfig.tsx`**
+
+Replace `src/components/menuConfig.tsx` in full with:
+
+```tsx
+import { Settings, LogOut } from 'lucide-react';
+import { mainItems } from './Menu/MainItems';
+
+export interface MenuItem { 
+    id: string; 
+    label: string; 
+    shortLabel?: string; 
+    popupLabel?: string; 
+    icon: React.ReactNode; 
+    badge?: number; 
+    expandable?: boolean; 
+    children?: { 
+        label: string; 
+        id: string; 
+        subtitle?: string; 
+        icon?: React.ReactNode; 
+        href?: string; 
+        isFeature?: boolean; 
+        isSubject?: boolean; 
+        courseCode?: string; 
+        subjectId?: string; 
+    }[]; 
+    danger?: boolean; 
+    onClick?: () => void; 
+    href?: string; 
+    isFeature?: boolean;
+    type?: 'item' | 'header' | 'divider';
+}
+
+export const getMainMenuItems = (sid: string = '', oid: string = '', t: (key: string) => string, lang: string = 'cz'): MenuItem[] => mainItems(sid, oid, t, lang);
+
+export const getSettingsMenuItems = (logout: () => void): MenuItem[] => [
+    { id: 'nastaveni', label: 'Nastavení', icon: <Settings className="w-5 h-5" /> },
+    { id: 'odhlaseni', label: 'Odhlášení', icon: <LogOut className="w-5 h-5" />, danger: true, onClick: logout }
+];
+```
+
+- [ ] **Step 3: Update `useMenuItems.ts`**
+
+In `src/hooks/ui/useMenuItems.ts`, delete this line:
+
+```ts
+  const pinnedPages = useAppStore(state => state.pinnedPages);
+```
+
+and this line:
+
+```ts
+  const navPages = useAppStore(state => state.navPages);
+```
+
+and change:
+
+```ts
+  const items = getMainMenuItems(params?.studium ?? '', params?.obdobi ?? '', t, language, pinnedPages, navPages);
+```
+
+to:
+
+```ts
+  const items = getMainMenuItems(params?.studium ?? '', params?.obdobi ?? '', t, language);
+```
+
+- [ ] **Step 4: Typecheck**
+
+Run: `npm run typecheck`
+Expected: exits 0 — this was the last consumer of `pinnedPages`/`PinnedPage`/`isPinned`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/Menu/MainItems.tsx src/components/menuConfig.tsx src/hooks/ui/useMenuItems.ts
+git commit -m "refactor(sidebar): drop pinnedPages/isPinned plumbing from menu config"
+```
+
+---
+
+### Task 5: i18n cleanup — rename the trigger label, drop dead pin strings
+
+**Files:**
+- Modify: `src/i18n/locales/cs.json:129-132`
+- Modify: `src/i18n/locales/en.json:129-132`
+
+**Interfaces:** none — string-only changes consumed by `t('sidebar.addPin')` in Tasks 1–2.
+
+- [ ] **Step 1: Edit `cs.json`**
+
+In `src/i18n/locales/cs.json`, this block:
+
+```json
+    "addPin": "Přidat",
+    "addPinTitle": "Připnout stránku",
+    "pinNudge": "Připni si sem nejpoužívanější IS stránky",
+    "pinLimitReached": "Maximum 6 stránek",
+```
+
+becomes:
+
+```json
+    "addPin": "IS stránky",
+```
+
+- [ ] **Step 2: Edit `en.json`**
+
+In `src/i18n/locales/en.json`, this block:
+
+```json
+    "addPin": "Add",
+    "addPinTitle": "Pin a page",
+    "pinNudge": "Pin your most-used IS pages here",
+    "pinLimitReached": "Maximum 6 pages",
+```
+
+becomes:
+
+```json
+    "addPin": "IS stránky",
+```
+
+(Same string in both locales — "IS stránky" is the Czech IS Mendelu system's proper name, not translated, matching how e.g. "eduroam" stays untranslated elsewhere in this file.)
+
+- [ ] **Step 3: Verify JSON is still valid and the key is used**
+
+Run: `node -e "JSON.parse(require('fs').readFileSync('src/i18n/locales/cs.json'))" && node -e "JSON.parse(require('fs').readFileSync('src/i18n/locales/en.json'))" && echo OK`
+Expected: `OK`
+
+Run: `grep -rn "addPinTitle\|pinNudge\|pinLimitReached" src`
+Expected: no output (no remaining references — they were already removed from `NavItem.tsx`/`MobileNavSheet.tsx` in Tasks 1–2).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/i18n/locales/cs.json src/i18n/locales/en.json
+git commit -m "i18n: rename sidebar.addPin to IS stránky, drop dead pin strings"
+```
+
+---
+
+### Task 6: Update the stale `noHardcodedIds` regression test
+
+**Files:**
+- Modify: `src/utils/__tests__/noHardcodedIds.test.ts:44-48`
+
+**Interfaces:** none.
+
+**Why:** this test asserts the literal string `href: injectUserParams(p.href, sid, lang, oid)` exists in `MainItems.tsx`. Task 4 deleted that line (along with the rest of the pinned-pages mapping), so this assertion is now testing code that no longer exists and must be removed — not weakened, removed, since the behavior it guarded (no hardcoded IDs in pinned-page links) no longer applies because there are no more pinned-page links in that file.
+
+- [ ] **Step 1: Remove the stale test block**
+
+In `src/utils/__tests__/noHardcodedIds.test.ts`, delete this `it(...)` block from the `describe('injectUserParams', ...)` suite:
+
+```ts
+    it('should be used for pinned pages in MainItems.tsx', () => {
+        const content = fs.readFileSync(path.resolve(__dirname, '../../components/Menu/MainItems.tsx'), 'utf-8');
+        expect(content).toContain('injectUserParams');
+        expect(content).toContain('href: injectUserParams(p.href, sid, lang, oid)');
+    });
+```
+
+leaving the `describe('injectUserParams', ...)` block with only its first `it('should be used when navigating to pages in SearchBar', ...)` test.
+
+- [ ] **Step 2: Run the test file**
+
+Run: `npx vitest run src/utils/__tests__/noHardcodedIds.test.ts`
+Expected: PASS (all remaining assertions green; the deleted one is gone).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/utils/__tests__/noHardcodedIds.test.ts
+git commit -m "test: drop stale pinned-pages assertion from noHardcodedIds"
+```
+
+---
+
+### Task 7: Full verification pass
+
+**Files:** none (verification only).
+
+**Interfaces:** none.
+
+- [ ] **Step 1: Typecheck**
+
+Run: `npm run typecheck`
+Expected: exits 0.
+
+- [ ] **Step 2: Lint**
+
+Run: `npm run lint`
+Expected: exits 0.
+
+- [ ] **Step 3: Full test suite**
+
+Run: `npm run test:run`
+Expected: exits 0, no failing tests.
+
+- [ ] **Step 4: Production build**
+
+Run: `npm run build`
+Expected: exits 0.
+
+- [ ] **Step 5: Grep for leftover references**
+
+Run: `grep -rln "PagePinnerModal\|pinnedPages\|pinPage\|unpinPage\|createPinnedPagesSlice\|PinnedPagesSlice\|migratePinnedIds" src`
+Expected: no output.
+
+- [ ] **Step 6: Manual smoke test**
+
+Run: `npm run dev`, load the unpacked extension build per the WXT dev workflow, open it on an IS Mendelu page (or with mock data per `VITE_USE_MOCK_DATA=true` if available). Hover the "Student" sidebar icon, confirm the flyout shows exactly 4 entries (eduroam, Portál studenta, Záznamníky, Testy) plus a new "IS stránky" row with a search icon. Click it, confirm `IsPortalPopover` opens, type a query, click a result, confirm it opens in a new tab and the popover stays open. Repeat on mobile width for `MobileNavSheet`.
+
+- [ ] **Step 7: Final commit (if any cleanup was needed)**
+
+```bash
+git status
+```
+
+If Steps 1–6 required no further code changes, this task produces no commit — verification-only.

--- a/docs/superpowers/plans/2026-07-02-erasmus-subjects-fallback.md
+++ b/docs/superpowers/plans/2026-07-02-erasmus-subjects-fallback.md
@@ -1,0 +1,422 @@
+# Erasmus Subjects Fallback Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When the study plan (KontrolaPlanu) is missing or empty — the Erasmus case — the Předměty view renders the enrolled-subjects card from the already-synced `subjects` store instead of "No study plan data".
+
+**Architecture:** A pure helper `buildFallbackPlan` maps the `subjects` store (from `student/list.pl`) into a minimal one-block `StudyPlan`; `SubjectsPanel` gains a render branch that feeds it into the existing `EnrolledNowSection` plus a caption. No sync changes, no persistence — the synthetic plan exists only during render. Spec: `docs/superpowers/specs/2026-07-02-erasmus-subjects-fallback-design.md`.
+
+**Tech Stack:** React 19, Zustand (`useAppStore`), TypeScript strict, Vitest + happy-dom + @testing-library/react, DaisyUI classes.
+
+## Global Constraints
+
+- NO `useEffect` for data fetching in components (the fallback is pure derivation from store state).
+- NO custom CSS — DaisyUI/Tailwind semantic classes only.
+- Max 200 lines per file.
+- Direct imports only — no re-export barrels.
+- Test first: write the failing test before implementation.
+- Do not touch any parser (`src/api/**` parsers are off-limits per CLAUDE.md).
+- Path alias `@/*` → `src/*`.
+
+---
+
+### Task 1: `buildFallbackPlan` util
+
+**Files:**
+- Create: `src/components/SubjectsPanel/buildFallbackPlan.ts`
+- Test: `src/components/SubjectsPanel/__tests__/buildFallbackPlan.test.ts`
+
+**Interfaces:**
+- Consumes: `SubjectsData`/`SubjectInfo` from `@/types/documents`, `StudyPlan`/`SubjectStatus` from `@/types/studyPlan` (both already exist).
+- Produces: `buildFallbackPlan(subjects: SubjectsData, language: 'cs' | 'en'): StudyPlan` — Task 2 imports exactly this signature.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/components/SubjectsPanel/__tests__/buildFallbackPlan.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { buildFallbackPlan } from '../buildFallbackPlan';
+import type { SubjectsData } from '@/types/documents';
+
+const subjects: SubjectsData = {
+  version: 1,
+  lastUpdated: '2026-07-02T00:00:00.000Z',
+  data: {
+    'EBC-ST': {
+      displayName: 'Statistika (display)',
+      fullName: 'EBC-ST Statistika',
+      nameCs: 'Statistika',
+      nameEn: 'Statistics',
+      subjectCode: 'EBC-ST',
+      subjectId: '123456',
+      folderUrl: 'https://is.mendelu.cz/auth/dok_server/slozka.pl?id=1',
+      fetchedAt: '2026-07-02T00:00:00.000Z',
+    },
+    'EBC-XX': {
+      displayName: 'Display Only',
+      fullName: 'EBC-XX Display Only',
+      subjectCode: 'EBC-XX',
+      folderUrl: 'https://is.mendelu.cz/auth/dok_server/slozka.pl?id=2',
+      fetchedAt: '2026-07-02T00:00:00.000Z',
+    },
+  },
+};
+
+describe('buildFallbackPlan', () => {
+  it('maps every subject into one block/one group as enrolled, unfulfilled', () => {
+    const plan = buildFallbackPlan(subjects, 'cs');
+    expect(plan.blocks).toHaveLength(1);
+    expect(plan.blocks[0].groups).toHaveLength(1);
+    const list = plan.blocks[0].groups[0].subjects;
+    expect(list).toHaveLength(2);
+    const st = list.find(s => s.code === 'EBC-ST')!;
+    expect(st.id).toBe('123456');
+    expect(st.isEnrolled).toBe(true);
+    expect(st.isFulfilled).toBe(false);
+    expect(st.credits).toBe(0);
+  });
+
+  it('picks nameEn for en and nameCs for cs', () => {
+    const en = buildFallbackPlan(subjects, 'en').blocks[0].groups[0].subjects.find(s => s.code === 'EBC-ST')!;
+    const cs = buildFallbackPlan(subjects, 'cs').blocks[0].groups[0].subjects.find(s => s.code === 'EBC-ST')!;
+    expect(en.name).toBe('Statistics');
+    expect(cs.name).toBe('Statistika');
+  });
+
+  it('falls back to displayName when the language name is missing', () => {
+    const s = buildFallbackPlan(subjects, 'en').blocks[0].groups[0].subjects.find(x => x.code === 'EBC-XX')!;
+    expect(s.name).toBe('Display Only');
+  });
+
+  it('missing subjectId maps to empty id', () => {
+    const s = buildFallbackPlan(subjects, 'cs').blocks[0].groups[0].subjects.find(x => x.code === 'EBC-XX')!;
+    expect(s.id).toBe('');
+  });
+
+  it('handles an empty subjects store', () => {
+    const plan = buildFallbackPlan({ version: 1, lastUpdated: '', data: {} }, 'cs');
+    expect(plan.blocks[0].groups[0].subjects).toHaveLength(0);
+    expect(plan.creditsAcquired).toBe(0);
+    expect(plan.creditsRequired).toBe(0);
+    expect(plan.isFulfilled).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run src/components/SubjectsPanel/__tests__/buildFallbackPlan.test.ts`
+Expected: FAIL — cannot resolve `../buildFallbackPlan`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/components/SubjectsPanel/buildFallbackPlan.ts`:
+
+```ts
+import type { StudyPlan, SubjectStatus } from '@/types/studyPlan';
+import type { SubjectsData } from '@/types/documents';
+
+/**
+ * Builds a minimal one-block StudyPlan from the subjects store (student/list.pl)
+ * for students without KontrolaPlanu (e.g. Erasmus/exchange). Render-only —
+ * never persisted, so it cannot leak into other plan consumers.
+ */
+export function buildFallbackPlan(subjects: SubjectsData, language: 'cs' | 'en'): StudyPlan {
+  const items: SubjectStatus[] = Object.values(subjects.data).map(info => ({
+    id: info.subjectId ?? '',
+    code: info.subjectCode,
+    name: (language === 'en' ? info.nameEn : info.nameCs) ?? info.displayName,
+    credits: 0,
+    type: '',
+    isEnrolled: true,
+    isFulfilled: false,
+    enrollmentCount: 0,
+    rawStatusText: '',
+  }));
+
+  return {
+    title: '',
+    isFulfilled: false,
+    creditsAcquired: 0,
+    creditsRequired: 0,
+    blocks: [{ title: '', groups: [{ name: '', statusDescription: '', subjects: items }] }],
+    zameranis: [],
+  };
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run src/components/SubjectsPanel/__tests__/buildFallbackPlan.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Typecheck, build, commit**
+
+Run: `npm run typecheck && npm run build`
+Expected: both exit 0.
+
+```bash
+git add src/components/SubjectsPanel/buildFallbackPlan.ts src/components/SubjectsPanel/__tests__/buildFallbackPlan.test.ts
+git commit -m "feat(subjects): buildFallbackPlan maps subjects store to a minimal StudyPlan"
+```
+
+---
+
+### Task 2: SubjectsPanel fallback branch + i18n
+
+**Files:**
+- Modify: `src/components/SubjectsPanel/index.tsx` (currently 70 lines — full replacement below)
+- Modify: `src/i18n/locales/en.json` (add one key inside the existing `"subjects"` object)
+- Modify: `src/i18n/locales/cs.json` (same key)
+- Test: `src/components/SubjectsPanel/__tests__/SubjectsPanel.fallback.test.tsx`
+
+**Interfaces:**
+- Consumes: `buildFallbackPlan(subjects: SubjectsData, language: 'cs' | 'en'): StudyPlan` from Task 1; existing `EnrolledNowSection` (`plan`, `failRates`, `onOpenSubject`, `onSearchSubject` props); existing store fields `subjects`, `language`, `studyPlanLoaded`, `syncStatus`.
+- Produces: nothing consumed by later tasks (final task).
+
+- [ ] **Step 1: Write the failing component test**
+
+Create `src/components/SubjectsPanel/__tests__/SubjectsPanel.fallback.test.tsx`:
+
+```tsx
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { StudyPlan } from '@/types/studyPlan';
+import type { SubjectsData } from '@/types/documents';
+
+// EnrolledNowSection has deep child deps (SubjectRow etc.) — replace with a
+// marker that exposes which subject codes it received.
+vi.mock('../EnrolledNowSection', () => ({
+  EnrolledNowSection: ({ plan }: { plan: StudyPlan }) => (
+    <div data-testid="enrolled-now">
+      {plan.blocks.flatMap(b => b.groups.flatMap(g => g.subjects.map(s => s.code))).join(',')}
+    </div>
+  ),
+}));
+// Avoid the success-rate batch fetch effect inside useSubjectsData.
+vi.mock('../useSubjectsData', () => ({
+  useSubjectsData: () => ({
+    zameraniLookup: new Map(), subjectSemesters: new Map(), subjectToZameranis: new Map(),
+    zameraniProgress: new Map(), failRates: {}, enrolledCredits: 0,
+  }),
+}));
+
+import { SubjectsPanel } from '../index';
+import { useAppStore } from '@/store/useAppStore';
+
+const subjects: SubjectsData = {
+  version: 1,
+  lastUpdated: '2026-07-02T00:00:00.000Z',
+  data: {
+    'EBC-ST': {
+      displayName: 'Statistika', fullName: 'EBC-ST Statistika', nameCs: 'Statistika', nameEn: 'Statistics',
+      subjectCode: 'EBC-ST', subjectId: '123456',
+      folderUrl: 'https://is.mendelu.cz/auth/dok_server/slozka.pl?id=1', fetchedAt: '',
+    },
+  },
+};
+
+const emptyPlan: StudyPlan = {
+  title: 'Empty', isFulfilled: false, creditsAcquired: 0, creditsRequired: 0,
+  blocks: [{ title: '1. semestr', groups: [{ name: 'G', statusDescription: '', subjects: [] }] }],
+};
+
+function setStore(overrides: { plan?: StudyPlan | null; subjects?: SubjectsData | null }) {
+  useAppStore.setState({
+    language: 'en',
+    studyPlanDual: overrides.plan ? { cz: overrides.plan, en: overrides.plan } : null,
+    studyPlanLoaded: true,
+    subjects: overrides.subjects ?? null,
+    syncStatus: { ...useAppStore.getState().syncStatus, handshakeDone: true, handshakeTimedOut: false, isSyncing: false },
+  });
+}
+
+function renderPanel() {
+  return render(
+    <SubjectsPanel onOpenSubject={() => {}} onSearchSubject={() => {}} onOpenStudyPlan={() => {}} />
+  );
+}
+
+beforeEach(() => {
+  setStore({ plan: null, subjects: null });
+});
+
+describe('SubjectsPanel Erasmus fallback', () => {
+  it('renders the fallback card from the subjects store when the plan is null', () => {
+    setStore({ plan: null, subjects });
+    renderPanel();
+    expect(screen.getByTestId('enrolled-now').textContent).toBe('EBC-ST');
+  });
+
+  it('renders the fallback when the plan exists but has zero subjects', () => {
+    setStore({ plan: emptyPlan, subjects });
+    renderPanel();
+    expect(screen.getByTestId('enrolled-now').textContent).toBe('EBC-ST');
+  });
+
+  it('shows the exchange caption and hides the Study Plan button in fallback mode', () => {
+    setStore({ plan: null, subjects });
+    renderPanel();
+    expect(screen.getByText(/exchange studies/i)).toBeTruthy();
+    expect(screen.queryByText('Study Plan')).toBeNull();
+  });
+
+  it('still shows the noData empty state when both plan and subjects are missing', () => {
+    setStore({ plan: null, subjects: null });
+    renderPanel();
+    expect(screen.getByText('No study plan data')).toBeTruthy();
+    expect(screen.queryByTestId('enrolled-now')).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run src/components/SubjectsPanel/__tests__/SubjectsPanel.fallback.test.tsx`
+Expected: FAIL — the two fallback renders show "No study plan data" instead of the `enrolled-now` marker, and the caption test finds no match. (The noData test may already pass — that's fine.)
+
+- [ ] **Step 3: Add the i18n key**
+
+In `src/i18n/locales/en.json`, inside the existing `"subjects"` object (e.g. right after `"noData"`), add:
+
+```json
+"noPlanExchange": "Study plan isn't available for exchange studies — showing your enrolled subjects instead.",
+```
+
+In `src/i18n/locales/cs.json`, same position, add:
+
+```json
+"noPlanExchange": "Studijní plán není pro výměnná studia dostupný — zobrazujeme tvoje zapsané předměty.",
+```
+
+- [ ] **Step 4: Implement the fallback branch**
+
+Replace the full contents of `src/components/SubjectsPanel/index.tsx` with:
+
+```tsx
+import { useMemo } from 'react';
+import { ChevronRight, Info } from 'lucide-react';
+import { useStudyPlan } from '@/hooks/useStudyPlan';
+import { useAppStore } from '@/store/useAppStore';
+import { useTranslation } from '@/hooks/useTranslation';
+import { SubjectsPanelHeader } from './SubjectsPanelHeader';
+import { SubjectsPanelSkeleton } from './SubjectsPanelSkeleton';
+import { EnrolledNowSection } from './EnrolledNowSection';
+import { StudyAveragesSection } from './StudyAveragesSection';
+import { useSubjectsData } from './useSubjectsData';
+import { buildFallbackPlan } from './buildFallbackPlan';
+
+interface SubjectsPanelProps {
+  onOpenSubject: (courseCode: string, courseName: string, courseId: string, facultyCode?: string, initialTab?: 'files' | 'stats' | 'syllabus' | 'classmates', isFulfilled?: boolean) => void;
+  onSearchSubject: (name: string) => void;
+  onOpenStudyPlan: () => void;
+}
+
+export function SubjectsPanel({ onOpenSubject, onSearchSubject, onOpenStudyPlan }: SubjectsPanelProps) {
+  const { t } = useTranslation();
+  const plan = useStudyPlan();
+  const studyPlanLoaded = useAppStore(s => s.studyPlanLoaded);
+  const studyStats = useAppStore(s => s.studyStats);
+  const studyComparison = useAppStore(s => s.studyComparison);
+  const subjects = useAppStore(s => s.subjects);
+  const language = useAppStore(s => s.language);
+  const handshakeDone = useAppStore(s => s.syncStatus.handshakeDone);
+  const handshakeTimedOut = useAppStore(s => s.syncStatus.handshakeTimedOut);
+  const isSyncing = useAppStore(s => s.syncStatus.isSyncing);
+
+  // Erasmus/exchange students have no KontrolaPlanu, so the plan never
+  // materializes — fall back to the subjects store (student/list.pl).
+  const planUsable = !!plan && plan.blocks.some(b => b.groups.some(g => g.subjects.length > 0));
+  const fallbackPlan = useMemo(() => {
+    if (planUsable || !subjects || Object.keys(subjects.data).length === 0) return null;
+    return buildFallbackPlan(subjects, language === 'en' ? 'en' : 'cs');
+  }, [planUsable, subjects, language]);
+
+  const effectivePlan = planUsable ? plan : fallbackPlan;
+  const { subjectSemesters, subjectToZameranis, zameraniProgress, failRates, enrolledCredits } = useSubjectsData(effectivePlan);
+
+  if (!effectivePlan) {
+    if (!studyPlanLoaded || (!handshakeDone && !handshakeTimedOut) || isSyncing) return <SubjectsPanelSkeleton />;
+    return <div className="flex items-center justify-center h-full text-base-content/50">{t('subjects.noData')}</div>;
+  }
+
+  if (!planUsable) {
+    return (
+      <div className="h-full flex flex-col overflow-hidden">
+        <div className="px-4 pt-4 pb-0 shrink-0">
+          <div className="flex items-start gap-2 text-xs text-base-content/50 pb-3">
+            <Info className="w-3.5 h-3.5 shrink-0 mt-0.5" />
+            <span>{t('subjects.noPlanExchange')}</span>
+          </div>
+          <EnrolledNowSection
+            plan={effectivePlan}
+            failRates={failRates}
+            onOpenSubject={onOpenSubject}
+            onSearchSubject={onSearchSubject}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full flex flex-col overflow-hidden">
+      <SubjectsPanelHeader
+        creditsAcquired={effectivePlan.creditsAcquired}
+        creditsRequired={effectivePlan.creditsRequired}
+        studyStats={studyStats}
+        plan={effectivePlan}
+        zameraniProgress={zameraniProgress}
+        enrolledCredits={enrolledCredits}
+      />
+
+      <div className="px-4 pt-3 pb-0 shrink-0">
+        <EnrolledNowSection
+          plan={effectivePlan}
+          failRates={failRates}
+          subjectSemesters={subjectSemesters}
+          subjectToZameranis={subjectToZameranis}
+          onOpenSubject={onOpenSubject}
+          onSearchSubject={onSearchSubject}
+        />
+        <div className="mt-3">
+          <StudyAveragesSection studyStats={studyStats} comparison={studyComparison} />
+        </div>
+      </div>
+
+      <div className="px-4 pt-3 pb-4 shrink-0">
+        <button
+          onClick={onOpenStudyPlan}
+          className="btn btn-ghost btn-sm w-full justify-between text-base-content/60 font-medium"
+        >
+          <span>{t('subjects.studyPlan')}</span>
+          <ChevronRight className="w-4 h-4" />
+        </button>
+      </div>
+    </div>
+  );
+}
+```
+
+Notes for the implementer:
+- `useSubjectsData` accepts `StudyPlan | null` and is called unconditionally before any early return — hooks order is preserved.
+- In the fallback branch, `subjectSemesters`/`subjectToZameranis` are intentionally not passed to `EnrolledNowSection` (they're empty maps for a synthetic plan; the props are optional).
+- Do NOT add any data-fetching `useEffect` — the success-rate batch fetch already lives inside `useSubjectsData`.
+
+- [ ] **Step 5: Run the new test to verify it passes**
+
+Run: `npx vitest run src/components/SubjectsPanel/__tests__/SubjectsPanel.fallback.test.tsx`
+Expected: PASS (4 tests).
+
+- [ ] **Step 6: Run the full test suite, typecheck, lint, build**
+
+Run: `npm run test:run && npm run typecheck && npm run lint && npm run build`
+Expected: all exit 0. Pay attention to existing SubjectsPanel-adjacent tests (`StudyPlanPage*.test.tsx`, `StudyAveragesSection.test.tsx`) — they must still pass unchanged.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/SubjectsPanel/index.tsx src/components/SubjectsPanel/__tests__/SubjectsPanel.fallback.test.tsx src/i18n/locales/en.json src/i18n/locales/cs.json
+git commit -m "feat(subjects): show enrolled subjects from list.pl when study plan is missing (Erasmus)"
+```

--- a/docs/superpowers/specs/2026-07-01-is-stranky-search-design.md
+++ b/docs/superpowers/specs/2026-07-01-is-stranky-search-design.md
@@ -13,24 +13,24 @@ Approaches considered:
 2. Fold page search into the global header search (`SearchBar/useSearch.ts`) as a third result section — rejected, drags a static local page list into the subject/people search's debounced-network/relevance-scoring machinery for no benefit.
 3. Hybrid (standalone component surfaced inside the global search overlay) — rejected, biggest lift for a feature usage shows is low-value.
 
-## Component & rename
+## Component & rename — reuse `IsPortalPopover`, don't build a new modal
 
-- `src/components/Sidebar/PagePinnerModal.tsx` → renamed `src/components/Sidebar/IsPagesSearchModal.tsx` (stays ≤200 lines per project convention).
-- Modal title: i18n key `sidebar.addPinTitle` → repurposed to read "IS stránky" (same string cs/en — it's a Czech IS-system proper name, not translated).
-- Trigger row in `NavItem.tsx` and `MobileNavSheet.tsx`: currently `Plus` icon + `t('sidebar.addPin')` ("Přidat"/"Add"). Becomes a `Search` (lucide) icon + label "IS stránky", reusing the `sidebar.addPinTitle` key (or repointing `sidebar.addPin` to "IS stránky" — implementer's call, just keep cs/en in sync).
+**Deviation from the original plan (discovered while mapping files for implementation):** the codebase already has `src/components/SearchBar/IsPortalPopover.tsx`, wired to the global header search bar's grid-icon launcher (`SearchBar/index.tsx`, `SearchBar/MobileSearchOverlay.tsx`). It already does exactly what this spec needs: fuzzy-filters every category in `pagesData`, and on click resolves `injectUserParams(href, studiumId, lang)` and `window.open(url, '_blank')` **without closing**. Building a second, near-identical modal (`IsPagesSearchModal`) would duplicate ~150 lines of UI for no behavioral difference. Decision: **delete `PagePinnerModal.tsx` outright and point the Sidebar/mobile trigger at the existing `IsPortalPopover`** instead of creating a new component.
+
+- `src/components/Sidebar/PagePinnerModal.tsx` is deleted, not renamed.
+- Trigger row in `NavItem.tsx` and `MobileNavSheet.tsx`: currently `Plus` icon + `t('sidebar.addPin')` ("Přidat"/"Add"), opens `PagePinnerModal`. Becomes a `Search` (lucide) icon + label "IS stránky" (repoint the `sidebar.addPin` key to that string), opens `IsPortalPopover` via the same local `pinnerOpen`/`setPinnerOpen` state already in both files (renamed to `portalOpen`/`setPortalOpen` for clarity) — same pattern `SearchBar/index.tsx` already uses (`isPortalOpen`/`setIsPortalOpen`).
+- `IsPortalPopover` has no modal title bar of its own (the triggering button already carries the label) — so no separate "title" string is needed; `sidebar.addPinTitle` key is deleted rather than repurposed.
 - Remove: the pin-limit hint (`sidebar.pinLimitReached`), the first-time nudge tooltip (`showPinHint` state, `pin_hint_dismissed` IndexedDB key, `sidebar.pinNudge` string) — there's no pin limit or pin concept left to nudge about.
-- i18n cleanup: drop `pinNudge` and `pinLimitReached` keys from `src/i18n/locales/cs.json` and `en.json`; update `addPinTitle`/`addPin` values to "IS stránky" (cs and en).
+- i18n cleanup: drop `addPinTitle`, `pinNudge`, `pinLimitReached` keys from `src/i18n/locales/cs.json` and `en.json`; update `addPin` value to "IS stránky" (same string cs/en — it's a Czech IS-system proper name, not translated).
+- `IsPortalPopover` itself is unmodified — it already resolves `studiumId`/`language` from the store internally, so the Sidebar/mobile trigger sites don't need to plumb those through.
 
 ## Behavior
 
-- Same fuzzy-search-over-categories UI as today: `fuzzyIncludes` filters `navPages ?? pagesData` per category, grouped under category headers, exactly as `PagePinnerModal` does now.
-- Each result row becomes a plain clickable item (no `Check`/pin icon). On click:
-  1. Resolve the URL: `injectUserParams(page.href, studiumId, lang, obdobiId)` (the modal needs `studiumId`/`obdobiId` from the store — currently only `MainItems.tsx` does this resolution for pinned children; the modal itself must now pull these the same way).
-  2. `window.open(url, '_blank', 'noopener,noreferrer')`.
-  3. **Modal stays open** — no auto-close after a click, so the user can open several pages in one search session.
-- The search input keeps its value/focus between clicks (no auto-clear) — re-searching is just editing the existing query.
-- Esc / backdrop click still closes the modal, unchanged from today.
-- The modal's open/close trigger wiring (`pinnerOpen` state in `NavItem.tsx`/`MobileNavSheet.tsx`) is unchanged — only the label/icon on the row that opens it changes.
+All of this is existing, already-shipped behavior in `IsPortalPopover` — nothing to build, only to point the Sidebar/mobile trigger at it:
+- Fuzzy-filters every category in `pagesData` as the user types (accent-insensitive `strip()` + `includes()`), grouped under category headers with icons.
+- Each result is a plain clickable item. On click: `injectUserParams(href, studiumId, language === 'en' ? 'en' : 'cz')` → `window.open(finalUrl, '_blank')`. **Stays open** after a click (no `onClose()` call in `handleLinkClick`), so the user can open several pages in one session.
+- Filter input keeps its value between clicks; Esc isn't wired but the `X` close button and backdrop click close it.
+- One behavior gap vs. the old pin-modal flow: `IsPortalPopover` doesn't use `navPages` (the live-scraped category list with corrected ids/labels) — it always reads the static `pagesData` import. This already matches how the global search's grid-icon launcher behaves today, so it's an accepted pre-existing characteristic, not a regression introduced by this change.
 
 ## Data/state removal
 
@@ -49,10 +49,10 @@ Delete entirely:
 
 ## Testing
 
-Per project convention (test-first, no `useEffect` for data fetching, etc.):
-- Rewrite the existing `PagePinnerModal` test suite (move/rename to `IsPagesSearchModal`) to cover: fuzzy search filters pages across categories; clicking a result calls `window.open` with the `injectUserParams`-resolved URL; the modal does **not** close after a click; Esc/backdrop-click still closes it.
-- Delete `createPinnedPagesSlice`'s test file along with the slice.
-- Update any `MainItems.tsx` / `NavItem.tsx` / `MobileNavSheet.tsx` tests that assert pin/unpin behavior or the 6-item cap — remove those assertions; add/keep coverage that the "Student" flyout renders exactly its 4 static children.
+Neither `PagePinnerModal.tsx` nor `createPinnedPagesSlice.ts` has an existing test file (verified — none found under `__tests__`), so there's nothing to delete on that front. `IsPortalPopover` itself is untouched, so its existing behavior needs no new tests. What does need attention:
+- `src/utils/__tests__/noHardcodedIds.test.ts` has a hard assertion (`should be used for pinned pages in MainItems.tsx`) checking that the literal string `href: injectUserParams(p.href, sid, lang, oid)` exists in `MainItems.tsx`. That line is deleted as part of this change (the `is` category's `children` goes back to its 4 static entries), so this test must be updated — delete that specific `it(...)` block; the sibling assertion covering `SearchBar/index.tsx`'s `injectUserParams` usage is untouched and still valid.
+- Any test asserting on `MenuItem.isPinned`, `pinnedPages`, or the 6-item cap (search the test suite for these before starting, since none were found during design-time exploration but the codebase may have changed) must be removed.
+- New coverage isn't required for `NavItem.tsx`/`MobileNavSheet.tsx`'s trigger-row change beyond what TypeScript + the build already enforce, since the row now just flips a boolean and renders an existing, already-tested-by-shipping component.
 
 ## Out of scope
 

--- a/docs/superpowers/specs/2026-07-02-erasmus-subjects-fallback-design.md
+++ b/docs/superpowers/specs/2026-07-02-erasmus-subjects-fallback-design.md
@@ -1,0 +1,87 @@
+# Erasmus Subjects Fallback — Design
+
+**Date:** 2026-07-02
+**Status:** Approved
+
+## Problem
+
+The Předměty view (`currentView === 'subjects'` → `SubjectsPanel`) is driven entirely by
+the StudyPlan parsed from `studijni_povinnosti.pl` (KontrolaPlanu). Erasmus/exchange
+students have no KontrolaPlanu page — the study plan never materializes, so they see the
+`subjects.noData` empty state even though their enrolled subjects are known.
+
+Their enrolled subjects are already synced for everyone (including Erasmus students) from
+`student/list.pl` via `fetchDualLanguageSubjects` → `syncSubjects` → the `subjects` store
+(Zustand + IDB). That store carries code, CZ+EN names, `subjectId`, and folder URL —
+everything the subject drawer needs.
+
+## Decision
+
+When the study plan is missing or empty and the `subjects` store has data, `SubjectsPanel`
+renders a fallback: the existing "Enrolled now" card populated from the `subjects` store,
+plus a muted caption explaining the study plan is not available for exchange studies.
+Nothing else (plan header, study averages, Study Plan button) is shown — that data does
+not exist without KontrolaPlanu.
+
+### Gating
+
+- Plan is **usable** iff it is non-null AND contains ≥ 1 subject across
+  `blocks[].groups[].subjects`.
+- Plan not usable AND `subjects.data` non-empty → **fallback branch**.
+- Plan not usable AND subjects also empty → current behavior unchanged
+  (skeleton while loading, then `subjects.noData`).
+- The gate does **not** use the `isErasmus` flag — any student whose KontrolaPlanu is
+  absent or fails to parse gets the fallback. Regular students always have a usable plan,
+  so nothing changes for them.
+
+## Approach: scoped synthetic plan (chosen)
+
+A small pure helper builds a minimal `StudyPlan` from the subjects store and feeds it into
+the existing `EnrolledNowSection` — confined to this one render branch, never persisted.
+
+- **New util** (new file, e.g. `src/components/SubjectsPanel/buildFallbackPlan.ts`):
+  `buildFallbackPlan(subjects: SubjectsData, language: 'cs' | 'en'): StudyPlan`
+  - One block, one group; each `SubjectInfo` maps to a `SubjectStatus` with
+    `isEnrolled: true`, `isFulfilled: false`, `credits: 0`, `enrollmentCount: 0`,
+    `id` = `subjectId ?? ''`, `code` = `subjectCode`,
+    `name` = `nameEn`/`nameCs` picked by current language (fallback to `displayName`).
+  - Plan scalars: `isFulfilled: false`, `creditsAcquired: 0`, `creditsRequired: 0`,
+    `zameranis: []`, neutral title.
+- **`SubjectsPanel` branch:** when gated into fallback, render only
+  `EnrolledNowSection` with the synthetic plan + the caption line. `useSubjectsData`
+  runs on the synthetic plan unchanged, so fail-rate chips and the success-rate batch
+  fetch work for free; `SubjectRow` → `onOpenSubject` (files/stats/syllabus/classmates
+  drawer) works untouched. Semester labels render as "–" (block title has no
+  semester number), which is correct — there is no plan semester to show.
+- **i18n:** new key (e.g. `subjects.noPlanExchange`) in both
+  `src/i18n/locales/cs.json` and `en.json`.
+
+### Alternatives considered
+
+1. **Dedicated fallback component** reading `useSubjects()` directly — conceptually
+   cleaner (no fake plan object) but duplicates EnrolledNowSection's card chrome and
+   success-rate wiring for identical pixels. Rejected.
+2. **Synthesize the plan at sync time** — would persist a fake plan into IDB and poison
+   other plan consumers (StudyPlanPage, insights, ErasmusPanel unfulfilled-courses).
+   Rejected; violates the "plan = KontrolaPlanu" invariant.
+
+## Data flow
+
+`student/list.pl` (already synced, dual-language) → `subjects` store →
+`buildFallbackPlan` (pure, per-render, language-aware) → `EnrolledNowSection`.
+
+No new fetching, no sync changes, no new persistence.
+
+## Error handling
+
+None new. Inputs are already validated by the existing sync path; the fallback is pure
+derivation. If the subjects store is empty or malformed, the gate simply doesn't fire and
+the existing empty state shows.
+
+## Testing (test-first, per project rules)
+
+1. Unit tests for `buildFallbackPlan`: mapping of fields, language pick (cs/en, fallback
+   to `displayName`), empty input → empty block.
+2. Component test for `SubjectsPanel`: with empty/null plan and non-empty subjects store,
+   the fallback card and caption render (and header/averages/Study Plan button do not);
+   with both empty, `subjects.noData` still renders.

--- a/src/components/SubjectsPanel/__tests__/SubjectsPanel.fallback.test.tsx
+++ b/src/components/SubjectsPanel/__tests__/SubjectsPanel.fallback.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { StudyPlan } from '@/types/studyPlan';
+import type { SubjectsData } from '@/types/documents';
+
+// EnrolledNowSection has deep child deps (SubjectRow etc.) — replace with a
+// marker that exposes which subject codes it received.
+vi.mock('../EnrolledNowSection', () => ({
+  EnrolledNowSection: ({ plan }: { plan: StudyPlan }) => (
+    <div data-testid="enrolled-now">
+      {plan.blocks.flatMap(b => b.groups.flatMap(g => g.subjects.map(s => s.code))).join(',')}
+    </div>
+  ),
+}));
+// Avoid the success-rate batch fetch effect inside useSubjectsData.
+vi.mock('../useSubjectsData', () => ({
+  useSubjectsData: () => ({
+    zameraniLookup: new Map(), subjectSemesters: new Map(), subjectToZameranis: new Map(),
+    zameraniProgress: new Map(), failRates: {}, enrolledCredits: 0,
+  }),
+}));
+
+import { SubjectsPanel } from '../index';
+import { useAppStore } from '@/store/useAppStore';
+
+const subjects: SubjectsData = {
+  version: 1,
+  lastUpdated: '2026-07-02T00:00:00.000Z',
+  data: {
+    'EBC-ST': {
+      displayName: 'Statistika', fullName: 'EBC-ST Statistika', nameCs: 'Statistika', nameEn: 'Statistics',
+      subjectCode: 'EBC-ST', subjectId: '123456',
+      folderUrl: 'https://is.mendelu.cz/auth/dok_server/slozka.pl?id=1', fetchedAt: '',
+    },
+  },
+};
+
+const emptyPlan: StudyPlan = {
+  title: 'Empty', isFulfilled: false, creditsAcquired: 0, creditsRequired: 0,
+  blocks: [{ title: '1. semestr', groups: [{ name: 'G', statusDescription: '', subjects: [] }] }],
+};
+
+function setStore(overrides: { plan?: StudyPlan | null; subjects?: SubjectsData | null }) {
+  useAppStore.setState({
+    language: 'en',
+    studyPlanDual: overrides.plan ? { cz: overrides.plan, en: overrides.plan } : null,
+    studyPlanLoaded: true,
+    subjects: overrides.subjects ?? null,
+    syncStatus: { ...useAppStore.getState().syncStatus, handshakeDone: true, handshakeTimedOut: false, isSyncing: false },
+  });
+}
+
+function renderPanel() {
+  return render(
+    <SubjectsPanel onOpenSubject={() => {}} onSearchSubject={() => {}} onOpenStudyPlan={() => {}} />
+  );
+}
+
+beforeEach(() => {
+  setStore({ plan: null, subjects: null });
+});
+
+describe('SubjectsPanel Erasmus fallback', () => {
+  it('renders the fallback card from the subjects store when the plan is null', () => {
+    setStore({ plan: null, subjects });
+    renderPanel();
+    expect(screen.getByTestId('enrolled-now').textContent).toBe('EBC-ST');
+  });
+
+  it('renders the fallback when the plan exists but has zero subjects', () => {
+    setStore({ plan: emptyPlan, subjects });
+    renderPanel();
+    expect(screen.getByTestId('enrolled-now').textContent).toBe('EBC-ST');
+  });
+
+  it('shows the exchange caption and hides the Study Plan button in fallback mode', () => {
+    setStore({ plan: null, subjects });
+    renderPanel();
+    expect(screen.getByText(/exchange studies/i)).toBeTruthy();
+    expect(screen.queryByText('Study Plan')).toBeNull();
+  });
+
+  it('still shows the noData empty state when both plan and subjects are missing', () => {
+    setStore({ plan: null, subjects: null });
+    renderPanel();
+    expect(screen.getByText('No study plan data')).toBeTruthy();
+    expect(screen.queryByTestId('enrolled-now')).toBeNull();
+  });
+});

--- a/src/components/SubjectsPanel/__tests__/SubjectsPanel.fallback.test.tsx
+++ b/src/components/SubjectsPanel/__tests__/SubjectsPanel.fallback.test.tsx
@@ -40,11 +40,11 @@ const emptyPlan: StudyPlan = {
   blocks: [{ title: '1. semestr', groups: [{ name: 'G', statusDescription: '', subjects: [] }] }],
 };
 
-function setStore(overrides: { plan?: StudyPlan | null; subjects?: SubjectsData | null }) {
+function setStore(overrides: { plan?: StudyPlan | null; subjects?: SubjectsData | null; studyPlanLoaded?: boolean }) {
   useAppStore.setState({
     language: 'en',
     studyPlanDual: overrides.plan ? { cz: overrides.plan, en: overrides.plan } : null,
-    studyPlanLoaded: true,
+    studyPlanLoaded: overrides.studyPlanLoaded ?? true,
     subjects: overrides.subjects ?? null,
     syncStatus: { ...useAppStore.getState().syncStatus, handshakeDone: true, handshakeTimedOut: false, isSyncing: false },
   });
@@ -85,5 +85,12 @@ describe('SubjectsPanel Erasmus fallback', () => {
     renderPanel();
     expect(screen.getByText('No study plan data')).toBeTruthy();
     expect(screen.queryByTestId('enrolled-now')).toBeNull();
+  });
+
+  it('renders the skeleton, not the fallback, when subjects are present but the plan has not settled yet', () => {
+    setStore({ plan: null, subjects, studyPlanLoaded: false });
+    renderPanel();
+    expect(screen.queryByTestId('enrolled-now')).toBeNull();
+    expect(screen.queryByText(/exchange studies/i)).toBeNull();
   });
 });

--- a/src/components/SubjectsPanel/__tests__/SubjectsPanel.fallback.test.tsx
+++ b/src/components/SubjectsPanel/__tests__/SubjectsPanel.fallback.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import type { StudyPlan } from '@/types/studyPlan';
 import type { SubjectsData } from '@/types/documents';
 
@@ -92,5 +92,19 @@ describe('SubjectsPanel Erasmus fallback', () => {
     renderPanel();
     expect(screen.queryByTestId('enrolled-now')).toBeNull();
     expect(screen.queryByText(/exchange studies/i)).toBeNull();
+  });
+
+  it('does not collapse the fallback back to a skeleton when a periodic background resync flips isSyncing', () => {
+    setStore({ plan: null, subjects });
+    renderPanel();
+    expect(screen.getByTestId('enrolled-now').textContent).toBe('EBC-ST');
+
+    act(() => {
+      useAppStore.setState({
+        syncStatus: { ...useAppStore.getState().syncStatus, isSyncing: true },
+      });
+    });
+
+    expect(screen.getByTestId('enrolled-now').textContent).toBe('EBC-ST');
   });
 });

--- a/src/components/SubjectsPanel/__tests__/buildFallbackPlan.test.ts
+++ b/src/components/SubjectsPanel/__tests__/buildFallbackPlan.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { buildFallbackPlan } from '../buildFallbackPlan';
+import type { SubjectsData } from '@/types/documents';
+
+const subjects: SubjectsData = {
+  version: 1,
+  lastUpdated: '2026-07-02T00:00:00.000Z',
+  data: {
+    'EBC-ST': {
+      displayName: 'Statistika (display)',
+      fullName: 'EBC-ST Statistika',
+      nameCs: 'Statistika',
+      nameEn: 'Statistics',
+      subjectCode: 'EBC-ST',
+      subjectId: '123456',
+      folderUrl: 'https://is.mendelu.cz/auth/dok_server/slozka.pl?id=1',
+      fetchedAt: '2026-07-02T00:00:00.000Z',
+    },
+    'EBC-XX': {
+      displayName: 'Display Only',
+      fullName: 'EBC-XX Display Only',
+      subjectCode: 'EBC-XX',
+      folderUrl: 'https://is.mendelu.cz/auth/dok_server/slozka.pl?id=2',
+      fetchedAt: '2026-07-02T00:00:00.000Z',
+    },
+  },
+};
+
+describe('buildFallbackPlan', () => {
+  it('maps every subject into one block/one group as enrolled, unfulfilled', () => {
+    const plan = buildFallbackPlan(subjects, 'cs');
+    expect(plan.blocks).toHaveLength(1);
+    expect(plan.blocks[0].groups).toHaveLength(1);
+    const list = plan.blocks[0].groups[0].subjects;
+    expect(list).toHaveLength(2);
+    const st = list.find(s => s.code === 'EBC-ST')!;
+    expect(st.id).toBe('123456');
+    expect(st.isEnrolled).toBe(true);
+    expect(st.isFulfilled).toBe(false);
+    expect(st.credits).toBe(0);
+  });
+
+  it('picks nameEn for en and nameCs for cs', () => {
+    const en = buildFallbackPlan(subjects, 'en').blocks[0].groups[0].subjects.find(s => s.code === 'EBC-ST')!;
+    const cs = buildFallbackPlan(subjects, 'cs').blocks[0].groups[0].subjects.find(s => s.code === 'EBC-ST')!;
+    expect(en.name).toBe('Statistics');
+    expect(cs.name).toBe('Statistika');
+  });
+
+  it('falls back to displayName when the language name is missing', () => {
+    const s = buildFallbackPlan(subjects, 'en').blocks[0].groups[0].subjects.find(x => x.code === 'EBC-XX')!;
+    expect(s.name).toBe('Display Only');
+  });
+
+  it('missing subjectId maps to empty id', () => {
+    const s = buildFallbackPlan(subjects, 'cs').blocks[0].groups[0].subjects.find(x => x.code === 'EBC-XX')!;
+    expect(s.id).toBe('');
+  });
+
+  it('handles an empty subjects store', () => {
+    const plan = buildFallbackPlan({ version: 1, lastUpdated: '', data: {} }, 'cs');
+    expect(plan.blocks[0].groups[0].subjects).toHaveLength(0);
+    expect(plan.creditsAcquired).toBe(0);
+    expect(plan.creditsRequired).toBe(0);
+    expect(plan.isFulfilled).toBe(false);
+  });
+});

--- a/src/components/SubjectsPanel/buildFallbackPlan.ts
+++ b/src/components/SubjectsPanel/buildFallbackPlan.ts
@@ -1,0 +1,30 @@
+import type { StudyPlan, SubjectStatus } from '@/types/studyPlan';
+import type { SubjectsData } from '@/types/documents';
+
+/**
+ * Builds a minimal one-block StudyPlan from the subjects store (student/list.pl)
+ * for students without KontrolaPlanu (e.g. Erasmus/exchange). Render-only —
+ * never persisted, so it cannot leak into other plan consumers.
+ */
+export function buildFallbackPlan(subjects: SubjectsData, language: 'cs' | 'en'): StudyPlan {
+  const items: SubjectStatus[] = Object.values(subjects.data).map(info => ({
+    id: info.subjectId ?? '',
+    code: info.subjectCode,
+    name: (language === 'en' ? info.nameEn : info.nameCs) ?? info.displayName,
+    credits: 0,
+    type: '',
+    isEnrolled: true,
+    isFulfilled: false,
+    enrollmentCount: 0,
+    rawStatusText: '',
+  }));
+
+  return {
+    title: '',
+    isFulfilled: false,
+    creditsAcquired: 0,
+    creditsRequired: 0,
+    blocks: [{ title: '', groups: [{ name: '', statusDescription: '', subjects: items }] }],
+    zameranis: [],
+  };
+}

--- a/src/components/SubjectsPanel/index.tsx
+++ b/src/components/SubjectsPanel/index.tsx
@@ -1,4 +1,5 @@
-import { ChevronRight } from 'lucide-react';
+import { useMemo } from 'react';
+import { ChevronRight, Info } from 'lucide-react';
 import { useStudyPlan } from '@/hooks/useStudyPlan';
 import { useAppStore } from '@/store/useAppStore';
 import { useTranslation } from '@/hooks/useTranslation';
@@ -7,6 +8,7 @@ import { SubjectsPanelSkeleton } from './SubjectsPanelSkeleton';
 import { EnrolledNowSection } from './EnrolledNowSection';
 import { StudyAveragesSection } from './StudyAveragesSection';
 import { useSubjectsData } from './useSubjectsData';
+import { buildFallbackPlan } from './buildFallbackPlan';
 
 interface SubjectsPanelProps {
   onOpenSubject: (courseCode: string, courseName: string, courseId: string, facultyCode?: string, initialTab?: 'files' | 'stats' | 'syllabus' | 'classmates', isFulfilled?: boolean) => void;
@@ -20,31 +22,61 @@ export function SubjectsPanel({ onOpenSubject, onSearchSubject, onOpenStudyPlan 
   const studyPlanLoaded = useAppStore(s => s.studyPlanLoaded);
   const studyStats = useAppStore(s => s.studyStats);
   const studyComparison = useAppStore(s => s.studyComparison);
+  const subjects = useAppStore(s => s.subjects);
+  const language = useAppStore(s => s.language);
   const handshakeDone = useAppStore(s => s.syncStatus.handshakeDone);
   const handshakeTimedOut = useAppStore(s => s.syncStatus.handshakeTimedOut);
   const isSyncing = useAppStore(s => s.syncStatus.isSyncing);
 
-  const { subjectSemesters, subjectToZameranis, zameraniProgress, failRates, enrolledCredits } = useSubjectsData(plan);
+  // Erasmus/exchange students have no KontrolaPlanu, so the plan never
+  // materializes — fall back to the subjects store (student/list.pl).
+  const planUsable = !!plan && plan.blocks.some(b => b.groups.some(g => g.subjects.length > 0));
+  const fallbackPlan = useMemo(() => {
+    if (planUsable || !subjects || Object.keys(subjects.data).length === 0) return null;
+    return buildFallbackPlan(subjects, language === 'en' ? 'en' : 'cs');
+  }, [planUsable, subjects, language]);
 
-  if (!plan) {
+  const effectivePlan = planUsable ? plan : fallbackPlan;
+  const { subjectSemesters, subjectToZameranis, zameraniProgress, failRates, enrolledCredits } = useSubjectsData(effectivePlan);
+
+  if (!effectivePlan) {
     if (!studyPlanLoaded || (!handshakeDone && !handshakeTimedOut) || isSyncing) return <SubjectsPanelSkeleton />;
     return <div className="flex items-center justify-center h-full text-base-content/50">{t('subjects.noData')}</div>;
+  }
+
+  if (!planUsable) {
+    return (
+      <div className="h-full flex flex-col overflow-hidden">
+        <div className="px-4 pt-4 pb-0 shrink-0">
+          <div className="flex items-start gap-2 text-xs text-base-content/50 pb-3">
+            <Info className="w-3.5 h-3.5 shrink-0 mt-0.5" />
+            <span>{t('subjects.noPlanExchange')}</span>
+          </div>
+          <EnrolledNowSection
+            plan={effectivePlan}
+            failRates={failRates}
+            onOpenSubject={onOpenSubject}
+            onSearchSubject={onSearchSubject}
+          />
+        </div>
+      </div>
+    );
   }
 
   return (
     <div className="h-full flex flex-col overflow-hidden">
       <SubjectsPanelHeader
-        creditsAcquired={plan.creditsAcquired}
-        creditsRequired={plan.creditsRequired}
+        creditsAcquired={effectivePlan.creditsAcquired}
+        creditsRequired={effectivePlan.creditsRequired}
         studyStats={studyStats}
-        plan={plan}
+        plan={effectivePlan}
         zameraniProgress={zameraniProgress}
         enrolledCredits={enrolledCredits}
       />
 
       <div className="px-4 pt-3 pb-0 shrink-0">
         <EnrolledNowSection
-          plan={plan}
+          plan={effectivePlan}
           failRates={failRates}
           subjectSemesters={subjectSemesters}
           subjectToZameranis={subjectToZameranis}

--- a/src/components/SubjectsPanel/index.tsx
+++ b/src/components/SubjectsPanel/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from 'react';
+import { useMemo, useState } from 'react';
 import { ChevronRight, Info } from 'lucide-react';
 import { useStudyPlan } from '@/hooks/useStudyPlan';
 import { useAppStore } from '@/store/useAppStore';
@@ -38,9 +38,9 @@ export function SubjectsPanel({ onOpenSubject, onSearchSubject, onOpenStudyPlan 
   // few minutes; once settled once, later isSyncing:true phases must not collapse
   // the fallback back to a skeleton mid-session for Erasmus students.
   const planSettled = studyPlanLoaded && (handshakeDone || handshakeTimedOut) && !isSyncing;
-  const settledOnce = useRef(false);
-  if (planSettled) settledOnce.current = true;
-  const gateOpen = planSettled || settledOnce.current;
+  const [settledOnce, setSettledOnce] = useState(false);
+  if (planSettled && !settledOnce) setSettledOnce(true);
+  const gateOpen = planSettled || settledOnce;
   const fallbackPlan = useMemo(() => {
     if (!gateOpen || planUsable || !subjects || Object.keys(subjects.data).length === 0) return null;
     return buildFallbackPlan(subjects, language === 'en' ? 'en' : 'cs');

--- a/src/components/SubjectsPanel/index.tsx
+++ b/src/components/SubjectsPanel/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useRef } from 'react';
 import { ChevronRight, Info } from 'lucide-react';
 import { useStudyPlan } from '@/hooks/useStudyPlan';
 import { useAppStore } from '@/store/useAppStore';
@@ -34,12 +34,17 @@ export function SubjectsPanel({ onOpenSubject, onSearchSubject, onOpenStudyPlan 
   // The fallback must wait until the plan has actually settled (loaded, handshake
   // resolved, not mid-sync) — otherwise regular students see the exchange caption
   // flash during cold load, since the subjects store (Tier 1) populates before the
-  // study plan (Tier 2 microtask).
+  // study plan (Tier 2 microtask). Latch: background resyncs flip isSyncing every
+  // few minutes; once settled once, later isSyncing:true phases must not collapse
+  // the fallback back to a skeleton mid-session for Erasmus students.
   const planSettled = studyPlanLoaded && (handshakeDone || handshakeTimedOut) && !isSyncing;
+  const settledOnce = useRef(false);
+  if (planSettled) settledOnce.current = true;
+  const gateOpen = planSettled || settledOnce.current;
   const fallbackPlan = useMemo(() => {
-    if (!planSettled || planUsable || !subjects || Object.keys(subjects.data).length === 0) return null;
+    if (!gateOpen || planUsable || !subjects || Object.keys(subjects.data).length === 0) return null;
     return buildFallbackPlan(subjects, language === 'en' ? 'en' : 'cs');
-  }, [planSettled, planUsable, subjects, language]);
+  }, [gateOpen, planUsable, subjects, language]);
 
   const effectivePlan = planUsable ? plan : fallbackPlan;
   const { subjectSemesters, subjectToZameranis, zameraniProgress, failRates, enrolledCredits } = useSubjectsData(effectivePlan);

--- a/src/components/SubjectsPanel/index.tsx
+++ b/src/components/SubjectsPanel/index.tsx
@@ -31,10 +31,15 @@ export function SubjectsPanel({ onOpenSubject, onSearchSubject, onOpenStudyPlan 
   // Erasmus/exchange students have no KontrolaPlanu, so the plan never
   // materializes — fall back to the subjects store (student/list.pl).
   const planUsable = !!plan && plan.blocks.some(b => b.groups.some(g => g.subjects.length > 0));
+  // The fallback must wait until the plan has actually settled (loaded, handshake
+  // resolved, not mid-sync) — otherwise regular students see the exchange caption
+  // flash during cold load, since the subjects store (Tier 1) populates before the
+  // study plan (Tier 2 microtask).
+  const planSettled = studyPlanLoaded && (handshakeDone || handshakeTimedOut) && !isSyncing;
   const fallbackPlan = useMemo(() => {
-    if (planUsable || !subjects || Object.keys(subjects.data).length === 0) return null;
+    if (!planSettled || planUsable || !subjects || Object.keys(subjects.data).length === 0) return null;
     return buildFallbackPlan(subjects, language === 'en' ? 'en' : 'cs');
-  }, [planUsable, subjects, language]);
+  }, [planSettled, planUsable, subjects, language]);
 
   const effectivePlan = planUsable ? plan : fallbackPlan;
   const { subjectSemesters, subjectToZameranis, zameraniProgress, failRates, enrolledCredits } = useSubjectsData(effectivePlan);

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -506,6 +506,7 @@
     "credits": "kreditů",
     "studyPlan": "Studijní plán",
     "noData": "Žádná data o studijním plánu",
+    "noPlanExchange": "Studijní plán není pro výměnná studia dostupný — zobrazujeme tvoje zapsané předměty.",
     "loading": "Načítání...",
     "fulfilled": "Splněno",
     "notFulfilled": "Nesplněno",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -506,6 +506,7 @@
     "credits": "credits",
     "studyPlan": "Study Plan",
     "noData": "No study plan data",
+    "noPlanExchange": "Study plan isn't available for exchange studies — showing your enrolled subjects instead.",
     "loading": "Loading...",
     "fulfilled": "Fulfilled",
     "notFulfilled": "Not fulfilled",


### PR DESCRIPTION
## Summary
- Erasmus/exchange students have no KontrolaPlanu (`studijni_povinnosti.pl`), so the Předměty view showed "No study plan data" for them. Their enrolled subjects are already synced for everyone from `student/list.pl` into the `subjects` store — this PR renders the existing "Enrolled now" card from that store when the study plan is missing or empty, plus a caption explaining why (`subjects.noPlanExchange`, cs+en).
- New pure helper `buildFallbackPlan(subjects, language)` maps the subjects store into a minimal one-block `StudyPlan` fed into the existing `EnrolledNowSection` — render-only, never persisted, so no other plan consumer (StudyPlanPage, insights, ErasmusPanel) can see it. Plan header, study averages, and the Study Plan button are hidden in fallback mode (that data doesn't exist without KontrolaPlanu).
- Gating is settled + latched: the fallback waits until the plan state has actually resolved (no "exchange studies" flash for regular students during the cold-load tier-1/tier-2 race) and latches once settled (no skeleton flicker for Erasmus students on every ~5-min background resync).

Spec: `docs/superpowers/specs/2026-07-02-erasmus-subjects-fallback-design.md` · Plan: `docs/superpowers/plans/2026-07-02-erasmus-subjects-fallback.md`

## Test plan
- [x] `buildFallbackPlan` unit tests: field mapping, cs/en name pick, displayName fallback, missing subjectId, empty store
- [x] `SubjectsPanel` component tests: fallback on null plan, fallback on empty plan, caption shown / Study Plan button hidden, noData preserved when both sources empty, skeleton (not fallback) before plan settles, fallback stays mounted when background resync flips `isSyncing`
- [x] Full suite: 892 passed (5 pre-existing local-fixture collection errors in ISKAM parser tests, unrelated); typecheck: only the 3 known pre-existing errors; build exits 0
- [ ] Manual smoke test with a real Erasmus account (no KontrolaPlanu) — needs a live IS session

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an “IS stránky” entry that opens a searchable launcher for sites and pages, replacing the old pinning-style flow.
  * Added an exchange-studies fallback in the Subjects view that shows enrolled subjects when the study plan is unavailable.

* **Bug Fixes**
  * Improved Subjects view behavior so exchange users no longer see an empty-state screen when enrolled subjects are available.
  * Updated related labels and messaging for clearer, localized wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->