### PR TITLE
fix(drive): rename stale-named files when the naming scheme changes

### DIFF
--- a/src/api/googleDrive.ts
+++ b/src/api/googleDrive.ts
@@ -132,6 +132,19 @@ export async function deleteFile(fileId: string): Promise<void> {
     }
 }
 
+/** Rename an existing Drive file in place (metadata-only, no content re-upload). */
+export async function renameFile(fileId: string, name: string): Promise<DriveFile> {
+    const token = await getAccessToken();
+    const res = await fetch(`${FILES_ENDPOINT}/${fileId}?fields=id,name,webViewLink`, {
+        method: 'PATCH',
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name }),
+    });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) throw new Error(`Drive rename failed: ${data?.error?.message || res.statusText}`);
+    return data as DriveFile;
+}
+
 /** Replace the content of an existing Drive file (used when the IS file changed). */
 export async function updateFileContent(fileId: string, content: Blob): Promise<DriveFile> {
     const token = await getAccessToken();

--- a/src/services/drive/__tests__/driveBackup.test.ts
+++ b/src/services/drive/__tests__/driveBackup.test.ts
@@ -18,6 +18,7 @@ const drive = vi.hoisted(() => ({
     findFileByProperty: vi.fn(async () => null),
     uploadFile: vi.fn(async () => ({ id: 'f1', name: 'f' })),
     updateFileContent: vi.fn(async () => ({ id: 'f1', name: 'f' })),
+    renameFile: vi.fn(async () => ({ id: 'f1', name: 'f' })),
     deleteFile: vi.fn(async () => {}),
     getFileLink: vi.fn(async () => null),
 }));
@@ -124,5 +125,40 @@ describe('syncDriveBackup quarantine of a permanently-failing file', () => {
         expect(manifest.quarantined).toBe(1);
         expect(manifest.failingSince).toBeNull(); // no longer a live streak
         expect(manifest.lastError).toMatch(/can't be saved/);
+    });
+});
+
+describe('syncDriveBackup rename-only pass (stale pre-fix Drive name)', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        manifest.files = {};
+        manifest.folders = { 'AAA - Name': 'folder-AAA - Name' };
+        manifest.failingSince = null;
+        manifest.lastError = null;
+    });
+
+    it('renames the Drive file in place, without re-fetching or re-uploading content, when only the computed name changed', async () => {
+        // Same date as the subject's file (see subject() above), but the Drive
+        // file still carries whatever name it was uploaded with before the
+        // multi-attachment numbering / comment-folding fix existed.
+        manifest.files['/a'] = { driveFileId: 'existingId', date: '1. 1. 2026', fileName: 'old-name.pdf' };
+
+        const r = await syncDriveBackup([subject('AAA', '/a')]);
+
+        expect(fetchWithAuth).not.toHaveBeenCalled();
+        expect(drive.uploadFile).not.toHaveBeenCalled();
+        expect(drive.updateFileContent).not.toHaveBeenCalled();
+        expect(drive.renameFile).toHaveBeenCalledWith('existingId', 'L1.pdf');
+        expect(r?.renamed).toBe(1);
+        expect(manifest.files['/a']).toEqual({ driveFileId: 'existingId', date: '1. 1. 2026', fileName: 'L1.pdf' });
+    });
+
+    it('backfills the stored name for a manifest entry with none at all (files synced before name tracking existed)', async () => {
+        manifest.files['/a'] = { driveFileId: 'existingId', date: '1. 1. 2026' };
+
+        const r = await syncDriveBackup([subject('AAA', '/a')]);
+
+        expect(drive.renameFile).toHaveBeenCalledWith('existingId', 'L1.pdf');
+        expect(r?.renamed).toBe(1);
     });
 });

--- a/src/services/drive/driveBackup.ts
+++ b/src/services/drive/driveBackup.ts
@@ -13,7 +13,7 @@ import pLimit from 'p-limit';
 import type { ParsedFile } from '../../types/documents';
 import { fetchWithAuth } from '../../api/client';
 import { isConnected } from '../../api/googleAuth';
-import { uploadFile, updateFileContent, ensureFolder, findFileByProperty, deleteFile, getFileLink } from '../../api/googleDrive';
+import { uploadFile, updateFileContent, renameFile, ensureFolder, findFileByProperty, deleteFile, getFileLink } from '../../api/googleDrive';
 import { loadManifest, saveManifest, clearManifest, acquireBackupLock, releaseBackupLock } from './driveManifest';
 import { flattenSubjectFiles, diffManifest, folderKey, linkHash, type DriveManifest } from './driveDiff';
 import { logError } from '../../utils/reportError';
@@ -39,6 +39,9 @@ export interface DriveBackupSubject {
 export interface DriveBackupResult {
     uploaded: number;
     updated: number;
+    /** Already-mirrored files whose content is unchanged but whose Drive name was
+     *  stale (e.g. a pre-fix duplicate name) — renamed in place, no re-upload. */
+    renamed: number;
     skipped: number;
     /** Files already present in Drive (found via appProperties) — manifest healed, not re-uploaded. */
     reused: number;
@@ -142,6 +145,7 @@ export async function syncDriveBackup(
     await saveManifest(manifest);
     let uploaded = 0;
     let updated = 0;
+    let renamed = 0;
     let skipped = 0;
     let reused = 0;
     // A failure is "transient" (will retry — legitimate amber) until a file has
@@ -173,8 +177,8 @@ export async function syncDriveBackup(
             const items = flattenSubjectFiles(subject.folderName, subject.files);
             const diff = diffManifest(items, manifest);
             skipped += diff.skip;
-            log(`${subject.code}: ${items.length} files → +${diff.create.length} new, ~${diff.update.length} changed, =${diff.skip} skip`);
-            if (!diff.create.length && !diff.update.length) continue;
+            log(`${subject.code}: ${items.length} files → +${diff.create.length} new, ~${diff.update.length} changed, #${diff.rename.length} renamed, =${diff.skip} skip`);
+            if (!diff.create.length && !diff.update.length && !diff.rename.length) continue;
 
             // Pre-create folders sequentially so parallel uploads can't race-create duplicates.
             for (const { pathSegments } of [...diff.create, ...diff.update.map((u) => u.item)]) {
@@ -191,7 +195,7 @@ export async function syncDriveBackup(
                         // interrupted run). Reuse it instead of uploading a duplicate.
                         const existingId = await findFileByProperty(LINK_PROP, hash);
                         if (existingId) {
-                            manifest.files[item.isLink] = { driveFileId: existingId, date: item.date };
+                            manifest.files[item.isLink] = { driveFileId: existingId, date: item.date, fileName: item.fileName };
                             clearFileFail(item.isLink);
                             reused++;
                             return;
@@ -203,7 +207,7 @@ export async function syncDriveBackup(
                             parentId ? [parentId] : undefined,
                             { [LINK_PROP]: hash },
                         );
-                        manifest.files[item.isLink] = { driveFileId: file.id, date: item.date };
+                        manifest.files[item.isLink] = { driveFileId: file.id, date: item.date, fileName: item.fileName };
                         clearFileFail(item.isLink);
                         uploaded++;
                     } catch (e) {
@@ -222,7 +226,7 @@ export async function syncDriveBackup(
                     if (sessionExpired) { transientFailed++; return; }
                     try {
                         await updateFileContent(driveFileId, await fetchBytes(item.isLink));
-                        manifest.files[item.isLink] = { driveFileId, date: item.date };
+                        manifest.files[item.isLink] = { driveFileId, date: item.date, fileName: item.fileName };
                         clearFileFail(item.isLink);
                         updated++;
                     } catch (e) {
@@ -231,6 +235,21 @@ export async function syncDriveBackup(
                         if (e instanceof IsSessionExpiredError) { sessionExpired = true; transientFailed++; }
                         else recordFileFail(item.isLink);
                         logError('Drive.update', e, { name: item.fileName });
+                    }
+                }));
+            }
+            for (const { item, driveFileId } of diff.rename) {
+                // Metadata-only Drive call — never touches IS, so it can't hit an
+                // expired-IS-session condition the way create/update's fetchBytes can.
+                tasks.push(limit(async () => {
+                    try {
+                        await renameFile(driveFileId, item.fileName);
+                        manifest.files[item.isLink] = { driveFileId, date: item.date, fileName: item.fileName };
+                        clearFileFail(item.isLink);
+                        renamed++;
+                    } catch (e) {
+                        recordFileFail(item.isLink);
+                        logError('Drive.rename', e, { name: item.fileName });
                     }
                 }));
             }
@@ -254,8 +273,8 @@ export async function syncDriveBackup(
         }
         await saveManifest(manifest);
         const failed = transientFailed + permanentFailed;
-        log(`done — uploaded ${uploaded}, updated ${updated}, reused ${reused}, skipped ${skipped}, failed ${failed}, quarantined ${manifest.quarantined}`);
-        return { uploaded, updated, skipped, reused, failed, quarantined: manifest.quarantined };
+        log(`done — uploaded ${uploaded}, updated ${updated}, renamed ${renamed}, reused ${reused}, skipped ${skipped}, failed ${failed}, quarantined ${manifest.quarantined}`);
+        return { uploaded, updated, renamed, skipped, reused, failed, quarantined: manifest.quarantined };
     } catch (e) {
         // Pass-level failure (auth/root/network) — record it so the UI can show
         // "backup failing since …" instead of silently appearing healthy. The

--- a/src/services/drive/driveDiff.test.ts
+++ b/src/services/drive/driveDiff.test.ts
@@ -136,9 +136,9 @@ describe('diffManifest', () => {
         expect(d.skip).toBe(0);
     });
 
-    it('skips files whose date is unchanged', () => {
+    it('skips files whose date and stored name are both unchanged', () => {
         const m = emptyManifest();
-        m.files['A'] = { driveFileId: 'drvA', date: 'd1' };
+        m.files['A'] = { driveFileId: 'drvA', date: 'd1', fileName: 'a' };
         const d = diffManifest(items, m);
         expect(d.skip).toBe(1);
         expect(d.create.map((i) => i.isLink)).toEqual(['B']);
@@ -146,10 +146,48 @@ describe('diffManifest', () => {
 
     it('marks a file for update when its date changed, carrying the existing Drive id', () => {
         const m = emptyManifest();
-        m.files['A'] = { driveFileId: 'drvA', date: 'OLD' };
+        m.files['A'] = { driveFileId: 'drvA', date: 'OLD', fileName: 'a' };
         const d = diffManifest(items, m);
         expect(d.update).toEqual([{ item: items[0], driveFileId: 'drvA' }]);
         expect(d.create.map((i) => i.isLink)).toEqual(['B']);
+    });
+
+    it('marks a file for rename when its date is unchanged but the computed name differs from what is stored', () => {
+        const m = emptyManifest();
+        m.files['A'] = { driveFileId: 'drvA', date: 'd1', fileName: 'old-name.pdf' };
+        const d = diffManifest(items, m);
+        expect(d.rename).toEqual([{ item: items[0], driveFileId: 'drvA' }]);
+        expect(d.update).toEqual([]);
+        expect(d.create.map((i) => i.isLink)).toEqual(['B']);
+    });
+
+    it('treats a manifest entry with no stored fileName (pre-fix backup) as needing a rename', () => {
+        // Files uploaded before fileName tracking existed have no stored name at
+        // all — this is the one-time backfill path that fixes stale duplicate
+        // names (e.g. several bare "Prezentace" attachments) without re-fetching content.
+        const m = emptyManifest();
+        m.files['A'] = { driveFileId: 'drvA', date: 'd1' };
+        const d = diffManifest(items, m);
+        expect(d.rename).toEqual([{ item: items[0], driveFileId: 'drvA' }]);
+    });
+
+    it('skips a file when both date and stored fileName are unchanged', () => {
+        const m = emptyManifest();
+        m.files['A'] = { driveFileId: 'drvA', date: 'd1', fileName: 'a' };
+        m.files['B'] = { driveFileId: 'drvB', date: 'd1', fileName: 'b' };
+        const d = diffManifest(items, m);
+        expect(d.rename).toEqual([]);
+        expect(d.update).toEqual([]);
+        expect(d.create).toEqual([]);
+        expect(d.skip).toBe(2);
+    });
+
+    it('prefers update over rename when both the date and the name changed', () => {
+        const m = emptyManifest();
+        m.files['A'] = { driveFileId: 'drvA', date: 'OLD', fileName: 'old-name.pdf' };
+        const d = diffManifest(items, m);
+        expect(d.update).toEqual([{ item: items[0], driveFileId: 'drvA' }]);
+        expect(d.rename).toEqual([]);
     });
 });
 

--- a/src/services/drive/driveDiff.ts
+++ b/src/services/drive/driveDiff.ts
@@ -25,8 +25,10 @@ export interface DriveManifest {
     rootWebViewLink: string | null;
     /** folderKey(pathSegments) → Drive folder id. */
     folders: Record<string, string>;
-    /** isLink → mirrored file state. */
-    files: Record<string, { driveFileId: string; date: string }>;
+    /** isLink → mirrored file state. `fileName` is optional for back-compat with
+     *  manifests written before name tracking existed — absent means "unknown",
+     *  which diffManifest treats as needing a rename to backfill it. */
+    files: Record<string, { driveFileId: string; date: string; fileName?: string }>;
     /** isLink → consecutive failed-pass count, for files not yet mirrored. */
     fileFails: Record<string, number>;
     /** How many files have failed enough passes to be deemed permanently un-mirrorable. */
@@ -46,6 +48,9 @@ export interface DriveManifest {
 export interface DriveDiff {
     create: DriveSyncItem[];
     update: { item: DriveSyncItem; driveFileId: string }[];
+    /** Content unchanged, but the computed name no longer matches what's stored —
+     *  a cheap metadata-only rename, no re-fetch/re-upload of bytes needed. */
+    rename: { item: DriveSyncItem; driveFileId: string }[];
     skip: number;
 }
 
@@ -130,10 +135,11 @@ export function flattenSubjectFiles(subjectFolderName: string, parsedFiles: Pars
     return items;
 }
 
-/** Split items into create / update / skip relative to what the manifest already mirrors. */
+/** Split items into create / update / rename / skip relative to what the manifest already mirrors. */
 export function diffManifest(items: DriveSyncItem[], manifest: DriveManifest): DriveDiff {
     const create: DriveSyncItem[] = [];
     const update: { item: DriveSyncItem; driveFileId: string }[] = [];
+    const rename: { item: DriveSyncItem; driveFileId: string }[] = [];
     let skip = 0;
 
     for (const item of items) {
@@ -142,10 +148,12 @@ export function diffManifest(items: DriveSyncItem[], manifest: DriveManifest): D
             create.push(item);
         } else if (existing.date !== item.date) {
             update.push({ item, driveFileId: existing.driveFileId });
+        } else if (existing.fileName !== item.fileName) {
+            rename.push({ item, driveFileId: existing.driveFileId });
         } else {
             skip++;
         }
     }
 
-    return { create, update, skip };
+    return { create, update, rename, skip };
 }


### PR DESCRIPTION
## Summary
- Files uploaded to the Drive backup before the multi-attachment numbering fix (`d54e7bd`) kept their generic, duplicate name forever (e.g. six identical "Prezentace" PDFs from one IS row's attachments) — the sync only ever created or overwrote content, never renamed an already-mirrored Drive file.
- The manifest now tracks each file's last-applied name (`fileName`). `diffManifest` gained a `rename` bucket: when the freshly computed name differs from what's stored (including manifest entries with no stored name at all, from before this tracking existed), the backup renames the Drive file in place via a cheap metadata-only Drive call — no re-fetch/re-upload of content.
- Root cause was confirmed against real IS Mendelu data (a subject's document row named "Prezentace" with 6 attachments, each with its own real filename that the parser currently doesn't surface, and an empty teacher comment — so the existing name/comment-fold logic contributes nothing and only the per-attachment numbering disambiguates them).

## Test plan
- [x] Wrote failing tests first for the new `rename` bucket in `driveDiff.test.ts` (4 cases) and the orchestrator wiring in `driveBackup.test.ts` (2 cases), confirmed red, then implemented
- [x] `npx vitest run` — 915 passing (5 unrelated pre-existing failures from gitignored local fixtures missing in this checkout)
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint --max-warnings=0` on changed files — clean
- [x] `npm run build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)