### PR TITLE
feat(dev): drive reIS UI under Chrome MCP via web-origin iframe

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,27 @@ npm run typecheck        # TypeScript strict check
 
 Run a single test file: `npx vitest run src/store/slices/__tests__/someSlice.test.ts`
 
+## Live UI testing with Chrome MCP
+
+Chrome MCP (`claude-in-chrome`) **cannot** drive the normal extension: reIS renders
+inside a `chrome-extension://` iframe, and one extension may not access another
+extension's frame, so every screenshot/JS/click on `is.mendelu.cz` throws
+`Cannot access a chrome-extension:// URL of different extension`. Workaround: serve
+the **real** iframe app from a web origin, which MCP *can* introspect.
+
+- **Quick UI check (Tier 1, no extension, mock data):**
+  `npm run iframe-dev` → point Chrome MCP at `http://localhost:5199/main.html`.
+  Renders the full styled app with mock data; drive/screenshot/click it directly.
+- **Full real-data (Tier 2):** `npm run iframe-dev` **and** `npm run build:mcp`
+  (sets `VITE_IFRAME_ORIGIN=http://localhost:5199`) → load `.output/chrome-mv3`
+  unpacked → visit `is.mendelu.cz/auth/`. The content script frames localhost so
+  MCP can see it; real synced data flows via postMessage.
+
+`VITE_IFRAME_ORIGIN` gates `resolveIframeSrc()`/`resolveIframeOrigin()` in
+`src/injector/iframeManager.ts` — the **normal `npm run build` is unaffected**
+(packaged `chrome-extension://` iframe). Full detail:
+`docs/superpowers/specs/2026-07-04-mcp-web-origin-iframe-design.md`.
+
 ## Release
 
 Pushing a `v*` tag triggers `.github/workflows/publish.yml` → builds Chrome + Firefox zips → submits to all three stores via `wxt submit`. Use `/release` to automate the full flow.

--- a/dev-iframe/chromeStub.ts
+++ b/dev-iframe/chromeStub.ts
@@ -1,0 +1,57 @@
+// Minimal `chrome.*` stub so the real reIS iframe app boots at a plain http
+// origin (mirrors src/test/setup.ts). Imported first in entry.tsx, before any
+// app module, so StorageService/SyncMigration/etc. find chrome.storage.
+//
+// This exists to run the iframe UI at http://localhost for Chrome MCP debugging
+// (claude-in-chrome cannot access a different extension's chrome-extension://
+// frame — see docs/superpowers/specs/2026-07-04-mcp-web-origin-iframe-design.md).
+const g = globalThis as unknown as { chrome?: Record<string, unknown> };
+
+if (!g.chrome) g.chrome = {};
+
+const mem: Record<string, unknown> = {};
+function compute(keys?: unknown): Record<string, unknown> {
+  if (keys == null) return { ...mem };
+  if (typeof keys === 'string') return { [keys]: mem[keys] };
+  if (Array.isArray(keys)) return Object.fromEntries(keys.map(k => [k, mem[k]]));
+  return Object.fromEntries(Object.keys(keys as object).map(k => [k, mem[k] ?? (keys as Record<string, unknown>)[k]]));
+}
+function makeArea() {
+  return {
+    get: (keys?: unknown, cb?: (r: unknown) => void) => {
+      if (typeof keys === 'function') { (keys as (r: unknown) => void)(compute()); return; }
+      const res = compute(keys);
+      if (typeof cb === 'function') { cb(res); return; }
+      return Promise.resolve(res);
+    },
+    set: (obj: Record<string, unknown>, cb?: () => void) => {
+      Object.assign(mem, obj);
+      if (typeof cb === 'function') { cb(); return; }
+      return Promise.resolve();
+    },
+    remove: (k: string | string[], cb?: () => void) => {
+      (Array.isArray(k) ? k : [k]).forEach(x => delete mem[x]);
+      if (typeof cb === 'function') { cb(); return; }
+      return Promise.resolve();
+    },
+    clear: (cb?: () => void) => {
+      for (const key of Object.keys(mem)) delete mem[key];
+      if (typeof cb === 'function') { cb(); return; }
+      return Promise.resolve();
+    },
+  };
+}
+
+if (!g.chrome.storage) {
+  const area = makeArea();
+  g.chrome.storage = { local: area, sync: area, onChanged: { addListener() {}, removeListener() {} } };
+}
+if (!g.chrome.runtime) {
+  g.chrome.runtime = {
+    id: 'dev-iframe',
+    getManifest: () => ({ version: '0.0.0' }),
+    getURL: (p: string) => '/' + p,
+    onMessage: { addListener() {}, removeListener() {} },
+    sendMessage: () => Promise.resolve(),
+  };
+}

--- a/dev-iframe/entry.tsx
+++ b/dev-iframe/entry.tsx
@@ -1,0 +1,4 @@
+// Boots the REAL reIS iframe app at an http origin for Chrome MCP debugging.
+// chromeStub MUST be imported before main.tsx so the store finds chrome.storage.
+import './chromeStub';
+import '@/entrypoints/main/main.tsx';

--- a/dev-iframe/main.html
+++ b/dev-iframe/main.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="cs" data-theme="mendelu-dark">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>reIS (dev iframe)</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./entry.tsx"></script>
+  </body>
+</html>

--- a/dev-iframe/vite.config.ts
+++ b/dev-iframe/vite.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import tailwindcss from '@tailwindcss/vite';
+import { resolve } from 'path';
+
+// Serves the real reIS iframe app at http://localhost:5199/main.html so
+// Chrome MCP (claude-in-chrome) can drive the UI live. A CDP client cannot
+// screenshot/script a *different extension's* chrome-extension:// frame, so in
+// the `build:mcp` build the content script points its iframe here instead.
+// See docs/superpowers/specs/2026-07-04-mcp-web-origin-iframe-design.md
+export default defineConfig({
+  root: resolve(__dirname),
+  // Serve the extension's static assets (iskam_logo.png, outlook/teams icons,
+  // fonts, emoji) so chrome.runtime.getURL('foo.png') → '/foo.png' resolves.
+  publicDir: resolve(__dirname, '../public'),
+  plugins: [react(), tailwindcss()],
+  resolve: { alias: { '@': resolve(__dirname, '../src') } },
+  server: {
+    port: 5199,
+    strictPort: true,
+    cors: true, // allow the is.mendelu.cz page to frame this origin
+  },
+});

--- a/docs/superpowers/plans/2026-07-03-society-events-location.md
+++ b/docs/superpowers/plans/2026-07-03-society-events-location.md
@@ -237,7 +237,7 @@ Insert alphabetically (after `spolky_accounts`, matching the file's existing ord
 
 ```bash
 cd /Users/dominik-personal/Documents/reis-admin
-npx tsc -b --noEmit
+npx tsc --noEmit
 ```
 
 Expected: no new errors.
@@ -679,7 +679,7 @@ export default function CampusPickerMap({
 
 ```bash
 cd /Users/dominik-personal/Documents/reis-admin
-npx tsc -b --noEmit
+npx tsc --noEmit
 ```
 
 Expected: no new errors.
@@ -1005,7 +1005,7 @@ export default function EventForm({ associationId, onRefresh, editingEvent, onCa
 
 ```bash
 cd /Users/dominik-personal/Documents/reis-admin
-npx tsc -b --noEmit
+npx tsc --noEmit
 ```
 
 Expected: no new errors.
@@ -1102,7 +1102,7 @@ export default function EventList({ events, onRefresh, onEdit }: EventListProps)
 
 ```bash
 cd /Users/dominik-personal/Documents/reis-admin
-npx tsc -b --noEmit
+npx tsc --noEmit
 ```
 
 Expected: no new errors.
@@ -1234,7 +1234,7 @@ Add a line inside the `inferredView === ...` title block, alongside the existing
 
 ```bash
 cd /Users/dominik-personal/Documents/reis-admin
-npx tsc -b --noEmit
+npx tsc --noEmit
 ```
 
 Expected: no new errors.
@@ -1519,7 +1519,7 @@ cd /Users/dominik-personal/Documents/reis-extension/.claude/worktrees/society-ma
 npm run typecheck && npm run lint && npx vitest run
 
 cd /Users/dominik-personal/Documents/reis-admin
-npx tsc -b --noEmit && npx vitest run
+npx tsc --noEmit && npx vitest run
 ```
 
 Then manually: create an event in reis-admin for each location mode, open the reis-extension campus map (`npm run dev`, load the extension, navigate to IS Mendelu), and confirm both events render as pins in the correct place with the correct society color/category emoji, and the "fly to room" click works for the campus-mode event.

--- a/docs/superpowers/plans/2026-07-03-society-events-location.md
+++ b/docs/superpowers/plans/2026-07-03-society-events-location.md
@@ -1,0 +1,1538 @@
+# Society Map Events: Location Model & Creation Flow Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let student-society organizers create/edit/delete campus-map events in reis-admin, located either in a specific campus room or anywhere in the city via a dropped pin or a searched address, and have those real events replace the reis-extension campus map's hardcoded mock data.
+
+**Architecture:** One new Supabase table (`spolky_events`) with a mode-discriminated location (`venue_kind` + `room_code` + `coord_lng/coord_lat` + `location`), RLS copied verbatim from the working `notifications` pattern. A new `src/features/events/` module in reis-admin provides create/edit/delete, embedding a small raw-Leaflet picker (building click for room mode, pin-drop + Nominatim address search for city mode) built from the same static `buildings.json`/`rooms-index.json` reis-extension already ships, duplicated into reis-admin (no shared package — see Global Constraints). reis-extension's `src/api/mapEvents.ts` swaps its mock seam for a real `select` against the new table; no changes are needed to `EventPin`/`EventDetailCard`/`EventLayer`/`EventsList` since the `MapEvent` shape is unchanged.
+
+**Tech Stack:** React 19 + TypeScript (both repos), Vite (reis-admin) / WXT (reis-extension), Supabase (`zvbpgkmnrqyprtkyxkwn`, project "reis-notifications"), Leaflet 1.9.4 (raw API, no react-leaflet), DaisyUI 5, Vitest.
+
+**Spec:** `docs/superpowers/specs/2026-07-03-society-events-location-design.md`
+
+## Global Constraints
+
+- Repos: `reis-extension` (this worktree, branch `worktree-society-map-events`) and `../reis-admin` (branch `society-map-events`, based on `origin/main`). Every reis-admin task below runs with `cwd` = `/Users/dominik-personal/Documents/reis-admin`.
+- No image upload capability (out of scope, per spec).
+- No moderation/approval queue (out of scope, per spec) — RLS trusts any active `spolky_accounts` row.
+- No in-extension creation UI (out of scope, per spec) — reis-admin only.
+- Mock data (`SEEDS`, `VENUE`, `VENUE_LABELS`, `URLS` in `src/api/mapEvents.ts`) is deleted entirely, not kept as a fallback.
+- Map styling in reis-admin's new picker must use fixed hex literals (the basemap is always light regardless of app theme) — never DaisyUI theme tokens for map layers, matching `src/components/CampusMap/mapHelpers.ts`'s existing convention in reis-extension.
+- reis-admin has zero test infrastructure today. This plan adds Vitest as a minimal dev dependency purely to TDD the two new pure logic functions (coordinate resolution, geocode-response parsing) — no component/DOM testing (no jsdom, no Testing Library) is introduced, matching the spec's explicit call that no E2E/component coverage is needed for the new admin UI.
+- No shared package is created between the two repos. `buildings.json`/`rooms-index.json` and the small map-style constants are duplicated into reis-admin; the `EventCategory` union is duplicated as a plain string-literal type. Comments at each duplication point note the reis-extension source of truth.
+- The admin form's location toggle only offers "campus" and "offcampus" — `venue_kind: 'online'` remains a valid value in the type/schema but has no UI entry point in this feature (not a regression; nothing offers it today either).
+- Room codes are stored using each room's friendly `name` field (e.g. `"Q01"`), not its opaque internal `code` (e.g. `"BA39N1009"`) — `focusRoomByCode` in reis-extension already matches on either, and `name` is what the existing mock data used.
+
+---
+
+## File Structure
+
+**reis-admin** (new branch `society-map-events`):
+- New: `supabase/migrations/20260703120000_add_spolky_events.sql`
+- Modify: `src/lib/database.types.ts` — add `spolky_events` table type
+- Modify: `package.json` — add `leaflet`, `@types/leaflet`, `vitest`, `"test"` script
+- New: `src/data/map/buildings.json`, `src/data/map/rooms-index.json` — copied static data
+- New: `src/features/events/mapStyles.ts` — duplicated style constants + `ringToLatLng`
+- New: `src/features/events/locationResolvers.ts` — pure functions (tested)
+- New: `src/features/events/locationResolvers.test.ts`
+- New: `src/features/events/nominatim.ts` — address search (tested)
+- New: `src/features/events/nominatim.test.ts`
+- New: `src/features/events/CampusPickerMap.tsx` — raw-Leaflet picker (manual verification)
+- New: `src/features/events/eventCategories.ts` — duplicated `EventCategory` union + Czech labels
+- New: `src/features/events/EventForm.tsx`
+- New: `src/features/events/EventList.tsx`
+- New: `src/features/events/index.tsx` — `EventsView`, mirrors `notifications/index.tsx`
+- Modify: `src/App.tsx` — add `/events` route
+- Modify: `src/components/Sidebar.tsx` — add nav item
+- Modify: `src/components/AppLayout.tsx` — add page title
+
+**reis-extension** (worktree `society-map-events`):
+- Modify: `src/data/societies.ts` — add `af`, `ldf`, `zf`
+- Modify: `src/api/mapEvents.ts` — real fetch, mock deleted
+- Modify: `src/api/__tests__/mapEvents.test.ts` — test the real row-mapping function
+- Modify: `src/store/slices/createMapSlice.ts` — drop now-unused `language` arg at the one call site
+- Modify: `src/data/eventCategories.ts` — delete `inferCategory` + `RULES` (mock-only, no other callers)
+
+---
+
+### Task 1: Supabase migration — `spolky_events` table + RLS
+
+**Files:**
+- Create: `/Users/dominik-personal/Documents/reis-admin/supabase/migrations/20260703120000_add_spolky_events.sql`
+
+**Interfaces:**
+- Produces: table `public.spolky_events` with columns `id, association_id, title, category, date, end_date, time, venue_kind, room_code, coord_lng, coord_lat, location, url, created_at, updated_at` — every later task's SQL/TS type must match these names exactly.
+
+- [ ] **Step 1: Write the migration file**
+
+```sql
+-- Society-authored campus-map events. Location is mode-discriminated:
+-- venue_kind='campus' carries room_code (+ coord resolved from the building's
+-- centre); venue_kind='offcampus' carries coord from a dropped pin or a
+-- geocoded address, with `location` as the free-text label. RLS mirrors the
+-- existing notifications table's association-scoped pattern exactly.
+
+CREATE TABLE public.spolky_events (
+  id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+  association_id text NOT NULL,
+  title text NOT NULL,
+  category text NOT NULL CHECK (category IN (
+    'party', 'boardgames', 'trip', 'quiz', 'sports',
+    'film', 'karaoke', 'culture', 'social', 'other'
+  )),
+  date date NOT NULL,
+  end_date date,
+  time text,
+  venue_kind text NOT NULL CHECK (venue_kind IN ('campus', 'online', 'offcampus')),
+  room_code text,
+  coord_lng double precision,
+  coord_lat double precision,
+  location text,
+  url text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.spolky_events ENABLE ROW LEVEL SECURITY;
+
+-- anon (extension): read every event, no auth on the student side
+CREATE POLICY "anon_read_spolky_events"
+  ON public.spolky_events FOR SELECT TO anon
+  USING (true);
+
+-- authenticated (admin dashboard): read every event (needed for the
+-- reis_admin "ghost" view and the social-proof read pattern already used by
+-- notifications); write only to their own association's rows.
+CREATE POLICY "auth_read_spolky_events"
+  ON public.spolky_events FOR SELECT TO authenticated
+  USING (true);
+
+CREATE POLICY "auth_insert_spolky_events"
+  ON public.spolky_events FOR INSERT TO authenticated
+  WITH CHECK (
+    association_id = (
+      SELECT association_id FROM public.spolky_accounts
+      WHERE email = (auth.jwt() ->> 'email') AND is_active = true LIMIT 1
+    )
+    OR get_my_role() = 'reis_admin'
+  );
+
+CREATE POLICY "auth_update_spolky_events"
+  ON public.spolky_events FOR UPDATE TO authenticated
+  USING (
+    association_id = (
+      SELECT association_id FROM public.spolky_accounts
+      WHERE email = (auth.jwt() ->> 'email') AND is_active = true LIMIT 1
+    )
+    OR get_my_role() = 'reis_admin'
+  )
+  WITH CHECK (
+    association_id = (
+      SELECT association_id FROM public.spolky_accounts
+      WHERE email = (auth.jwt() ->> 'email') AND is_active = true LIMIT 1
+    )
+    OR get_my_role() = 'reis_admin'
+  );
+
+CREATE POLICY "auth_delete_spolky_events"
+  ON public.spolky_events FOR DELETE TO authenticated
+  USING (
+    association_id = (
+      SELECT association_id FROM public.spolky_accounts
+      WHERE email = (auth.jwt() ->> 'email') AND is_active = true LIMIT 1
+    )
+    OR get_my_role() = 'reis_admin'
+  );
+```
+
+- [ ] **Step 2: Apply the migration to the remote project**
+
+Use the Supabase MCP tool `mcp__claude_ai_Supabase__execute_sql` with `project_id: "zvbpgkmnrqyprtkyxkwn"` and the exact SQL from Step 1 as `query`. This matches how prior migrations in this repo were applied (hand-authored file + direct execution against the remote project, no local Supabase stack).
+
+- [ ] **Step 3: Verify**
+
+Call `mcp__claude_ai_Supabase__list_tables` with `project_id: "zvbpgkmnrqyprtkyxkwn"`, `schemas: ["public"]`, `verbose: true`. Confirm `spolky_events` appears with `rls_enabled: true` and 0 rows, and its columns match Step 1 exactly.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/dominik-personal/Documents/reis-admin
+git add supabase/migrations/20260703120000_add_spolky_events.sql
+git commit -m "feat(events): add spolky_events table with association-scoped RLS"
+```
+
+---
+
+### Task 2: reis-admin database types
+
+**Files:**
+- Modify: `/Users/dominik-personal/Documents/reis-admin/src/lib/database.types.ts`
+
+**Interfaces:**
+- Consumes: the exact column set from Task 1.
+- Produces: `Tables<'spolky_events'>` usable via `import { Tables } from '@/lib/database.types'`, matching the style already used for `Tables<'notifications'>`.
+
+- [ ] **Step 1: Add the table block**
+
+Insert alphabetically (after `spolky_accounts`, matching the file's existing ordering) inside the `Tables` object:
+
+```ts
+      spolky_events: {
+        Row: {
+          association_id: string
+          category: string
+          coord_lat: number | null
+          coord_lng: number | null
+          created_at: string
+          date: string
+          end_date: string | null
+          id: string
+          location: string | null
+          room_code: string | null
+          time: string | null
+          title: string
+          updated_at: string
+          url: string | null
+          venue_kind: string
+        }
+        Insert: {
+          association_id: string
+          category: string
+          coord_lat?: number | null
+          coord_lng?: number | null
+          created_at?: string
+          date: string
+          end_date?: string | null
+          id?: string
+          location?: string | null
+          room_code?: string | null
+          time?: string | null
+          title: string
+          updated_at?: string
+          url?: string | null
+          venue_kind: string
+        }
+        Update: {
+          association_id?: string
+          category?: string
+          coord_lat?: number | null
+          coord_lng?: number | null
+          created_at?: string
+          date?: string
+          end_date?: string | null
+          id?: string
+          location?: string | null
+          room_code?: string | null
+          time?: string | null
+          title?: string
+          updated_at?: string
+          url?: string | null
+          venue_kind?: string
+        }
+        Relationships: []
+      }
+```
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+cd /Users/dominik-personal/Documents/reis-admin
+npx tsc -b --noEmit
+```
+
+Expected: no new errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/database.types.ts
+git commit -m "feat(events): add spolky_events to database.types.ts"
+```
+
+---
+
+### Task 3: Add Leaflet + Vitest tooling to reis-admin
+
+**Files:**
+- Modify: `/Users/dominik-personal/Documents/reis-admin/package.json`
+
+**Interfaces:**
+- Produces: `leaflet`/`@types/leaflet` importable by Task 6/8; `vitest` runnable by Tasks 4 and 5.
+
+- [ ] **Step 1: Install dependencies**
+
+```bash
+cd /Users/dominik-personal/Documents/reis-admin
+npm install --save-exact leaflet@1.9.4
+npm install --save-dev --save-exact @types/leaflet@1.9.21 vitest@3.2.4
+```
+
+- [ ] **Step 2: Add the test script**
+
+In `package.json` `scripts`, add:
+
+```json
+    "test": "vitest run"
+```
+
+- [ ] **Step 3: Verify**
+
+```bash
+npx vitest run
+```
+
+Expected: "No test files found" (no test files exist yet) — exits without error, confirming the runner is wired up.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add package.json package-lock.json
+git commit -m "chore: add leaflet + vitest for the events feature"
+```
+
+---
+
+### Task 4: Copy static map data + style constants into reis-admin
+
+**Files:**
+- Create: `/Users/dominik-personal/Documents/reis-admin/src/data/map/buildings.json` (copy of reis-extension's file, byte-identical)
+- Create: `/Users/dominik-personal/Documents/reis-admin/src/data/map/rooms-index.json` (copy of reis-extension's file, byte-identical)
+- Create: `/Users/dominik-personal/Documents/reis-admin/src/features/events/mapStyles.ts`
+
+**Interfaces:**
+- Produces: `BUILDING_STYLE`, `SELECTED_STYLE`, `ringToLatLng(ring: number[][]): [number, number][]` — consumed by Task 6 (`CampusPickerMap.tsx`).
+
+- [ ] **Step 1: Copy the static data files**
+
+```bash
+cp /Users/dominik-personal/Documents/reis-extension/src/data/map/buildings.json \
+   /Users/dominik-personal/Documents/reis-admin/src/data/map/buildings.json
+cp /Users/dominik-personal/Documents/reis-extension/src/data/map/rooms-index.json \
+   /Users/dominik-personal/Documents/reis-admin/src/data/map/rooms-index.json
+```
+
+- [ ] **Step 2: Write `mapStyles.ts`**
+
+```ts
+// Duplicated from reis-extension's src/components/CampusMap/mapHelpers.ts —
+// this repo has no shared package with the extension, so keep these two files
+// in sync by hand if the source ever changes. Fixed hex literals: the campus
+// basemap is always light regardless of this app's theme.
+import type { PathOptions } from 'leaflet';
+
+export const BUILDING_STYLE: PathOptions = {
+  color: '#2563eb', weight: 2, fillColor: '#3b82f6', fillOpacity: 0.25, bubblingMouseEvents: false,
+};
+
+export const SELECTED_STYLE: PathOptions = {
+  color: '#ea580c', weight: 3, fillColor: '#fb923c', fillOpacity: 0.85, bubblingMouseEvents: false,
+};
+
+// A distinct pin color for the off-campus/city mode — never orange, so it's
+// never mistaken for a selected building.
+export const PIN_COLOR = '#16a34a';
+
+export function ringToLatLng(ring: number[][]): [number, number][] {
+  return ring.map((c) => [c[1], c[0]] as [number, number]);
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/dominik-personal/Documents/reis-admin
+git add src/data/map/buildings.json src/data/map/rooms-index.json src/features/events/mapStyles.ts
+git commit -m "feat(events): add campus map data + style constants"
+```
+
+---
+
+### Task 5: Pure location-resolution logic (TDD)
+
+**Files:**
+- Create: `/Users/dominik-personal/Documents/reis-admin/src/features/events/locationResolvers.ts`
+- Test: `/Users/dominik-personal/Documents/reis-admin/src/features/events/locationResolvers.test.ts`
+
+**Interfaces:**
+- Consumes: `Building` shape `{ id: number; name: string; center: [number, number] }` (subset of `buildings.json`'s per-building objects), `RoomIndexEntry` shape `{ code: string; name: string; buildingId: number }` (subset of `rooms-index.json`'s entries).
+- Produces: `resolveBuildingCoord(buildingId, buildings): [number, number] | null`, `roomsForBuilding(buildingId, rooms): RoomIndexEntry[]` — consumed by Task 7 (`EventForm.tsx`).
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { resolveBuildingCoord, roomsForBuilding } from './locationResolvers';
+
+const BUILDINGS = [
+  { id: 0, name: 'Q', center: [16.614, 49.2096] as [number, number] },
+  { id: 5, name: 'A', center: [16.601, 49.211] as [number, number] },
+];
+
+const ROOMS = [
+  { code: 'BA39N1009', name: 'Q01', buildingId: 0 },
+  { code: 'BA39N6006', name: 'Q6.06', buildingId: 0 },
+  { code: 'XY1', name: 'A101', buildingId: 5 },
+];
+
+describe('resolveBuildingCoord', () => {
+  it('returns the matching building\'s centre', () => {
+    expect(resolveBuildingCoord(0, BUILDINGS)).toEqual([16.614, 49.2096]);
+  });
+
+  it('returns null for an unknown building id', () => {
+    expect(resolveBuildingCoord(999, BUILDINGS)).toBeNull();
+  });
+});
+
+describe('roomsForBuilding', () => {
+  it('filters rooms to the given building, sorted by name', () => {
+    const result = roomsForBuilding(0, ROOMS);
+    expect(result.map((r) => r.name)).toEqual(['Q01', 'Q6.06']);
+  });
+
+  it('returns an empty array for a building with no rooms', () => {
+    expect(roomsForBuilding(999, ROOMS)).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+cd /Users/dominik-personal/Documents/reis-admin
+npx vitest run src/features/events/locationResolvers.test.ts
+```
+
+Expected: FAIL — `locationResolvers.ts` doesn't exist yet.
+
+- [ ] **Step 3: Implement**
+
+```ts
+export interface BuildingLite {
+  id: number;
+  name: string;
+  center: [number, number];
+}
+
+export interface RoomIndexEntry {
+  code: string;
+  name: string;
+  buildingId: number;
+}
+
+export function resolveBuildingCoord(
+  buildingId: number,
+  buildings: BuildingLite[],
+): [number, number] | null {
+  const b = buildings.find((x) => x.id === buildingId);
+  return b ? b.center : null;
+}
+
+export function roomsForBuilding(
+  buildingId: number,
+  rooms: RoomIndexEntry[],
+): RoomIndexEntry[] {
+  return rooms
+    .filter((r) => r.buildingId === buildingId)
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+```bash
+npx vitest run src/features/events/locationResolvers.test.ts
+```
+
+Expected: PASS, 4 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/features/events/locationResolvers.ts src/features/events/locationResolvers.test.ts
+git commit -m "feat(events): add pure building/room location resolvers"
+```
+
+---
+
+### Task 6: Nominatim address search (TDD)
+
+**Files:**
+- Create: `/Users/dominik-personal/Documents/reis-admin/src/features/events/nominatim.ts`
+- Test: `/Users/dominik-personal/Documents/reis-admin/src/features/events/nominatim.test.ts`
+
+**Interfaces:**
+- Produces: `GeocodeResult { label: string; coord: [number, number] }`, `parseNominatimResults(raw: unknown[]): GeocodeResult[]` (pure, tested), `searchAddress(query: string): Promise<GeocodeResult[]>` (network wrapper, not unit-tested) — consumed by Task 7 (`EventForm.tsx`).
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { parseNominatimResults } from './nominatim';
+
+describe('parseNominatimResults', () => {
+  it('maps Nominatim rows into label + [lng, lat] coord', () => {
+    const raw = [
+      { display_name: 'Česká, Brno-střed, Brno, Czechia', lon: '16.606389', lat: '49.198056' },
+    ];
+    expect(parseNominatimResults(raw)).toEqual([
+      { label: 'Česká, Brno-střed, Brno, Czechia', coord: [16.606389, 49.198056] },
+    ]);
+  });
+
+  it('returns an empty array for empty input', () => {
+    expect(parseNominatimResults([])).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+cd /Users/dominik-personal/Documents/reis-admin
+npx vitest run src/features/events/nominatim.test.ts
+```
+
+Expected: FAIL — module doesn't exist.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// Free, keyless geocoding for the off-campus address-search input. Bounded to
+// a Brno viewbox (left,top,right,bottom = lon_min,lat_max,lon_max,lat_min) so
+// short/ambiguous queries resolve locally. Nominatim's usage policy caps
+// unauthenticated use at ~1 req/sec — callers must debounce.
+const BRNO_VIEWBOX = '16.40,49.28,16.75,49.10';
+
+export interface GeocodeResult {
+  label: string;
+  coord: [number, number]; // [lng, lat]
+}
+
+interface NominatimRow {
+  display_name: string;
+  lon: string;
+  lat: string;
+}
+
+export function parseNominatimResults(raw: unknown[]): GeocodeResult[] {
+  return (raw as NominatimRow[]).map((row) => ({
+    label: row.display_name,
+    coord: [parseFloat(row.lon), parseFloat(row.lat)],
+  }));
+}
+
+export async function searchAddress(query: string): Promise<GeocodeResult[]> {
+  if (!query.trim()) return [];
+  const params = new URLSearchParams({
+    q: query,
+    format: 'jsonv2',
+    limit: '5',
+    viewbox: BRNO_VIEWBOX,
+    bounded: '1',
+  });
+  const res = await fetch(`https://nominatim.openstreetmap.org/search?${params}`, {
+    headers: { 'Accept-Language': 'cs' },
+  });
+  if (!res.ok) return [];
+  const data = await res.json();
+  return parseNominatimResults(data);
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+```bash
+npx vitest run src/features/events/nominatim.test.ts
+```
+
+Expected: PASS, 2 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/features/events/nominatim.ts src/features/events/nominatim.test.ts
+git commit -m "feat(events): add Brno-bounded Nominatim address search"
+```
+
+---
+
+### Task 7: `CampusPickerMap.tsx` — raw-Leaflet picker
+
+**Files:**
+- Create: `/Users/dominik-personal/Documents/reis-admin/src/features/events/CampusPickerMap.tsx`
+
+**Interfaces:**
+- Consumes: `BUILDING_STYLE`, `SELECTED_STYLE`, `PIN_COLOR`, `ringToLatLng` (Task 4); `buildings.json` (Task 4).
+- Produces: `<CampusPickerMap mode selectedBuildingId onBuildingClick pin onPinChange />` — consumed by Task 9 (`EventForm.tsx`).
+- No automated test: this is an interactive Leaflet-DOM component and reis-admin intentionally has no jsdom/component-testing setup (see Global Constraints). Verified manually in Task 9's manual-verification step once it's wired into the form.
+
+- [ ] **Step 1: Write the component**
+
+```tsx
+import { useEffect, useRef } from 'react';
+import L from 'leaflet';
+import 'leaflet/dist/leaflet.css';
+import buildingsJson from '../../data/map/buildings.json';
+import { BUILDING_STYLE, SELECTED_STYLE, PIN_COLOR, ringToLatLng } from './mapStyles';
+
+interface BuildingsMeta {
+  buildings: Array<{
+    id: number;
+    outline: { coordinates: number[][][] };
+    center: [number, number];
+    bounds: [[number, number], [number, number]];
+  }>;
+  campus: { bounds: [[number, number], [number, number]] };
+}
+
+const META = buildingsJson as BuildingsMeta;
+
+interface CampusPickerMapProps {
+  mode: 'campus' | 'offcampus';
+  selectedBuildingId: number | null;
+  onBuildingClick: (buildingId: number) => void;
+  pin: [number, number] | null; // [lng, lat]
+  onPinChange: (coord: [number, number]) => void;
+}
+
+export default function CampusPickerMap({
+  mode, selectedBuildingId, onBuildingClick, pin, onPinChange,
+}: CampusPickerMapProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const mapRef = useRef<L.Map | null>(null);
+  const buildingLayerRef = useRef<L.LayerGroup>(L.layerGroup());
+  const markerRef = useRef<L.Marker | null>(null);
+
+  // init once
+  useEffect(() => {
+    if (!containerRef.current || mapRef.current) return;
+    const map = L.map(containerRef.current, { attributionControl: true });
+    const [[s, w], [n, e]] = META.campus.bounds;
+    map.fitBounds([[s, w], [n, e]]);
+    L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
+      attribution: '&copy; OpenStreetMap &copy; CARTO',
+      maxZoom: 20,
+    }).addTo(map);
+    buildingLayerRef.current.addTo(map);
+    mapRef.current = map;
+  }, []);
+
+  // draw / restyle buildings whenever mode or selection changes
+  useEffect(() => {
+    buildingLayerRef.current.clearLayers();
+    for (const b of META.buildings) {
+      const style = b.id === selectedBuildingId ? SELECTED_STYLE : BUILDING_STYLE;
+      const poly = L.polygon(ringToLatLng(b.outline.coordinates[0]), style);
+      if (mode === 'campus') {
+        poly.on('click', () => onBuildingClick(b.id));
+      }
+      poly.addTo(buildingLayerRef.current);
+    }
+  }, [mode, selectedBuildingId, onBuildingClick]);
+
+  // off-campus mode: click-to-drop-pin
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map || mode !== 'offcampus') return;
+    const handler = (e: L.LeafletMouseEvent) => onPinChange([e.latlng.lng, e.latlng.lat]);
+    map.on('click', handler);
+    return () => { map.off('click', handler); };
+  }, [mode, onPinChange]);
+
+  // render/move the draggable pin marker — a plain colored-circle div icon
+  // (not the default Leaflet pin) so it's visually distinct from a building
+  // selection, and draggable so the organizer can fine-tune placement after
+  // an initial click or address-search hit.
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+    if (!pin || mode !== 'offcampus') {
+      markerRef.current?.remove();
+      markerRef.current = null;
+      return;
+    }
+    const latlng: [number, number] = [pin[1], pin[0]];
+    if (!markerRef.current) {
+      const icon = L.divIcon({
+        className: '',
+        html: `<div style="width:18px;height:18px;border-radius:9999px;background:${PIN_COLOR};border:2px solid white;box-shadow:0 1px 4px rgba(0,0,0,.4);"></div>`,
+        iconSize: [18, 18],
+        iconAnchor: [9, 9],
+      });
+      const marker = L.marker(latlng, { icon, draggable: true }).addTo(map);
+      marker.on('dragend', () => {
+        const p = marker.getLatLng();
+        onPinChange([p.lng, p.lat]);
+      });
+      markerRef.current = marker;
+    } else {
+      markerRef.current.setLatLng(latlng);
+    }
+  }, [pin, mode, onPinChange]);
+
+  return <div ref={containerRef} className="w-full h-80 rounded-lg overflow-hidden border border-base-300" />;
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+cd /Users/dominik-personal/Documents/reis-admin
+npx tsc -b --noEmit
+```
+
+Expected: no new errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/features/events/CampusPickerMap.tsx
+git commit -m "feat(events): add raw-Leaflet campus/city location picker"
+```
+
+---
+
+### Task 8: Duplicated `EventCategory` union + Czech labels
+
+**Files:**
+- Create: `/Users/dominik-personal/Documents/reis-admin/src/features/events/eventCategories.ts`
+
+**Interfaces:**
+- Produces: `EventCategory` type, `CATEGORY_LABELS: Record<EventCategory, string>` — consumed by Task 9 (`EventForm.tsx`).
+
+- [ ] **Step 1: Write the file**
+
+```ts
+// Duplicated from reis-extension's src/types/events.ts `EventCategory` union —
+// keep in sync by hand if that union ever changes (no shared package between
+// the two repos; see plan Global Constraints).
+export type EventCategory =
+  | 'party' | 'boardgames' | 'trip' | 'quiz' | 'sports'
+  | 'film' | 'karaoke' | 'culture' | 'social' | 'other';
+
+export const CATEGORY_LABELS: Record<EventCategory, string> = {
+  party: 'Párty',
+  boardgames: 'Deskové hry',
+  trip: 'Výlet',
+  quiz: 'Kvíz',
+  sports: 'Sport',
+  film: 'Film',
+  karaoke: 'Karaoke',
+  culture: 'Kultura',
+  social: 'Společenská akce',
+  other: 'Ostatní',
+};
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+cd /Users/dominik-personal/Documents/reis-admin
+git add src/features/events/eventCategories.ts
+git commit -m "feat(events): add duplicated EventCategory union + Czech labels"
+```
+
+---
+
+### Task 9: `EventForm.tsx`
+
+**Files:**
+- Create: `/Users/dominik-personal/Documents/reis-admin/src/features/events/EventForm.tsx`
+
+**Interfaces:**
+- Consumes: `supabase` (`@/lib/supabase`), `DatePicker` (`@/components/DatePicker`), `toLocalDateString` (`@/lib/utils`), `resolveBuildingCoord`/`roomsForBuilding` (Task 5), `searchAddress`/`GeocodeResult` (Task 6), `CampusPickerMap` (Task 7), `EventCategory`/`CATEGORY_LABELS` (Task 8), `buildingsJson`/`roomsIndexJson` (Task 4).
+- Produces: `<EventForm associationId={string} onRefresh={() => void} />` — consumed by Task 11 (`index.tsx`).
+- Manual verification only (no automated test — see Task 7's rationale, same applies to this form).
+
+- [ ] **Step 1: Write the component**
+
+```tsx
+import { useState, useMemo } from 'react';
+import { supabase } from '@/lib/supabase';
+import { toast } from 'sonner';
+import { Plus, X, Send } from 'lucide-react';
+import { toLocalDateString } from '@/lib/utils';
+import DatePicker from '@/components/DatePicker';
+import buildingsJson from '../../data/map/buildings.json';
+import roomsIndexJson from '../../data/map/rooms-index.json';
+import { resolveBuildingCoord, roomsForBuilding, type BuildingLite, type RoomIndexEntry } from './locationResolvers';
+import { searchAddress, type GeocodeResult } from './nominatim';
+import CampusPickerMap from './CampusPickerMap';
+import { CATEGORY_LABELS, type EventCategory } from './eventCategories';
+
+const BUILDINGS = (buildingsJson as { buildings: BuildingLite[] }).buildings;
+const ROOMS = roomsIndexJson as RoomIndexEntry[];
+
+interface EventFormProps {
+  associationId: string | null;
+  onRefresh: () => void;
+}
+
+type LocationMode = 'campus' | 'offcampus';
+
+export default function EventForm({ associationId, onRefresh }: EventFormProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [title, setTitle] = useState('');
+  const [category, setCategory] = useState<EventCategory>('other');
+  const [date, setDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+  const [time, setTime] = useState('');
+  const [url, setUrl] = useState('');
+  const [mode, setMode] = useState<LocationMode>('campus');
+  const [buildingId, setBuildingId] = useState<number | null>(null);
+  const [roomCode, setRoomCode] = useState<string>('');
+  const [pin, setPin] = useState<[number, number] | null>(null);
+  const [addressQuery, setAddressQuery] = useState('');
+  const [addressResults, setAddressResults] = useState<GeocodeResult[]>([]);
+  const [addressLabel, setAddressLabel] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const roomOptions = useMemo(
+    () => (buildingId != null ? roomsForBuilding(buildingId, ROOMS) : []),
+    [buildingId],
+  );
+
+  const handleAddressSearch = async () => {
+    setAddressResults(await searchAddress(addressQuery));
+  };
+
+  const pickAddressResult = (r: GeocodeResult) => {
+    setPin(r.coord);
+    setAddressLabel(r.label);
+    setAddressResults([]);
+  };
+
+  const resetForm = () => {
+    setTitle(''); setCategory('other'); setDate(''); setEndDate(''); setTime(''); setUrl('');
+    setMode('campus'); setBuildingId(null); setRoomCode(''); setPin(null);
+    setAddressQuery(''); setAddressResults([]); setAddressLabel('');
+    setIsExpanded(false);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!associationId || !title || !date) return;
+
+    const coord = mode === 'campus'
+      ? (buildingId != null ? resolveBuildingCoord(buildingId, BUILDINGS) : null)
+      : pin;
+    const location = mode === 'campus' ? (roomCode || null) : (addressLabel || null);
+
+    setSubmitting(true);
+    try {
+      const { error } = await supabase.from('spolky_events').insert([{
+        association_id: associationId,
+        title,
+        category,
+        date,
+        end_date: endDate || null,
+        time: time || null,
+        venue_kind: mode,
+        room_code: mode === 'campus' ? (roomCode || null) : null,
+        coord_lng: coord ? coord[0] : null,
+        coord_lat: coord ? coord[1] : null,
+        location,
+        url: url || null,
+      }]);
+      if (error) throw error;
+
+      toast.success('Událost vytvořena');
+      resetForm();
+      onRefresh();
+    } catch (error: unknown) {
+      toast.error(error instanceof Error ? error.message : 'Chyba při ukládání');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const todayStr = toLocalDateString(new Date());
+
+  if (!isExpanded) {
+    return (
+      <button onClick={() => setIsExpanded(true)} className="btn btn-primary w-full gap-2 shadow-sm">
+        <Plus size={20} /> Vytvořit novou událost
+      </button>
+    );
+  }
+
+  return (
+    <div className="card bg-base-100 shadow-md border border-base-content/10">
+      <div className="card-body p-6">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="card-title text-xl">Nová událost</h2>
+          <button onClick={resetForm} className="btn btn-ghost btn-sm btn-square"><X size={20} /></button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <input
+            type="text" value={title} onChange={(e) => setTitle(e.target.value)}
+            placeholder="Název události" className="input input-bordered w-full" required maxLength={80}
+          />
+
+          <select
+            value={category} onChange={(e) => setCategory(e.target.value as EventCategory)}
+            className="select select-bordered w-full"
+          >
+            {(Object.entries(CATEGORY_LABELS) as [EventCategory, string][]).map(([key, label]) => (
+              <option key={key} value={key}>{label}</option>
+            ))}
+          </select>
+
+          <div className="grid grid-cols-2 gap-3">
+            <DatePicker value={date} onChange={setDate} min={todayStr} />
+            <input type="time" value={time} onChange={(e) => setTime(e.target.value)} className="input input-bordered w-full" />
+          </div>
+          <DatePicker value={endDate} onChange={setEndDate} min={date || todayStr} />
+
+          <input
+            type="url" value={url} onChange={(e) => setUrl(e.target.value)}
+            placeholder="Odkaz (nepovinné)" className="input input-bordered w-full" maxLength={200}
+          />
+
+          <div className="join">
+            <button
+              type="button"
+              className={`btn btn-sm join-item ${mode === 'campus' ? 'btn-primary' : 'btn-ghost'}`}
+              onClick={() => setMode('campus')}
+            >
+              Na kampusu
+            </button>
+            <button
+              type="button"
+              className={`btn btn-sm join-item ${mode === 'offcampus' ? 'btn-primary' : 'btn-ghost'}`}
+              onClick={() => setMode('offcampus')}
+            >
+              Ve městě
+            </button>
+          </div>
+
+          <CampusPickerMap
+            mode={mode}
+            selectedBuildingId={buildingId}
+            onBuildingClick={(id) => { setBuildingId(id); setRoomCode(''); }}
+            pin={pin}
+            onPinChange={setPin}
+          />
+
+          {mode === 'campus' ? (
+            <select
+              value={roomCode} onChange={(e) => setRoomCode(e.target.value)}
+              className="select select-bordered w-full" disabled={buildingId == null}
+            >
+              <option value="">{buildingId == null ? 'Nejprve klikněte na budovu' : 'Vyberte místnost'}</option>
+              {roomOptions.map((r) => (
+                <option key={r.code} value={r.name}>{r.name}</option>
+              ))}
+            </select>
+          ) : (
+            <div className="space-y-2">
+              <div className="join w-full">
+                <input
+                  type="text" value={addressQuery} onChange={(e) => setAddressQuery(e.target.value)}
+                  placeholder="Hledat adresu…" className="input input-bordered join-item w-full"
+                />
+                <button type="button" className="btn join-item" onClick={handleAddressSearch}>Hledat</button>
+              </div>
+              {addressResults.length > 0 && (
+                <ul className="menu bg-base-200 rounded-box">
+                  {addressResults.map((r) => (
+                    <li key={r.label}><a onClick={() => pickAddressResult(r)}>{r.label}</a></li>
+                  ))}
+                </ul>
+              )}
+              {addressLabel && <p className="text-sm text-base-content/70">{addressLabel}</p>}
+            </div>
+          )}
+
+          <div className="card-actions justify-end pt-2 border-t border-base-200">
+            <button type="button" onClick={resetForm} className="btn btn-ghost" disabled={submitting}>Zrušit</button>
+            <button type="submit" className="btn btn-primary gap-2 px-8" disabled={submitting || !title || !date}>
+              {submitting ? <span className="loading loading-spinner"></span> : (<><Send size={18} /> Vytvořit</>)}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+cd /Users/dominik-personal/Documents/reis-admin
+npx tsc -b --noEmit
+```
+
+Expected: no new errors.
+
+- [ ] **Step 3: Manual verification**
+
+```bash
+npm run dev
+```
+
+Log in as a society account, open the new events view (built in Task 11), click "Vytvořit novou událost", confirm: (a) campus mode — clicking a building highlights it orange and populates the room dropdown; submitting inserts a row with `venue_kind='campus'`, a non-null `room_code`, and `coord_lng`/`coord_lat` equal to the building's `center`; (b) offcampus mode — clicking the map or picking an address result drops a green marker; submitting inserts a row with `venue_kind='offcampus'`, `room_code=null`, and `coord_lng`/`coord_lat` from the pin.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/features/events/EventForm.tsx
+git commit -m "feat(events): add event creation form with dual location modes"
+```
+
+---
+
+### Task 10: `EventList.tsx`
+
+**Files:**
+- Create: `/Users/dominik-personal/Documents/reis-admin/src/features/events/EventList.tsx`
+
+**Interfaces:**
+- Consumes: `Tables<'spolky_events'>` (Task 2).
+- Produces: `<EventList events onRefresh />` — consumed by Task 11 (`index.tsx`).
+- Manual verification only (same rationale as Tasks 7/9).
+
+- [ ] **Step 1: Write the component**
+
+```tsx
+import { useState } from 'react';
+import { Trash2, Pencil, Check, X, CalendarOff } from 'lucide-react';
+import { supabase } from '@/lib/supabase';
+import { toast } from 'sonner';
+import { Tables } from '@/lib/database.types';
+
+interface EventListProps {
+  events: Tables<'spolky_events'>[];
+  onRefresh: () => void;
+}
+
+interface EditState {
+  id: string;
+  title: string;
+  date: string;
+}
+
+export default function EventList({ events, onRefresh }: EventListProps) {
+  const [editing, setEditing] = useState<EditState | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const handleDelete = async (id: string) => {
+    if (!confirm('Opravdu smazat tuto událost?')) return;
+    try {
+      const { error } = await supabase.from('spolky_events').delete().eq('id', id);
+      if (error) throw error;
+      toast.success('Událost smazána');
+      onRefresh();
+    } catch (error: unknown) {
+      toast.error(error instanceof Error ? error.message : 'Chyba mazání');
+    }
+  };
+
+  const startEdit = (e: Tables<'spolky_events'>) => setEditing({ id: e.id, title: e.title, date: e.date });
+  const cancelEdit = () => setEditing(null);
+
+  const saveEdit = async () => {
+    if (!editing || !editing.title || !editing.date) return;
+    setSaving(true);
+    try {
+      const { error } = await supabase
+        .from('spolky_events')
+        .update({ title: editing.title, date: editing.date })
+        .eq('id', editing.id);
+      if (error) throw error;
+      toast.success('Uloženo');
+      setEditing(null);
+      onRefresh();
+    } catch (error: unknown) {
+      toast.error(error instanceof Error ? error.message : 'Chyba při ukládání');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (!events.length) {
+    return (
+      <div className="text-center py-8 opacity-40">
+        <CalendarOff className="w-8 h-8 mx-auto mb-2" />
+        <p className="text-sm">Žádné události</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="table">
+        <thead>
+          <tr><th>Událost</th><th className="w-28">Datum</th><th>Místo</th><th className="w-24"></th><th className="w-10"></th></tr>
+        </thead>
+        <tbody>
+          {events.map((e) => {
+            const isEditing = editing?.id === e.id;
+            if (isEditing) {
+              return (
+                <tr key={e.id} className="bg-base-200/50">
+                  <td>
+                    <input
+                      type="text" value={editing.title}
+                      onChange={(ev) => setEditing({ ...editing, title: ev.target.value })}
+                      className="input input-sm input-bordered w-full" maxLength={80} autoFocus
+                    />
+                  </td>
+                  <td>
+                    <input
+                      type="date" value={editing.date}
+                      onChange={(ev) => setEditing({ ...editing, date: ev.target.value })}
+                      className="input input-sm input-bordered w-full"
+                    />
+                  </td>
+                  <td></td>
+                  <td>
+                    <button className="btn btn-sm btn-primary gap-1" onClick={saveEdit} disabled={saving}>
+                      {saving ? <span className="loading loading-spinner loading-sm" /> : <Check size={16} />} Uložit
+                    </button>
+                  </td>
+                  <td><button className="btn btn-sm btn-ghost btn-square" onClick={cancelEdit}><X size={16} /></button></td>
+                </tr>
+              );
+            }
+            return (
+              <tr key={e.id}>
+                <td className="font-medium">{e.title}</td>
+                <td className="text-sm text-base-content/70">
+                  {new Date(e.date).toLocaleDateString('cs-CZ', { day: 'numeric', month: 'short' })}
+                </td>
+                <td className="text-sm text-base-content/70">{e.room_code || e.location || '—'}</td>
+                <td><button className="btn btn-ghost btn-xs gap-1" onClick={() => startEdit(e)}><Pencil size={12} /> Upravit</button></td>
+                <td><button className="btn btn-ghost btn-xs btn-square text-error" onClick={() => handleDelete(e.id)}><Trash2 size={14} /></button></td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+cd /Users/dominik-personal/Documents/reis-admin
+npx tsc -b --noEmit
+```
+
+Expected: no new errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/features/events/EventList.tsx
+git commit -m "feat(events): add event list with edit/delete"
+```
+
+---
+
+### Task 11: `EventsView` (`index.tsx`) + route/nav wiring
+
+**Files:**
+- Create: `/Users/dominik-personal/Documents/reis-admin/src/features/events/index.tsx`
+- Modify: `/Users/dominik-personal/Documents/reis-admin/src/App.tsx`
+- Modify: `/Users/dominik-personal/Documents/reis-admin/src/components/Sidebar.tsx`
+- Modify: `/Users/dominik-personal/Documents/reis-admin/src/components/AppLayout.tsx`
+
+**Interfaces:**
+- Consumes: `EventForm` (Task 9), `EventList` (Task 10).
+- Produces: route `/events`, nav item "Události".
+
+- [ ] **Step 1: Write `index.tsx`** (mirrors `src/features/notifications/index.tsx`)
+
+```tsx
+import { useState, useEffect, useCallback } from 'react';
+import { supabase } from '@/lib/supabase';
+import { toast } from 'sonner';
+import { CalendarDays } from 'lucide-react';
+import EventForm from './EventForm';
+import EventList from './EventList';
+import { Tables } from '@/lib/database.types';
+
+interface EventsViewProps {
+  associationId: string | null;
+  isReisAdmin: boolean;
+  isGhosting: boolean;
+}
+
+export default function EventsView({ associationId, isReisAdmin, isGhosting }: EventsViewProps) {
+  const [events, setEvents] = useState<Tables<'spolky_events'>[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const fetchEvents = useCallback(async () => {
+    if (!isReisAdmin && !associationId) return;
+    setLoading(true);
+    try {
+      let query = supabase.from('spolky_events').select('*').order('date', { ascending: true });
+      if (!isReisAdmin || isGhosting) query = query.eq('association_id', associationId!);
+      const { data, error } = await query;
+      if (error) throw error;
+      setEvents(data || []);
+    } catch (error: unknown) {
+      console.error('Fetch error:', error);
+      toast.error('Chyba načítání dat');
+    } finally {
+      setLoading(false);
+    }
+  }, [associationId, isReisAdmin, isGhosting]);
+
+  useEffect(() => { fetchEvents(); }, [fetchEvents]);
+
+  if (!isReisAdmin && !associationId) {
+    return <div className="skeleton w-full h-32 rounded-box opacity-50"></div>;
+  }
+
+  return (
+    <div className="space-y-6">
+      <EventForm associationId={associationId} onRefresh={fetchEvents} />
+
+      <div className="space-y-4">
+        <h3 className="font-bold text-xl px-1 flex items-center gap-2">
+          <CalendarDays className="w-5 h-5 text-primary" /> Vaše události
+        </h3>
+        {loading ? (
+          <div className="space-y-3">
+            <div className="skeleton h-20 w-full rounded-box opacity-20"></div>
+            <div className="skeleton h-20 w-full rounded-box opacity-20"></div>
+          </div>
+        ) : (
+          <EventList events={events} onRefresh={fetchEvents} />
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Wire the route in `App.tsx`**
+
+Add the import near the other feature imports:
+
+```tsx
+import EventsView from '@/features/events';
+```
+
+Add the route inside `<Routes>`, alongside the other authenticated routes:
+
+```tsx
+                    <Route path="/events" element={<EventsView associationId={effectiveAssociationId} isReisAdmin={isReisAdmin} isGhosting={ghostingAssociation !== null} />} />
+```
+
+- [ ] **Step 3: Add the nav item in `Sidebar.tsx`**
+
+Add `CalendarDays` (or another distinct `lucide-react` icon not already used for the primary nav array) to the imports, and add an entry to the primary nav items array alongside the existing `{ id: 'notifications', ... }` entry:
+
+```tsx
+  { id: 'events', label: 'Události', icon: CalendarDays },
+```
+
+- [ ] **Step 4: Add the page title in `AppLayout.tsx`**
+
+Add a line inside the `inferredView === ...` title block, alongside the existing ones:
+
+```tsx
+                            {inferredView === 'events' && 'Události'}
+```
+
+- [ ] **Step 5: Typecheck**
+
+```bash
+cd /Users/dominik-personal/Documents/reis-admin
+npx tsc -b --noEmit
+```
+
+Expected: no new errors.
+
+- [ ] **Step 6: Manual verification**
+
+```bash
+npm run dev
+```
+
+Log in, confirm "Události" appears in the sidebar, navigating to it shows the form + list, and creating/editing/deleting an event works end-to-end against the real `spolky_events` table (verify with `mcp__claude_ai_Supabase__execute_sql`: `select * from spolky_events;`).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/features/events/index.tsx src/App.tsx src/components/Sidebar.tsx src/components/AppLayout.tsx
+git commit -m "feat(events): wire EventsView into routing, nav, and layout"
+```
+
+---
+
+### Task 12: reis-extension — expand the society catalog to 6
+
+**Files:**
+- Modify: `/Users/dominik-personal/Documents/reis-extension/.claude/worktrees/society-map-events/src/data/societies.ts`
+
+**Interfaces:**
+- Produces: `SOCIETIES['af']`, `SOCIETIES['ldf']`, `SOCIETIES['zf']` — consumed by Task 13 (`mapEvents.ts`'s `societyById` calls) and already-existing consumers (`EventsList.tsx`'s `ALL_SOCIETIES` filter chips, no code change needed there).
+
+- [ ] **Step 1: Add the three entries**
+
+Reuse each faculty's existing brand color from `ORGANIZERS` in `src/types/events.ts` (`af: '#c87800'`, `ldf: '#0a5028'`, `zf: '#8c0a00'`) and the logo files already shipped at `public/spolky/{af,ldf,zf}.jpg`:
+
+```ts
+export const SOCIETIES: Record<string, Society> = {
+  esn: { id: 'esn', name: 'ESN MENDELU', shortName: 'ESN', color: '#00AEEF', glyph: '✷', logo: '/spolky/esn.jpg', facultyKey: 'mendelu' },
+  supef: { id: 'supef', name: 'SU PEF', shortName: 'SUPEF', color: '#0046a0', glyph: 'SU', logo: '/spolky/supef.jpg', facultyKey: 'pef' },
+  au_frrms: { id: 'au_frrms', name: 'AU FRRMS', shortName: 'AU FRRMS', color: '#c32897', glyph: 'AU', logo: '/spolky/au_frrms.jpg', facultyKey: 'frrms' },
+  af: { id: 'af', name: 'AF Spolek', shortName: 'AF', color: '#c87800', glyph: 'AF', logo: '/spolky/af.jpg', facultyKey: 'af' },
+  ldf: { id: 'ldf', name: 'LDF Spolek', shortName: 'LDF', color: '#0a5028', glyph: 'LDF', logo: '/spolky/ldf.jpg', facultyKey: 'ldf' },
+  zf: { id: 'zf', name: 'ZF Spolek', shortName: 'ZF', color: '#8c0a00', glyph: 'ZF', logo: '/spolky/zf.jpg', facultyKey: 'zf' },
+};
+```
+
+Names (`AF Spolek`, `LDF Spolek`, `ZF Spolek`) match `spolky_accounts.association_name` exactly, confirmed via the earlier `select association_id, association_name from spolky_accounts` query.
+
+- [ ] **Step 2: Run the existing society/event tests**
+
+```bash
+cd /Users/dominik-personal/Documents/reis-extension/.claude/worktrees/society-map-events
+npx vitest run src/components/CampusMap/__tests__/EventsList.test.ts
+```
+
+Expected: PASS (the filter-chip test already iterates `ALL_SOCIETIES` generically).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/data/societies.ts
+git commit -m "feat(events): expand society catalog to all 6 spolky_accounts associations"
+```
+
+---
+
+### Task 13: reis-extension — real `fetchMapEvents`, delete the mock seam
+
+**Files:**
+- Modify: `/Users/dominik-personal/Documents/reis-extension/.claude/worktrees/society-map-events/src/api/mapEvents.ts`
+- Modify: `/Users/dominik-personal/Documents/reis-extension/.claude/worktrees/society-map-events/src/api/__tests__/mapEvents.test.ts`
+- Modify: `/Users/dominik-personal/Documents/reis-extension/.claude/worktrees/society-map-events/src/store/slices/createMapSlice.ts`
+
+**Interfaces:**
+- Consumes: `supabase` (`src/services/spolky/supabaseClient.ts`), `societyById` (Task 12's expanded catalog), `MapEvent`/`EventCategory` (`src/types/events.ts`, unchanged), `spolky_events` columns (Task 1).
+- Produces: `fetchMapEvents(): Promise<MapEvent[]>` (signature changes — drops the now-unused `language` parameter) and the exported pure mapper `toMapEvent(row: SpolkyEventRow): MapEvent` (tested directly).
+
+- [ ] **Step 1: Write the failing test**
+
+Replace the full contents of `src/api/__tests__/mapEvents.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { toMapEvent } from '../mapEvents';
+
+describe('toMapEvent', () => {
+  it('maps a campus-room row into a MapEvent with a resolved building coord', () => {
+    const row = {
+      id: 'abc', association_id: 'supef', title: 'PEF Kvíz', category: 'quiz',
+      date: '2026-07-10', end_date: null, time: '18:00', venue_kind: 'campus',
+      room_code: 'Q01', coord_lng: 16.614247, coord_lat: 49.209592,
+      location: null, url: null,
+    };
+    expect(toMapEvent(row)).toEqual({
+      id: 'abc', title: 'PEF Kvíz', url: '', date: '2026-07-10', endDate: null,
+      time: '18:00', location: null, imageUrl: null, organizerKey: 'pef',
+      societyId: 'supef', coord: [16.614247, 49.209592], roomCode: 'Q01',
+      venueKind: 'campus', category: 'quiz',
+    });
+  });
+
+  it('maps an off-campus row with a free-text location and no room code', () => {
+    const row = {
+      id: 'def', association_id: 'esn', title: 'Tram Party', category: 'party',
+      date: '2026-07-17', end_date: null, time: '20:00', venue_kind: 'offcampus',
+      room_code: null, coord_lng: 16.606389, coord_lat: 49.198056,
+      location: 'Česká (sraz)', url: 'https://www.instagram.com/esnmendelubrno/',
+    };
+    expect(toMapEvent(row)).toEqual({
+      id: 'def', title: 'Tram Party', url: 'https://www.instagram.com/esnmendelubrno/',
+      date: '2026-07-17', endDate: null, time: '20:00', location: 'Česká (sraz)',
+      imageUrl: null, organizerKey: 'mendelu', societyId: 'esn',
+      coord: [16.606389, 49.198056], roomCode: null, venueKind: 'offcampus', category: 'party',
+    });
+  });
+
+  it('maps a null coord when either coordinate is missing', () => {
+    const row = {
+      id: 'ghi', association_id: 'af', title: 'AF Den', category: 'culture',
+      date: '2026-08-01', end_date: null, time: null, venue_kind: 'offcampus',
+      room_code: null, coord_lng: null, coord_lat: null, location: 'TBD', url: null,
+    };
+    expect(toMapEvent(row).coord).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+cd /Users/dominik-personal/Documents/reis-extension/.claude/worktrees/society-map-events
+npx vitest run src/api/__tests__/mapEvents.test.ts
+```
+
+Expected: FAIL — `toMapEvent` is not exported yet (the file still only exports `MOCK_MAP_EVENTS`/`fetchMapEvents`).
+
+- [ ] **Step 3: Replace `mapEvents.ts` entirely**
+
+```ts
+import type { MapEvent, EventCategory } from '../types/events';
+import { societyById } from '../data/societies';
+import { supabase } from '../services/spolky/supabaseClient';
+import { logError } from '../utils/reportError';
+
+interface SpolkyEventRow {
+  id: string;
+  association_id: string;
+  title: string;
+  category: string;
+  date: string;
+  end_date: string | null;
+  time: string | null;
+  venue_kind: string;
+  room_code: string | null;
+  coord_lng: number | null;
+  coord_lat: number | null;
+  location: string | null;
+  url: string | null;
+}
+
+// Pure row -> MapEvent mapping, kept separate from the network call so it's
+// directly unit-testable without hitting Supabase.
+export function toMapEvent(row: SpolkyEventRow): MapEvent {
+  const soc = societyById(row.association_id);
+  const coord: [number, number] | null =
+    row.coord_lng != null && row.coord_lat != null ? [row.coord_lng, row.coord_lat] : null;
+  return {
+    id: row.id,
+    title: row.title,
+    url: row.url ?? '',
+    date: row.date,
+    endDate: row.end_date,
+    time: row.time,
+    location: row.location,
+    imageUrl: null,
+    organizerKey: soc.facultyKey,
+    societyId: row.association_id,
+    coord,
+    roomCode: row.room_code,
+    venueKind: row.venue_kind as MapEvent['venueKind'],
+    category: row.category as EventCategory,
+  };
+}
+
+export async function fetchMapEvents(): Promise<MapEvent[]> {
+  const { data, error } = await supabase
+    .from('spolky_events')
+    .select('*')
+    .order('date', { ascending: true });
+
+  if (error) {
+    logError('Api.fetchMapEvents', error);
+    return [];
+  }
+
+  return (data ?? []).map((row) => toMapEvent(row as SpolkyEventRow));
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+```bash
+npx vitest run src/api/__tests__/mapEvents.test.ts
+```
+
+Expected: PASS, 3 tests.
+
+- [ ] **Step 5: Update the one `fetchMapEvents` call site**
+
+In `src/store/slices/createMapSlice.ts`, the `loadMapEvents` action currently reads (per the earlier audit, around line 119):
+
+```ts
+      const events = await fetchMapEvents(language);
+```
+
+Change it to:
+
+```ts
+      const events = await fetchMapEvents();
+```
+
+If `language` becomes unused in that function as a result, remove the now-dead parameter/variable at that call site only — do not touch unrelated logic in the same file.
+
+- [ ] **Step 6: Run the map slice test suite**
+
+```bash
+npx vitest run src/store/slices/__tests__/createMapSlice.test.ts
+```
+
+Expected: PASS (or update any test that explicitly asserted `fetchMapEvents` was called with a language argument — change the assertion to a no-arg call).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/api/mapEvents.ts src/api/__tests__/mapEvents.test.ts src/store/slices/createMapSlice.ts
+git commit -m "feat(events): replace mock map events with real spolky_events fetch"
+```
+
+---
+
+### Task 14: reis-extension — delete dead `inferCategory` mock seam
+
+**Files:**
+- Modify: `/Users/dominik-personal/Documents/reis-extension/.claude/worktrees/society-map-events/src/data/eventCategories.ts`
+
+**Interfaces:**
+- Removes: `inferCategory`, `RULES` (confirmed via grep to have no callers outside the now-deleted mock in `mapEvents.ts`). `CATEGORY_ICON`, `CATEGORY_COLOR`, `CATEGORY_EMOJI_SRC` are unaffected and remain exported.
+
+- [ ] **Step 1: Delete the mock-only code**
+
+Remove the `RULES` array and the `inferCategory` function (currently lines 59–76) from `src/data/eventCategories.ts`, leaving `CATEGORY_ICON`, `CATEGORY_COLOR`, and `CATEGORY_EMOJI_SRC` untouched.
+
+- [ ] **Step 2: Confirm nothing else references it**
+
+```bash
+cd /Users/dominik-personal/Documents/reis-extension/.claude/worktrees/society-map-events
+grep -rn "inferCategory" src/
+```
+
+Expected: no matches.
+
+- [ ] **Step 3: Typecheck + full test run**
+
+```bash
+npm run typecheck
+npx vitest run
+```
+
+Expected: both pass with no new failures.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/data/eventCategories.ts
+git commit -m "chore(events): delete dead inferCategory mock seam"
+```
+
+---
+
+## Final Verification (after all tasks)
+
+```bash
+cd /Users/dominik-personal/Documents/reis-extension/.claude/worktrees/society-map-events
+npm run typecheck && npm run lint && npx vitest run
+
+cd /Users/dominik-personal/Documents/reis-admin
+npx tsc -b --noEmit && npx vitest run
+```
+
+Then manually: create an event in reis-admin for each location mode, open the reis-extension campus map (`npm run dev`, load the extension, navigate to IS Mendelu), and confirm both events render as pins in the correct place with the correct society color/category emoji, and the "fly to room" click works for the campus-mode event.

--- a/docs/superpowers/plans/2026-07-03-society-events-location.md
+++ b/docs/superpowers/plans/2026-07-03-society-events-location.md
@@ -12,7 +12,7 @@
 
 ## Global Constraints
 
-- Repos: `reis-extension` (this worktree, branch `worktree-society-map-events`) and `../reis-admin` (branch `society-map-events`, based on `origin/main`). Every reis-admin task below runs with `cwd` = `/Users/dominik-personal/Documents/reis-admin`.
+- Repos: `reis-extension` (this worktree, branch `worktree-society-map-events`) and `../reis-admin` (branch `society-map-events`, based on `origin/main`). Every reis-admin task below runs with `cwd` = `/Users/dominik-personal/Documents/reis-admin/.claude/worktrees/society-map-events` — a DEDICATED WORKTREE, not the bare `/Users/dominik-personal/Documents/reis-admin` checkout, which is shared with unrelated concurrent work and must not be touched.
 - No image upload capability (out of scope, per spec).
 - No moderation/approval queue (out of scope, per spec) — RLS trusts any active `spolky_accounts` row.
 - No in-extension creation UI (out of scope, per spec) — reis-admin only.
@@ -58,7 +58,7 @@
 ### Task 1: Supabase migration — `spolky_events` table + RLS
 
 **Files:**
-- Create: `/Users/dominik-personal/Documents/reis-admin/supabase/migrations/20260703120000_add_spolky_events.sql`
+- Create: `/Users/dominik-personal/Documents/reis-admin/.claude/worktrees/society-map-events/supabase/migrations/20260703120000_add_spolky_events.sql`
 
 **Interfaces:**
 - Produces: table `public.spolky_events` with columns `id, association_id, title, category, date, end_date, time, venue_kind, room_code, coord_lng, coord_lat, location, url, created_at, updated_at` — every later task's SQL/TS type must match these names exactly.
@@ -156,7 +156,7 @@ Call `mcp__claude_ai_Supabase__list_tables` with `project_id: "zvbpgkmnrqyprtkyx
 - [ ] **Step 4: Commit**
 
 ```bash
-cd /Users/dominik-personal/Documents/reis-admin
+cd /Users/dominik-personal/Documents/reis-admin/.claude/worktrees/society-map-events
 git add supabase/migrations/20260703120000_add_spolky_events.sql
 git commit -m "feat(events): add spolky_events table with association-scoped RLS"
 ```
@@ -166,7 +166,7 @@ git commit -m "feat(events): add spolky_events table with association-scoped RLS
 ### Task 2: reis-admin database types
 
 **Files:**
-- Modify: `/Users/dominik-personal/Documents/reis-admin/src/lib/database.types.ts`
+- Modify: `/Users/dominik-personal/Documents/reis-admin/.claude/worktrees/society-map-events/src/lib/database.types.ts`
 
 **Interfaces:**
 - Consumes: the exact column set from Task 1.
@@ -236,7 +236,7 @@ Insert alphabetically (after `spolky_accounts`, matching the file's existing ord
 - [ ] **Step 2: Typecheck**
 
 ```bash
-cd /Users/dominik-personal/Documents/reis-admin
+cd /Users/dominik-personal/Documents/reis-admin/.claude/worktrees/society-map-events
 npx tsc --noEmit
 ```
 
@@ -254,7 +254,7 @@ git commit -m "feat(events): add spolky_events to database.types.ts"
 ### Task 3: Add Leaflet + Vitest tooling to reis-admin
 
 **Files:**
-- Modify: `/Users/dominik-personal/Documents/reis-admin/package.json`
+- Modify: `/Users/dominik-personal/Documents/reis-admin/.claude/worktrees/society-map-events/package.json`
 
 **Interfaces:**
 - Produces: `leaflet`/`@types/leaflet` importable by Task 6/8; `vitest` runnable by Tasks 4 and 5.
@@ -262,7 +262,7 @@ git commit -m "feat(events): add spolky_events to database.types.ts"
 - [ ] **Step 1: Install dependencies**
 
 ```bash
-cd /Users/dominik-personal/Documents/reis-admin
+cd /Users/dominik-personal/Documents/reis-admin/.claude/worktrees/society-map-events
 npm install --save-exact leaflet@1.9.4
 npm install --save-dev --save-exact @types/leaflet@1.9.21 vitest@3.2.4
 ```
@@ -295,9 +295,9 @@ git commit -m "chore: add leaflet + vitest for the events feature"
 ### Task 4: Copy static map data + style constants into reis-admin
 
 **Files:**
-- Create: `/Users/dominik-personal/Documents/reis-admin/src/data/map/buildings.json` (copy of reis-extension's file, byte-identical)
-- Create: `/Users/dominik-personal/Documents/reis-admin/src/data/map/rooms-index.json` (copy of reis-extension's file, byte-identical)
-- Create: `/Users/dominik-personal/Documents/reis-admin/src/features/events/mapStyles.ts`
+- Create: `/Users/dominik-personal/Documents/reis-admin/.claude/worktrees/society-map-events/src/data/map/buildings.json` (copy of reis-extension's file, byte-identical)
+- Create: `/Users/dominik-personal/Documents/reis-admin/.claude/worktrees/society-map-events/src/data/map/rooms-index.json` (copy of reis-extension's file, byte-identical)
+- Create: `/Users/dominik-personal/Documents/reis-admin/.claude/worktrees/society-map-events/src/features/events/mapStyles.ts`
 
 **Interfaces:**
 - Produces: `BUILDING_STYLE`, `SELECTED_STYLE`, `ringToLatLng(ring: number[][]): [number, number][]` — consumed by Task 6 (`CampusPickerMap.tsx`).
@@ -306,9 +306,9 @@ git commit -m "chore: add leaflet + vitest for the events feature"
 
 ```bash
 cp /Users/dominik-personal/Documents/reis-extension/src/data/map/buildings.json \
-   /Users/dominik-personal/Documents/reis-admin/src/data/map/buildings.json
+   /Users/dominik-personal/Documents/reis-admin/.claude/worktrees/society-map-events/src/data/map/buildings.json
 cp /Users/dominik-personal/Documents/reis-extension/src/data/map/rooms-index.json \
-   /Users/dominik-personal/Documents/reis-admin/src/data/map/rooms-index.json
+   /Users/dominik-personal/Documents/reis-admin/.claude/worktrees/society-map-events/src/data/map/rooms-index.json
 ```
 
 - [ ] **Step 2: Write `mapStyles.ts`**
@@ -340,7 +340,7 @@ export function ringToLatLng(ring: number[][]): [number, number][] {
 - [ ] **Step 3: Commit**
 
 ```bash
-cd /Users/dominik-personal/Documents/reis-admin
+cd /Users/dominik-personal/Documents/reis-admin/.claude/worktrees/society-map-events
 git add src/data/map/buildings.json src/data/map/rooms-index.json src/features/events/mapStyles.ts
 git commit -m "feat(events): add campus map data + style constants"
 ```
@@ -350,8 +350,8 @@ git commit -m "feat(events): add campus map data + style constants"
 ### Task 5: Pure location-resolution logic (TDD)
 
 **Files:**
-- Create: `/Users/dominik-personal/Documents/reis-admin/src/features/events/locationResolvers.ts`
-- Test: `/Users/dominik-personal/Documents/reis-admin/src/features/events/locationResolvers.test.ts`
+- Create: `/Users/dominik-personal/Documents/reis-admin/.claude/worktrees/society-map-events/src/features/events/locationResolvers.ts`
+- Test: `/Users/dominik-personal/Documents/reis-admin/.claude/worktrees/society-map-events/src/features/events/locationResolvers.test.ts`
 
 **Interfaces:**
 - Consumes: `Building` shape `{ id: number; name: string; center: [number, number] }` (subset of `buildings.json`'s per-building objects), `RoomIndexEntry` shape `{ code: string; name: string; buildingId: number }` (subset of `rooms-index.json`'s entries).
@@ -399,7 +399,7 @@ describe('roomsForBuilding', () => {
 - [ ] **Step 2: Run to verify it fails**
 
 ```bash
-cd /Users/dominik-personal/Documents/reis-admin
+cd /Users/dominik-personal/Documents/reis-admin/.claude/worktrees/society-map-events
 npx vitest run src/features/events/locationResolvers.test.ts
 ```
 
@@ -458,8 +458,8 @@ git commit -m "feat(events): add pure building/room location resolvers"
 ### Task 6: Nominatim address search (TDD)
 
 **Files:**
-- Create: `/Users/dominik-personal/Documents/reis-admin/src/features/events/nominatim.ts`
-- Test: `/Users/dominik-personal/Documents/reis-admin/src/features/events/nominatim.test.ts`
+- Create: `/Users/dominik-personal/Documents/reis-admin/.claude/worktrees/society-map-events/src/features/events/nominatim.ts`
+- Test: `/Users/dominik-personal/Documents/reis-admin/.claude/worktrees/society-map-events/src/features/events/nominatim.test.ts`
 
 **Interfaces:**
 - Produces: `GeocodeResult { label: string; coord: [number, number] }`, `parseNominatimResults(raw: unknown[]): GeocodeResult[]` (pure, tested), `searchAddress(query: string): Promise<GeocodeResult[]>` (network wrapper, not unit-tested) — consumed by Task 7 (`EventForm.tsx`).
@@ -489,7 +489,7 @@ describe('parseNominatimResults', () => {
 - [ ] **Step 2: Run to verify it fails**
 
 ```bash
-cd /Users/dominik-personal/Documents/reis-admin
+cd /Users/dominik-personal/Documents/reis-admin/.claude/worktrees/society-map-events
 npx vitest run src/features/events/nominatim.test.ts
 ```
 
@@ -560,7 +560,7 @@ git commit -m "feat(events): add Brno-bounded Nominatim address search"
 ### Task 7: `CampusPickerMap.tsx` — raw-Leaflet picker
 
 **Files:**
-- Create: `/Users/dominik-personal/Documents/reis-admin/src/features/events/CampusPickerMap.tsx`
+- Create: `/Users/dominik-personal/Documents/reis-admin/.claude/worktrees/society-map-events/src/features/events/CampusPickerMap.tsx`
 
 **Interfaces:**
 - Consumes: `BUILDING_STYLE`, `SELECTED_STYLE`, `PIN_COLOR`, `ringToLatLng` (Task 4); `buildings.json` (Task 4).
@@ -678,7 +678,7 @@ export default function CampusPickerMap({
 - [ ] **Step 2: Typecheck**
 
 ```bash
-cd /Users/dominik-personal/Documents/reis-admin
+cd /Users/dominik-personal/Documents/reis-admin/.claude/worktrees/society-map-events
 npx tsc --noEmit
 ```
 
@@ -696,7 +696,7 @@ git commit -m "feat(events): add raw-Leaflet campus/city location picker"
 ### Task 8: Duplicated `EventCategory` union + Czech labels
 
 **Files:**
-- Create: `/Users/dominik-personal/Documents/reis-admin/src/features/events/eventCategories.ts`
+- Create: `/Users/dominik-personal/Documents/reis-admin/.claude/worktrees/society-map-events/src/features/events/eventCategories.ts`
 
 **Interfaces:**
 - Produces: `EventCategory` type, `CATEGORY_LABELS: Record<EventCategory, string>` — consumed by Task 9 (`EventForm.tsx`).
@@ -728,7 +728,7 @@ export const CATEGORY_LABELS: Record<EventCategory, string> = {
 - [ ] **Step 2: Commit**
 
 ```bash
-cd /Users/dominik-personal/Documents/reis-admin
+cd /Users/dominik-personal/Documents/reis-admin/.claude/worktrees/society-map-events
 git add src/features/events/eventCategories.ts
 git commit -m "feat(events): add duplicated EventCategory union + Czech labels"
 ```
@@ -738,7 +738,7 @@ git commit -m "feat(events): add duplicated EventCategory union + Czech labels"
 ### Task 9: `EventForm.tsx`
 
 **Files:**
-- Create: `/Users/dominik-personal/Documents/reis-admin/src/features/events/EventForm.tsx`
+- Create: `/Users/dominik-personal/Documents/reis-admin/.claude/worktrees/society-map-events/src/features/events/EventForm.tsx`
 
 **Interfaces:**
 - Consumes: `supabase` (`@/lib/supabase`), `Tables` (`@/lib/database.types`, Task 2), `DatePicker` (`@/components/DatePicker`), `toLocalDateString` (`@/lib/utils`), `resolveBuildingCoord`/`roomsForBuilding` (Task 5), `searchAddress`/`GeocodeResult` (Task 6), `CampusPickerMap` (Task 7), `EventCategory`/`CATEGORY_LABELS` (Task 8), `buildingsJson`/`roomsIndexJson` (Task 4).
@@ -1004,7 +1004,7 @@ export default function EventForm({ associationId, onRefresh, editingEvent, onCa
 - [ ] **Step 2: Typecheck**
 
 ```bash
-cd /Users/dominik-personal/Documents/reis-admin
+cd /Users/dominik-personal/Documents/reis-admin/.claude/worktrees/society-map-events
 npx tsc --noEmit
 ```
 
@@ -1030,7 +1030,7 @@ git commit -m "feat(events): add event creation form with dual location modes"
 ### Task 10: `EventList.tsx`
 
 **Files:**
-- Create: `/Users/dominik-personal/Documents/reis-admin/src/features/events/EventList.tsx`
+- Create: `/Users/dominik-personal/Documents/reis-admin/.claude/worktrees/society-map-events/src/features/events/EventList.tsx`
 
 **Interfaces:**
 - Consumes: `Tables<'spolky_events'>` (Task 2).
@@ -1101,7 +1101,7 @@ export default function EventList({ events, onRefresh, onEdit }: EventListProps)
 - [ ] **Step 2: Typecheck**
 
 ```bash
-cd /Users/dominik-personal/Documents/reis-admin
+cd /Users/dominik-personal/Documents/reis-admin/.claude/worktrees/society-map-events
 npx tsc --noEmit
 ```
 
@@ -1119,10 +1119,10 @@ git commit -m "feat(events): add event list with edit/delete"
 ### Task 11: `EventsView` (`index.tsx`) + route/nav wiring
 
 **Files:**
-- Create: `/Users/dominik-personal/Documents/reis-admin/src/features/events/index.tsx`
-- Modify: `/Users/dominik-personal/Documents/reis-admin/src/App.tsx`
-- Modify: `/Users/dominik-personal/Documents/reis-admin/src/components/Sidebar.tsx`
-- Modify: `/Users/dominik-personal/Documents/reis-admin/src/components/AppLayout.tsx`
+- Create: `/Users/dominik-personal/Documents/reis-admin/.claude/worktrees/society-map-events/src/features/events/index.tsx`
+- Modify: `/Users/dominik-personal/Documents/reis-admin/.claude/worktrees/society-map-events/src/App.tsx`
+- Modify: `/Users/dominik-personal/Documents/reis-admin/.claude/worktrees/society-map-events/src/components/Sidebar.tsx`
+- Modify: `/Users/dominik-personal/Documents/reis-admin/.claude/worktrees/society-map-events/src/components/AppLayout.tsx`
 
 **Interfaces:**
 - Consumes: `EventForm` (Task 9), `EventList` (Task 10).
@@ -1233,7 +1233,7 @@ Add a line inside the `inferredView === ...` title block, alongside the existing
 - [ ] **Step 5: Typecheck**
 
 ```bash
-cd /Users/dominik-personal/Documents/reis-admin
+cd /Users/dominik-personal/Documents/reis-admin/.claude/worktrees/society-map-events
 npx tsc --noEmit
 ```
 
@@ -1518,7 +1518,7 @@ git commit -m "chore(events): delete dead inferCategory mock seam"
 cd /Users/dominik-personal/Documents/reis-extension/.claude/worktrees/society-map-events
 npm run typecheck && npm run lint && npx vitest run
 
-cd /Users/dominik-personal/Documents/reis-admin
+cd /Users/dominik-personal/Documents/reis-admin/.claude/worktrees/society-map-events
 npx tsc --noEmit && npx vitest run
 ```
 

--- a/docs/superpowers/plans/2026-07-03-society-events-location.md
+++ b/docs/superpowers/plans/2026-07-03-society-events-location.md
@@ -741,19 +741,20 @@ git commit -m "feat(events): add duplicated EventCategory union + Czech labels"
 - Create: `/Users/dominik-personal/Documents/reis-admin/src/features/events/EventForm.tsx`
 
 **Interfaces:**
-- Consumes: `supabase` (`@/lib/supabase`), `DatePicker` (`@/components/DatePicker`), `toLocalDateString` (`@/lib/utils`), `resolveBuildingCoord`/`roomsForBuilding` (Task 5), `searchAddress`/`GeocodeResult` (Task 6), `CampusPickerMap` (Task 7), `EventCategory`/`CATEGORY_LABELS` (Task 8), `buildingsJson`/`roomsIndexJson` (Task 4).
-- Produces: `<EventForm associationId={string} onRefresh={() => void} />` — consumed by Task 11 (`index.tsx`).
+- Consumes: `supabase` (`@/lib/supabase`), `Tables` (`@/lib/database.types`, Task 2), `DatePicker` (`@/components/DatePicker`), `toLocalDateString` (`@/lib/utils`), `resolveBuildingCoord`/`roomsForBuilding` (Task 5), `searchAddress`/`GeocodeResult` (Task 6), `CampusPickerMap` (Task 7), `EventCategory`/`CATEGORY_LABELS` (Task 8), `buildingsJson`/`roomsIndexJson` (Task 4).
+- Produces: `<EventForm associationId={string} onRefresh={() => void} editingEvent={Tables<'spolky_events'> | null} onCancelEdit={() => void} />` — consumed by Task 11 (`index.tsx`). When `editingEvent` is non-null the form opens pre-filled and submits an `update` instead of an `insert`; both Create and Edit use one form so every field (including location) stays editable after publish, per spec.
 - Manual verification only (no automated test — see Task 7's rationale, same applies to this form).
 
 - [ ] **Step 1: Write the component**
 
 ```tsx
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import { supabase } from '@/lib/supabase';
 import { toast } from 'sonner';
 import { Plus, X, Send } from 'lucide-react';
 import { toLocalDateString } from '@/lib/utils';
 import DatePicker from '@/components/DatePicker';
+import { Tables } from '@/lib/database.types';
 import buildingsJson from '../../data/map/buildings.json';
 import roomsIndexJson from '../../data/map/rooms-index.json';
 import { resolveBuildingCoord, roomsForBuilding, type BuildingLite, type RoomIndexEntry } from './locationResolvers';
@@ -767,26 +768,61 @@ const ROOMS = roomsIndexJson as RoomIndexEntry[];
 interface EventFormProps {
   associationId: string | null;
   onRefresh: () => void;
+  editingEvent?: Tables<'spolky_events'> | null;
+  onCancelEdit?: () => void;
 }
 
 type LocationMode = 'campus' | 'offcampus';
 
-export default function EventForm({ associationId, onRefresh }: EventFormProps) {
+const EMPTY_STATE = {
+  title: '', category: 'other' as EventCategory, date: '', endDate: '', time: '', url: '',
+  mode: 'campus' as LocationMode, buildingId: null as number | null, roomCode: '',
+  pin: null as [number, number] | null, addressLabel: '',
+};
+
+export default function EventForm({ associationId, onRefresh, editingEvent, onCancelEdit }: EventFormProps) {
   const [isExpanded, setIsExpanded] = useState(false);
-  const [title, setTitle] = useState('');
-  const [category, setCategory] = useState<EventCategory>('other');
-  const [date, setDate] = useState('');
-  const [endDate, setEndDate] = useState('');
-  const [time, setTime] = useState('');
-  const [url, setUrl] = useState('');
-  const [mode, setMode] = useState<LocationMode>('campus');
-  const [buildingId, setBuildingId] = useState<number | null>(null);
-  const [roomCode, setRoomCode] = useState<string>('');
-  const [pin, setPin] = useState<[number, number] | null>(null);
+  const [title, setTitle] = useState(EMPTY_STATE.title);
+  const [category, setCategory] = useState<EventCategory>(EMPTY_STATE.category);
+  const [date, setDate] = useState(EMPTY_STATE.date);
+  const [endDate, setEndDate] = useState(EMPTY_STATE.endDate);
+  const [time, setTime] = useState(EMPTY_STATE.time);
+  const [url, setUrl] = useState(EMPTY_STATE.url);
+  const [mode, setMode] = useState<LocationMode>(EMPTY_STATE.mode);
+  const [buildingId, setBuildingId] = useState<number | null>(EMPTY_STATE.buildingId);
+  const [roomCode, setRoomCode] = useState<string>(EMPTY_STATE.roomCode);
+  const [pin, setPin] = useState<[number, number] | null>(EMPTY_STATE.pin);
   const [addressQuery, setAddressQuery] = useState('');
   const [addressResults, setAddressResults] = useState<GeocodeResult[]>([]);
-  const [addressLabel, setAddressLabel] = useState('');
+  const [addressLabel, setAddressLabel] = useState(EMPTY_STATE.addressLabel);
   const [submitting, setSubmitting] = useState(false);
+
+  // Pre-fill and auto-expand when an event is handed in for editing. A room's
+  // buildingId isn't stored on the row itself, so it's re-derived from the
+  // stored room_code via the same ROOMS index the picker uses.
+  useEffect(() => {
+    if (!editingEvent) return;
+    setTitle(editingEvent.title);
+    setCategory(editingEvent.category as EventCategory);
+    setDate(editingEvent.date);
+    setEndDate(editingEvent.end_date ?? '');
+    setTime(editingEvent.time ?? '');
+    setUrl(editingEvent.url ?? '');
+    setMode(editingEvent.venue_kind as LocationMode);
+    setRoomCode(editingEvent.room_code ?? '');
+    setBuildingId(
+      editingEvent.room_code
+        ? (ROOMS.find((r) => r.name === editingEvent.room_code)?.buildingId ?? null)
+        : null,
+    );
+    setPin(
+      editingEvent.coord_lng != null && editingEvent.coord_lat != null
+        ? [editingEvent.coord_lng, editingEvent.coord_lat]
+        : null,
+    );
+    setAddressLabel(editingEvent.location ?? '');
+    setIsExpanded(true);
+  }, [editingEvent]);
 
   const roomOptions = useMemo(
     () => (buildingId != null ? roomsForBuilding(buildingId, ROOMS) : []),
@@ -804,10 +840,12 @@ export default function EventForm({ associationId, onRefresh }: EventFormProps) 
   };
 
   const resetForm = () => {
-    setTitle(''); setCategory('other'); setDate(''); setEndDate(''); setTime(''); setUrl('');
-    setMode('campus'); setBuildingId(null); setRoomCode(''); setPin(null);
-    setAddressQuery(''); setAddressResults([]); setAddressLabel('');
+    setTitle(EMPTY_STATE.title); setCategory(EMPTY_STATE.category); setDate(EMPTY_STATE.date);
+    setEndDate(EMPTY_STATE.endDate); setTime(EMPTY_STATE.time); setUrl(EMPTY_STATE.url);
+    setMode(EMPTY_STATE.mode); setBuildingId(EMPTY_STATE.buildingId); setRoomCode(EMPTY_STATE.roomCode);
+    setPin(EMPTY_STATE.pin); setAddressQuery(''); setAddressResults([]); setAddressLabel(EMPTY_STATE.addressLabel);
     setIsExpanded(false);
+    onCancelEdit?.();
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -819,25 +857,29 @@ export default function EventForm({ associationId, onRefresh }: EventFormProps) 
       : pin;
     const location = mode === 'campus' ? (roomCode || null) : (addressLabel || null);
 
+    const payload = {
+      association_id: associationId,
+      title,
+      category,
+      date,
+      end_date: endDate || null,
+      time: time || null,
+      venue_kind: mode,
+      room_code: mode === 'campus' ? (roomCode || null) : null,
+      coord_lng: coord ? coord[0] : null,
+      coord_lat: coord ? coord[1] : null,
+      location,
+      url: url || null,
+    };
+
     setSubmitting(true);
     try {
-      const { error } = await supabase.from('spolky_events').insert([{
-        association_id: associationId,
-        title,
-        category,
-        date,
-        end_date: endDate || null,
-        time: time || null,
-        venue_kind: mode,
-        room_code: mode === 'campus' ? (roomCode || null) : null,
-        coord_lng: coord ? coord[0] : null,
-        coord_lat: coord ? coord[1] : null,
-        location,
-        url: url || null,
-      }]);
+      const { error } = editingEvent
+        ? await supabase.from('spolky_events').update(payload).eq('id', editingEvent.id)
+        : await supabase.from('spolky_events').insert([payload]);
       if (error) throw error;
 
-      toast.success('Událost vytvořena');
+      toast.success(editingEvent ? 'Uloženo' : 'Událost vytvořena');
       resetForm();
       onRefresh();
     } catch (error: unknown) {
@@ -861,7 +903,7 @@ export default function EventForm({ associationId, onRefresh }: EventFormProps) 
     <div className="card bg-base-100 shadow-md border border-base-content/10">
       <div className="card-body p-6">
         <div className="flex items-center justify-between mb-4">
-          <h2 className="card-title text-xl">Nová událost</h2>
+          <h2 className="card-title text-xl">{editingEvent ? 'Upravit událost' : 'Nová událost'}</h2>
           <button onClick={resetForm} className="btn btn-ghost btn-sm btn-square"><X size={20} /></button>
         </div>
 
@@ -949,7 +991,7 @@ export default function EventForm({ associationId, onRefresh }: EventFormProps) 
           <div className="card-actions justify-end pt-2 border-t border-base-200">
             <button type="button" onClick={resetForm} className="btn btn-ghost" disabled={submitting}>Zrušit</button>
             <button type="submit" className="btn btn-primary gap-2 px-8" disabled={submitting || !title || !date}>
-              {submitting ? <span className="loading loading-spinner"></span> : (<><Send size={18} /> Vytvořit</>)}
+              {submitting ? <span className="loading loading-spinner"></span> : (<><Send size={18} /> {editingEvent ? 'Uložit' : 'Vytvořit'}</>)}
             </button>
           </div>
         </form>
@@ -974,7 +1016,7 @@ Expected: no new errors.
 npm run dev
 ```
 
-Log in as a society account, open the new events view (built in Task 11), click "Vytvořit novou událost", confirm: (a) campus mode — clicking a building highlights it orange and populates the room dropdown; submitting inserts a row with `venue_kind='campus'`, a non-null `room_code`, and `coord_lng`/`coord_lat` equal to the building's `center`; (b) offcampus mode — clicking the map or picking an address result drops a green marker; submitting inserts a row with `venue_kind='offcampus'`, `room_code=null`, and `coord_lng`/`coord_lat` from the pin.
+Log in as a society account, open the new events view (built in Task 11), click "Vytvořit novou událost", confirm: (a) campus mode — clicking a building highlights it orange and populates the room dropdown; submitting inserts a row with `venue_kind='campus'`, a non-null `room_code`, and `coord_lng`/`coord_lat` equal to the building's `center`; (b) offcampus mode — clicking the map or picking an address result drops a green marker; submitting inserts a row with `venue_kind='offcampus'`, `room_code=null`, and `coord_lng`/`coord_lat` from the pin. Then, from the list (Task 10/11), click "Upravit" on an existing event of each kind and confirm the form re-opens pre-filled with the correct mode/building/room or pin/address, and saving updates the same row (`id` unchanged) rather than creating a new one.
 
 - [ ] **Step 4: Commit**
 
@@ -992,14 +1034,13 @@ git commit -m "feat(events): add event creation form with dual location modes"
 
 **Interfaces:**
 - Consumes: `Tables<'spolky_events'>` (Task 2).
-- Produces: `<EventList events onRefresh />` — consumed by Task 11 (`index.tsx`).
+- Produces: `<EventList events onRefresh onEdit={(event: Tables<'spolky_events'>) => void} />` — consumed by Task 11 (`index.tsx`). "Upravit" hands the full row up to the parent, which passes it to `EventForm` as `editingEvent` (Task 9) — this list does not edit anything itself.
 - Manual verification only (same rationale as Tasks 7/9).
 
 - [ ] **Step 1: Write the component**
 
 ```tsx
-import { useState } from 'react';
-import { Trash2, Pencil, Check, X, CalendarOff } from 'lucide-react';
+import { Trash2, Pencil, CalendarOff } from 'lucide-react';
 import { supabase } from '@/lib/supabase';
 import { toast } from 'sonner';
 import { Tables } from '@/lib/database.types';
@@ -1007,18 +1048,10 @@ import { Tables } from '@/lib/database.types';
 interface EventListProps {
   events: Tables<'spolky_events'>[];
   onRefresh: () => void;
+  onEdit: (event: Tables<'spolky_events'>) => void;
 }
 
-interface EditState {
-  id: string;
-  title: string;
-  date: string;
-}
-
-export default function EventList({ events, onRefresh }: EventListProps) {
-  const [editing, setEditing] = useState<EditState | null>(null);
-  const [saving, setSaving] = useState(false);
-
+export default function EventList({ events, onRefresh, onEdit }: EventListProps) {
   const handleDelete = async (id: string) => {
     if (!confirm('Opravdu smazat tuto událost?')) return;
     try {
@@ -1028,28 +1061,6 @@ export default function EventList({ events, onRefresh }: EventListProps) {
       onRefresh();
     } catch (error: unknown) {
       toast.error(error instanceof Error ? error.message : 'Chyba mazání');
-    }
-  };
-
-  const startEdit = (e: Tables<'spolky_events'>) => setEditing({ id: e.id, title: e.title, date: e.date });
-  const cancelEdit = () => setEditing(null);
-
-  const saveEdit = async () => {
-    if (!editing || !editing.title || !editing.date) return;
-    setSaving(true);
-    try {
-      const { error } = await supabase
-        .from('spolky_events')
-        .update({ title: editing.title, date: editing.date })
-        .eq('id', editing.id);
-      if (error) throw error;
-      toast.success('Uloženo');
-      setEditing(null);
-      onRefresh();
-    } catch (error: unknown) {
-      toast.error(error instanceof Error ? error.message : 'Chyba při ukládání');
-    } finally {
-      setSaving(false);
     }
   };
 
@@ -1069,47 +1080,17 @@ export default function EventList({ events, onRefresh }: EventListProps) {
           <tr><th>Událost</th><th className="w-28">Datum</th><th>Místo</th><th className="w-24"></th><th className="w-10"></th></tr>
         </thead>
         <tbody>
-          {events.map((e) => {
-            const isEditing = editing?.id === e.id;
-            if (isEditing) {
-              return (
-                <tr key={e.id} className="bg-base-200/50">
-                  <td>
-                    <input
-                      type="text" value={editing.title}
-                      onChange={(ev) => setEditing({ ...editing, title: ev.target.value })}
-                      className="input input-sm input-bordered w-full" maxLength={80} autoFocus
-                    />
-                  </td>
-                  <td>
-                    <input
-                      type="date" value={editing.date}
-                      onChange={(ev) => setEditing({ ...editing, date: ev.target.value })}
-                      className="input input-sm input-bordered w-full"
-                    />
-                  </td>
-                  <td></td>
-                  <td>
-                    <button className="btn btn-sm btn-primary gap-1" onClick={saveEdit} disabled={saving}>
-                      {saving ? <span className="loading loading-spinner loading-sm" /> : <Check size={16} />} Uložit
-                    </button>
-                  </td>
-                  <td><button className="btn btn-sm btn-ghost btn-square" onClick={cancelEdit}><X size={16} /></button></td>
-                </tr>
-              );
-            }
-            return (
-              <tr key={e.id}>
-                <td className="font-medium">{e.title}</td>
-                <td className="text-sm text-base-content/70">
-                  {new Date(e.date).toLocaleDateString('cs-CZ', { day: 'numeric', month: 'short' })}
-                </td>
-                <td className="text-sm text-base-content/70">{e.room_code || e.location || '—'}</td>
-                <td><button className="btn btn-ghost btn-xs gap-1" onClick={() => startEdit(e)}><Pencil size={12} /> Upravit</button></td>
-                <td><button className="btn btn-ghost btn-xs btn-square text-error" onClick={() => handleDelete(e.id)}><Trash2 size={14} /></button></td>
-              </tr>
-            );
-          })}
+          {events.map((e) => (
+            <tr key={e.id}>
+              <td className="font-medium">{e.title}</td>
+              <td className="text-sm text-base-content/70">
+                {new Date(e.date).toLocaleDateString('cs-CZ', { day: 'numeric', month: 'short' })}
+              </td>
+              <td className="text-sm text-base-content/70">{e.room_code || e.location || '—'}</td>
+              <td><button className="btn btn-ghost btn-xs gap-1" onClick={() => onEdit(e)}><Pencil size={12} /> Upravit</button></td>
+              <td><button className="btn btn-ghost btn-xs btn-square text-error" onClick={() => handleDelete(e.id)}><Trash2 size={14} /></button></td>
+            </tr>
+          ))}
         </tbody>
       </table>
     </div>
@@ -1167,6 +1148,7 @@ interface EventsViewProps {
 export default function EventsView({ associationId, isReisAdmin, isGhosting }: EventsViewProps) {
   const [events, setEvents] = useState<Tables<'spolky_events'>[]>([]);
   const [loading, setLoading] = useState(false);
+  const [editingEvent, setEditingEvent] = useState<Tables<'spolky_events'> | null>(null);
 
   const fetchEvents = useCallback(async () => {
     if (!isReisAdmin && !associationId) return;
@@ -1193,7 +1175,12 @@ export default function EventsView({ associationId, isReisAdmin, isGhosting }: E
 
   return (
     <div className="space-y-6">
-      <EventForm associationId={associationId} onRefresh={fetchEvents} />
+      <EventForm
+        associationId={associationId}
+        onRefresh={fetchEvents}
+        editingEvent={editingEvent}
+        onCancelEdit={() => setEditingEvent(null)}
+      />
 
       <div className="space-y-4">
         <h3 className="font-bold text-xl px-1 flex items-center gap-2">
@@ -1205,7 +1192,7 @@ export default function EventsView({ associationId, isReisAdmin, isGhosting }: E
             <div className="skeleton h-20 w-full rounded-box opacity-20"></div>
           </div>
         ) : (
-          <EventList events={events} onRefresh={fetchEvents} />
+          <EventList events={events} onRefresh={fetchEvents} onEdit={setEditingEvent} />
         )}
       </div>
     </div>

--- a/docs/superpowers/specs/2026-07-03-society-events-location-design.md
+++ b/docs/superpowers/specs/2026-07-03-society-events-location-design.md
@@ -1,0 +1,99 @@
+# Society Map Events: Location Model & Creation Flow
+
+**Status:** Approved for planning
+**Date:** 2026-07-03
+**Repos touched:** `reis-extension`, `reis-admin`, Supabase project `reis-notifications` (`zvbpgkmnrqyprtkyxkwn`)
+
+## Problem
+
+The campus map's events feature (blue building polygons, "Akce" sidebar, society filter chips) is currently a UI-complete prototype running entirely on hardcoded mock data (`src/api/mapEvents.ts`, `SEEDS` array). There is no way for a student society ("spolek") to actually create an event, and no data model or UI exists for the two location types real events need: a specific room inside a specific campus building, or a free location anywhere in the city (e.g. a tram-stop meetup). This design moves the feature from prototype to production: real society-authored events, with both location modes, replacing the mock data entirely.
+
+## Current state (from codebase audit)
+
+- **`MapEvent`** (`src/types/events.ts`) already has the exact shape this feature needs: `coord: [lng,lat] | null`, `roomCode: string | null`, `venueKind: 'campus' | 'online' | 'offcampus'`, plus the inherited `MendeluEvent` fields (`title`, `url`, `date`, `endDate`, `time`, `location`, `imageUrl`, `organizerKey`). No type changes are required.
+- **On-campus room resolution is already solved**: `src/data/map/buildings.json` + a rooms index give every room a polygon; `polygonCentroid()` (`mapHelpers.ts`) already derives a coordinate from any polygon. A "pick building → pick room" UI needs no new backend.
+- **Off-campus placement is a genuine gap**: no click-to-place-pin or geocoding exists anywhere in either repo today. Mock off-campus events use hardcoded lat/lng literals.
+- **Auth is already solved and reusable**: `spolky_accounts` (Supabase table, 7 rows) gives each society one Supabase Auth login, admin-provisioned (not self-signup), with `association_id`/`role` columns. The existing `notifications` feature already uses this exact pattern — RLS scoping writes to the caller's own `association_id` — end to end, in production, in `reis-admin`.
+- **`spolky_accounts.association_id` values**: `af`, `au_frrms`, `esn`, `ldf`, `reis` (internal admin, not a society), `supef`, `zf` — six real student associations. The extension's static `Society` catalog (`src/data/societies.ts`) currently only has visual assets (color/glyph/logo) for three of them (`esn`, `supef`, `au_frrms`).
+- **`reis-admin`** (Vercel dashboard) has zero map/Leaflet dependency and zero society/event management today, but already has the authenticated society session and a near-identical "create notification" form to clone.
+- Both the location-gap audit and the frontend-design audit independently flagged the same open risk: no moderation/validation exists for an organizer-submitted location before it renders next to previously-trusted data.
+
+## Decisions
+
+| Question | Decision |
+|---|---|
+| Where do organizers create events? | `reis-admin` dashboard (not the extension). Reuses existing auth; extension gets no new login surface. |
+| Moderation of organizer-submitted locations? | None for v1 — `spolky_accounts` are already admin-provisioned, vetted accounts. Revisit only if abuse occurs. |
+| City-pin location input? | Both click-to-drop-pin on a map **and** typed-address search (Nominatim/OSM, Brno-bounded, free, no key). |
+| Room/pin picker UI in `reis-admin`? | A real embedded Leaflet map (not a text-only dropdown), reusing the same building/room GeoJSON data as the extension, so organizers get the same visual placement experience as the student-facing map. |
+| Society scope? | All 6 real associations (`af`, `au_frrms`, `esn`, `ldf`, `supef`, `zf`) get event-creation access — the map is moving from prototype to production, so catalog coverage should match the real account list. `reis` (internal admin) is excluded. |
+| Event images? | Out of scope. No upload capability. Pins fall back to the society's existing `logo`/`glyph`, which `EventPin` already supports for `imageUrl: null`. |
+| Mock data after launch? | Removed entirely. `fetchMapEvents` becomes a real query; an empty table renders an empty map, which is correct production behavior. |
+| Edit/cancel after publish? | Included in v1 — a lightweight per-society events list with edit/delete, alongside the create form. |
+| Data model shape | A single `spolky_events` table with a mode discriminator (`venue_kind` + `room_code` + `coord` + `location`), not normalized placement tables and not a lat/lng-only minimal schema. This is a 1:1 match for the existing `MapEvent` type and preserves the existing "fly to room" affordance. |
+
+## Data model
+
+New Supabase table `spolky_events` (project `reis-notifications`):
+
+| column | type | notes |
+|---|---|---|
+| `id` | uuid PK, default `uuid_generate_v4()` | |
+| `association_id` | text | matches `spolky_accounts.association_id`; who authored the event |
+| `title` | text | |
+| `category` | text | check constraint against the `EventCategory` union (`party`, `boardgames`, `trip`, `quiz`, `sports`, `film`, `karaoke`, `culture`, `social`, `other`) |
+| `date` | date | |
+| `end_date` | date, nullable | |
+| `time` | text, nullable | mirrors `MendeluEvent.time` |
+| `venue_kind` | text | check constraint: `'campus' \| 'online' \| 'offcampus'` |
+| `room_code` | text, nullable | set only when `venue_kind = 'campus'` |
+| `coord_lng` | double precision, nullable | resolved room centroid, or dropped-pin/geocoded point |
+| `coord_lat` | double precision, nullable | |
+| `location` | text, nullable | free-text label: typed address or manual description |
+| `url` | text, nullable | mirrors `MendeluEvent.url` |
+| `created_at` | timestamptz, default `now()` | |
+| `updated_at` | timestamptz, default `now()` | |
+
+No `image_url` column.
+
+**RLS**, copied from the existing `notifications` table's working pattern:
+- `insert`/`update`/`delete`: only rows where `association_id` matches the caller's own row in `spolky_accounts` (resolved via `auth.jwt()->>'email'`), and that account is `is_active`.
+- `select`: public (`anon` role) — the extension has no student-side auth, and event data is not sensitive.
+
+**Society catalog**: `src/data/societies.ts` grows from 3 to 6 entries, adding `af`, `ldf`, `zf` alongside the existing `esn`, `supef`, `au_frrms`, each with a `color`/`glyph`/`logo` following the existing entry shape. Logo images already exist at `public/spolky/{af,ldf,zf}.jpg` — this is a pure data addition, no new asset sourcing needed.
+
+## `reis-admin` creation UX
+
+New feature module `src/features/events/`, added as a nav item alongside the existing `notifications`/`users`/`study-jams` modules, cloned from the existing "create notification" form's session/`association_id`/submit scaffolding.
+
+**New dependencies**: `react-leaflet` + `leaflet`, plus the campus `buildings.json`/rooms-index/`landmarks.json` data (shared with `reis-extension`; exact sharing mechanism — copy vs. build-time symlink vs. a small shared package — is an implementation-plan decision, not a design decision).
+
+**Form flow**:
+1. Title, category, date/time, optional end date, optional url — plain fields.
+2. **Location mode toggle**: a `join` of two `btn-sm` buttons ("Na kampusu" / "Ve městě"), matching the existing society-filter-chip active/ghost convention. Not tabs or a wizard — this is one field with two input strategies, not independent content panels.
+3. **Campus mode**: embedded Leaflet map with the same blue building polygons as the student map. Click a building → dropdown of that building's rooms (friendly `label` shown first, code like `Q01` shown secondary) → selecting a room applies the existing orange "selected" polygon highlight and resolves `room_code` + `coord` via `polygonCentroid()`.
+4. **Off-campus mode**: same map, building polygons inert. Organizer either clicks anywhere to drop a pin (a distinct marker color/glyph — never the room-selection orange, so the two modes are never visually ambiguous) or types an address into a Brno-bounded Nominatim search box that resolves to a draggable pin for fine-tuning. Either path fills `coord` + `location`.
+5. Submit inserts into `spolky_events`; RLS enforces the `association_id` scope server-side (no client-side trust required).
+
+**Events list**: each society sees their own published events (a simple table/list, matching the existing `users`/`notifications` list patterns) with edit and delete actions, reusing the same form for edit.
+
+**Visual constraint carried over from the student map**: the basemap is always light regardless of app theme (established constraint, see `campus-map-always-light-basemap` design history) — all new picker styling (selection highlight, pin colors) must use fixed hex literals tuned for a light background, not DaisyUI theme tokens, matching how `mapHelpers.ts` already does it.
+
+## `reis-extension` read-side changes
+
+- `src/api/mapEvents.ts`: the mock seam (`SEEDS` array and its relative-date "never looks empty" logic) is deleted. `fetchMapEvents(language)` becomes a real `select * from spolky_events` (public/anon read), mapping `venue_kind`/`room_code`/`coord_lng`+`coord_lat` back into the existing `coord: [lng,lat] | null` shape.
+- No changes needed to `EventPin.tsx`, `EventDetailCard.tsx`, `EventLayer.tsx`, or the fly-to-room click affordance — they already consume the `MapEvent` shape this produces.
+- A failed fetch degrades to an empty events list plus a `logError` call (`Api.fetchMapEvents` context, per the existing telemetry convention), not a broken map.
+
+## Testing
+
+- `reis-admin`: unit tests for the location-mode resolution logic (room→coord via centroid, pin/address→coord) and for RLS-scoped create/update/delete, written before implementation per this repo's test-first convention.
+- `reis-extension`: update `mapEvents` API tests to assert against the new Supabase-backed path instead of `SEEDS`. No changes expected to existing `EventPin`/`EventDetailCard` component tests since the `MapEvent` contract is unchanged.
+- No Playwright E2E coverage of the `reis-admin` Leaflet picker is in scope for v1 (this repo's E2E suite targets `reis-extension`, not `reis-admin`).
+
+## Explicitly out of scope for v1
+
+- Event image upload.
+- Admin moderation/approval queue for organizer-submitted locations.
+- In-extension (as opposed to `reis-admin`) event creation.
+- E2E test coverage of the new `reis-admin` picker UI.

--- a/docs/superpowers/specs/2026-07-04-mcp-web-origin-iframe-design.md
+++ b/docs/superpowers/specs/2026-07-04-mcp-web-origin-iframe-design.md
@@ -1,0 +1,75 @@
+# Driving reIS live under Chrome MCP — Design Spec
+
+**Date:** 2026-07-04
+**Status:** Implemented & verified
+
+## Problem / root cause
+
+Chrome MCP (the `claude-in-chrome` extension) cannot screenshot, script, or click
+the reIS UI on `is.mendelu.cz`. Every `computer`/`javascript_tool`/`read_page`
+call on such a tab throws:
+
+> `Cannot access a chrome-extension:// URL of different extension`
+
+**Root cause (verified, not the symptom):** reIS renders its whole UI inside an
+iframe whose `src` is `chrome-extension://<reis-id>/main.html`. `claude-in-chrome`
+is *itself* an extension, and **Chrome forbids one extension from accessing
+another extension's frame**. So the moment reIS's cross-extension iframe exists in
+the tab, MCP is locked out of the entire tab. This is a hard Chrome security
+boundary — MCP can *never* be granted access to that frame. The reIS app itself
+renders fine for a human; only automated introspection is blocked. It never
+happens without MCP (confirmed by the user).
+
+## Solution: serve the iframe from a web origin in a dedicated build
+
+An *external* origin (not `chrome-extension://`) is fully accessible to MCP. So in
+a **`build:mcp`** build, the content script points its iframe at a localhost dev
+server serving the real iframe app, instead of the packaged extension page.
+
+Feasible because:
+- The iframe app (`src/entrypoints/main`) uses **no `chrome.*` APIs directly** —
+  it is fed entirely by postMessage; a small `chrome` stub covers the store's
+  `chrome.storage` use.
+- IS pages send **no CSP `frame-src`** (only `X-Frame-Options: SAMEORIGIN`, which
+  governs *being framed*, not *framing*), so a localhost iframe is allowed.
+  `http://localhost` is exempt from mixed-content blocking.
+- All iframe→parent `postMessage` calls use `'*'` target origin, so the handshake
+  works cross-origin.
+
+## Implementation
+
+| Piece | File |
+|---|---|
+| iframe src / origin resolver (env-gated) | `src/injector/iframeManager.ts` — `resolveIframeSrc()`, `resolveIframeOrigin()` |
+| content-script message-origin check tracks the same flag | `src/injector/messageHandler.ts` |
+| dev server serving the **real** app at `:5199` (chrome stub + mock data + assets) | `dev-iframe/` (`vite.config.ts`, `main.html`, `entry.tsx`, `chromeStub.ts`) |
+| Tailwind scans app source under a non-root vite root | `src/index.css` — additive `@source "./**/*.{ts,tsx,html}"` |
+| scripts | `package.json` — `iframe-dev`, `build:mcp` |
+
+`VITE_IFRAME_ORIGIN` (set only by `build:mcp=http://localhost:5199`) flips both
+`resolveIframeSrc()` (→ `…/main.html`) and `resolveIframeOrigin()` (→ the origin
+the message handler accepts). Unset in the normal build → packaged
+`chrome-extension://` page, **prod totally unaffected** (verified: no `localhost`
+string in the normal build output).
+
+## Two tiers of use
+
+- **Tier 1 (quick, UI only):** `npm run iframe-dev`, then point MCP at
+  `http://localhost:5199/main.html`. `VITE_USE_MOCK_DATA=true` populates the UI;
+  no extension load, no IS login. Best for feature UI work.
+- **Tier 2 (full, real IS data):** `npm run iframe-dev` **and** `npm run build:mcp`
+  → load unpacked → visit `is.mendelu.cz/auth/`. The content script frames
+  localhost; real synced data flows over the origin-agnostic postMessage IPC.
+
+## Known limitations
+
+- WebISKAM (`iskamMessageHandler.ts`) still hard-codes the extension origin — the
+  same fix could be applied if ISKAM needs live MCP debugging (out of scope).
+- The default mock dataset has no study plan, so the Předměty tab shows an empty
+  state under Tier 1; other views (calendar, exams badge) populate.
+
+## Out of scope (YAGNI)
+
+- Auto-loading the unpacked extension (Chrome file picker can't be automated).
+- Switching the whole project to Playwright MCP (considered; A keeps the existing
+  `claude-in-chrome` workflow with a small, prod-safe code change).

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "test:serenity": "xvfb-run -a playwright test e2e/serenity/specs",
     "test:smoke": "xvfb-run -a playwright test e2e/serenity/specs/smoke.spec.ts",
     "test:e2e:setup": "playwright install chromium",
-    "typecheck": "tsc -b"
+    "typecheck": "tsc -b",
+    "iframe-dev": "VITE_USE_MOCK_DATA=true vite --config dev-iframe/vite.config.ts",
+    "build:mcp": "VITE_IFRAME_ORIGIN=http://localhost:5199 wxt build"
   },
   "dependencies": {
     "@fontsource/inter": "^5.2.8",

--- a/src/api/__tests__/mapEvents.test.ts
+++ b/src/api/__tests__/mapEvents.test.ts
@@ -1,16 +1,43 @@
 import { describe, it, expect } from 'vitest';
-import { MOCK_MAP_EVENTS } from '../mapEvents';
+import { toMapEvent } from '../mapEvents';
 
-describe('MOCK_MAP_EVENTS categories', () => {
-  it('gives every event a category', () => {
-    for (const e of MOCK_MAP_EVENTS) expect(e.category).toBeTruthy();
+describe('toMapEvent', () => {
+  it('maps a campus-room row into a MapEvent with a resolved building coord', () => {
+    const row = {
+      id: 'abc', association_id: 'supef', title: 'PEF Kvíz', category: 'quiz',
+      date: '2026-07-10', end_date: null, time: '18:00', venue_kind: 'campus',
+      room_code: 'Q01', coord_lng: 16.614247, coord_lat: 49.209592,
+      location: null, url: null,
+    };
+    expect(toMapEvent(row)).toEqual({
+      id: 'abc', title: 'PEF Kvíz', url: '', date: '2026-07-10', endDate: null,
+      time: '18:00', location: null, imageUrl: null, organizerKey: 'pef',
+      societyId: 'supef', coord: [16.614247, 49.209592], roomCode: 'Q01',
+      venueKind: 'campus', category: 'quiz',
+    });
   });
 
-  it('categorises known titles correctly', () => {
-    const byTitle = (t: string) => MOCK_MAP_EVENTS.find((e) => e.title === t);
-    expect(byTitle('Erasmus Cup: Basketball')?.category).toBe('sports');
-    expect(byTitle('Tram Party')?.category).toBe('party');
-    expect(byTitle('PEF Kvíz')?.category).toBe('quiz');
-    expect(byTitle('Karaoke Night')?.category).toBe('karaoke');
+  it('maps an off-campus row with a free-text location and no room code', () => {
+    const row = {
+      id: 'def', association_id: 'esn', title: 'Tram Party', category: 'party',
+      date: '2026-07-17', end_date: null, time: '20:00', venue_kind: 'offcampus',
+      room_code: null, coord_lng: 16.606389, coord_lat: 49.198056,
+      location: 'Česká (sraz)', url: 'https://www.instagram.com/esnmendelubrno/',
+    };
+    expect(toMapEvent(row)).toEqual({
+      id: 'def', title: 'Tram Party', url: 'https://www.instagram.com/esnmendelubrno/',
+      date: '2026-07-17', endDate: null, time: '20:00', location: 'Česká (sraz)',
+      imageUrl: null, organizerKey: 'mendelu', societyId: 'esn',
+      coord: [16.606389, 49.198056], roomCode: null, venueKind: 'offcampus', category: 'party',
+    });
+  });
+
+  it('maps a null coord when either coordinate is missing', () => {
+    const row = {
+      id: 'ghi', association_id: 'af', title: 'AF Den', category: 'culture',
+      date: '2026-08-01', end_date: null, time: null, venue_kind: 'offcampus',
+      room_code: null, coord_lng: null, coord_lat: null, location: 'TBD', url: null,
+    };
+    expect(toMapEvent(row).coord).toBeNull();
   });
 });

--- a/src/api/mapEvents.ts
+++ b/src/api/mapEvents.ts
@@ -1,110 +1,58 @@
-import type { MapEvent, FacultyKey, EventCategory } from '../types/events';
+import type { MapEvent, EventCategory } from '../types/events';
 import { societyById } from '../data/societies';
-import { inferCategory } from '../data/eventCategories';
+import { supabase } from '../services/spolky/supabaseClient';
+import { logError } from '../utils/reportError';
 
-// MOCK provider — the single seam the real backend replaces. Titles + dates are
-// real, taken from the ESN MENDELU / SU PEF / AU FRRMS public calendars; venues
-// are inferred from each society's home base (the calendars don't list rooms),
-// and recurring annual events are positioned into the current window so the demo
-// isn't empty. Coords are [lng, lat] from the bundled map data:
-const VENUE = {
-  Q: [16.614247, 49.209592] as [number, number], // PEF building Q (id 0)
-  FRRMS: [16.614393, 49.218171] as [number, number], // FRRMS / Kolej Akademie
-  TAUF: [16.588635, 49.215198] as [number, number], // Tauferovy sports centre
-  JAK: [16.630567, 49.216291] as [number, number], // Koleje JAK
-  CESKA: [16.606389, 49.198056] as [number, number], // Česká tram stop (Česká/Joštova), city centre — off-campus meet-up point
-};
-
-// Off-campus venues that still get a map pin (a real meet-up spot in the city),
-// as opposed to on-campus venues. Used to tag venueKind honestly.
-const OFFCAMPUS_VENUES = new Set<keyof typeof VENUE>(['CESKA']);
-
-const URLS: Record<string, string> = {
-  esn: 'https://www.instagram.com/esnmendelubrno/',
-  supef: 'https://www.instagram.com/supefmendelu/',
-  au_frrms: 'https://au.mendelu.cz',
-};
-
-type Lang = 'cz' | 'en';
-
-// Localized labels for the descriptive venues (the rooms like "Q01" are already
-// language-neutral). Event *titles* stay single strings on purpose — they're
-// proper event names (e.g. "PEF Kvíz", "Tram Party"), not translatable copy.
-const VENUE_LABELS: Partial<Record<keyof typeof VENUE, Record<Lang, string>>> = {
-  TAUF: { cz: 'Sportovní centrum', en: 'Sports centre' },
-  JAK: { cz: 'Koleje JAK', en: 'JAK dorms' },
-  FRRMS: { cz: 'FRRMS', en: 'FRRMS' },
-  CESKA: { cz: 'Česká (sraz)', en: 'Česká (meetup)' },
-};
-
-interface Seed {
+interface SpolkyEventRow {
+  id: string;
+  association_id: string;
   title: string;
-  societyId: string;
-  date: string; // ISO yyyy-mm-dd
+  category: string;
+  date: string;
+  end_date: string | null;
   time: string | null;
-  venue: keyof typeof VENUE | null; // null = off-campus, list-only
-  room?: string;
-  category?: EventCategory; // override; defaults to inferCategory(title)
+  venue_kind: string;
+  room_code: string | null;
+  coord_lng: number | null;
+  coord_lat: number | null;
+  location: string | null;
+  url: string | null;
 }
 
-// Local (not UTC) ISO yyyy-mm-dd — avoids the off-by-one toISOString gives near
-// midnight in CET. The mock window is anchored to "now" so the demo always shows
-// upcoming events no matter when it runs.
-function isoLocal(d: Date): string {
-  const m = String(d.getMonth() + 1).padStart(2, '0');
-  const day = String(d.getDate()).padStart(2, '0');
-  return `${d.getFullYear()}-${m}-${day}`;
-}
-
-// `days` from today. The list groups by a rolling 7-day window (see weekSections),
-// so 1–2 days out is always "this week" and 7+ days out is always "next week" —
-// no calendar-boundary spill, no empty "This week" on weekends.
-function inDays(days: number): string {
-  const d = new Date();
-  d.setHours(0, 0, 0, 0);
-  d.setDate(d.getDate() + days);
-  return isoLocal(d);
-}
-
-// A tight 4-event window — this week + next week — so the panel reads as a short,
-// near-term agenda rather than a whole-semester dump. Kept varied on purpose:
-// three societies, on- and off-campus, distinct categories/pins.
-const SEEDS: Seed[] = [
-  // This week (tomorrow + day after — always inside the rolling 7-day window)
-  { title: 'Erasmus Cup: Basketball', societyId: 'esn', date: inDays(1), time: '18:00', venue: 'TAUF' },
-  { title: 'PEF Kvíz', societyId: 'supef', date: inDays(2), time: '18:00', venue: 'Q', room: 'Q01' },
-  // Next week (8 + 10 days out — always in the second window)
-  { title: 'Tram Party', societyId: 'esn', date: inDays(8), time: '20:00', venue: 'CESKA' },
-  { title: 'Karaoke Night', societyId: 'au_frrms', date: inDays(10), time: '19:00', venue: 'FRRMS' },
-];
-
-function toEvent(s: Seed, i: number, language: Lang): MapEvent {
-  const soc = societyById(s.societyId);
-  const coord = s.venue ? VENUE[s.venue] : null;
+// Pure row -> MapEvent mapping, kept separate from the network call so it's
+// directly unit-testable without hitting Supabase.
+export function toMapEvent(row: SpolkyEventRow): MapEvent {
+  const soc = societyById(row.association_id);
+  const coord: [number, number] | null =
+    row.coord_lng != null && row.coord_lat != null ? [row.coord_lng, row.coord_lat] : null;
   return {
-    id: `mock-${i}-${s.date}`,
-    title: s.title,
-    url: URLS[s.societyId] ?? '',
-    date: s.date,
-    endDate: null,
-    time: s.time,
-    location: s.room ?? (s.venue ? VENUE_LABELS[s.venue]?.[language] ?? null : null),
+    id: row.id,
+    title: row.title,
+    url: row.url ?? '',
+    date: row.date,
+    endDate: row.end_date,
+    time: row.time,
+    location: row.location,
     imageUrl: null,
-    organizerKey: soc.facultyKey as FacultyKey,
-    societyId: s.societyId,
+    organizerKey: soc.facultyKey,
+    societyId: row.association_id,
     coord,
-    roomCode: s.room ?? null,
-    venueKind: s.venue == null || OFFCAMPUS_VENUES.has(s.venue) ? 'offcampus' : 'campus',
-    category: s.category ?? inferCategory(s.title),
+    roomCode: row.room_code,
+    venueKind: row.venue_kind as MapEvent['venueKind'],
+    category: row.category as EventCategory,
   };
 }
 
-// Default Czech dataset — used by tests and as the eager export; the runtime path
-// builds per-language via fetchMapEvents.
-export const MOCK_MAP_EVENTS: MapEvent[] = SEEDS.map((s, i) => toEvent(s, i, 'cz'));
+export async function fetchMapEvents(): Promise<MapEvent[]> {
+  const { data, error } = await supabase
+    .from('spolky_events')
+    .select('*')
+    .order('date', { ascending: true });
 
-// Async to mirror the real network seam; builds the dataset in the requested
-// language for now (so the English UI gets English venue labels).
-export async function fetchMapEvents(language: Lang): Promise<MapEvent[]> {
-  return SEEDS.map((s, i) => toEvent(s, i, language));
+  if (error) {
+    logError('Api.fetchMapEvents', error);
+    return [];
+  }
+
+  return (data ?? []).map((row) => toMapEvent(row as SpolkyEventRow));
 }

--- a/src/components/CampusMap/__tests__/EventLayer.test.tsx
+++ b/src/components/CampusMap/__tests__/EventLayer.test.tsx
@@ -10,7 +10,7 @@ import { render, act } from '@testing-library/react';
 import { EventLayer } from '../EventLayer';
 import { setMapInstance } from '../mapInstance';
 import { useAppStore } from '../../../store/useAppStore';
-import { MOCK_MAP_EVENTS } from '../../../api/mapEvents';
+import { MOCK_MAP_EVENTS } from './fixtures/mockMapEvents';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let handlers: Record<string, (...a: any[]) => void>;

--- a/src/components/CampusMap/__tests__/EventsList.test.tsx
+++ b/src/components/CampusMap/__tests__/EventsList.test.tsx
@@ -7,7 +7,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { EventsList } from '../EventsList';
 import { useAppStore } from '../../../store/useAppStore';
-import { MOCK_MAP_EVENTS } from '../../../api/mapEvents';
+import { MOCK_MAP_EVENTS } from './fixtures/mockMapEvents';
 
 beforeEach(() => {
   useAppStore.setState({ mapEvents: MOCK_MAP_EVENTS, eventFilter: 'all', mapSelection: null, language: 'en' });

--- a/src/components/CampusMap/__tests__/MapSidePanel.test.tsx
+++ b/src/components/CampusMap/__tests__/MapSidePanel.test.tsx
@@ -7,7 +7,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MapSidePanel } from '../MapSidePanel';
 import { useAppStore } from '../../../store/useAppStore';
-import { MOCK_MAP_EVENTS } from '../../../api/mapEvents';
+import { MOCK_MAP_EVENTS } from './fixtures/mockMapEvents';
 
 beforeEach(() => {
   useAppStore.setState({ mapPanelTab: 'places', mapEvents: MOCK_MAP_EVENTS, eventFilter: 'all', mapSelection: null, language: 'en' });

--- a/src/components/CampusMap/__tests__/eventHelpers.test.ts
+++ b/src/components/CampusMap/__tests__/eventHelpers.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { sortByDate, filterEvents, groupEventsByVenue, weekSections, relativeDayLabel } from '../eventHelpers';
-import { MOCK_MAP_EVENTS } from '../../../api/mapEvents';
+import { MOCK_MAP_EVENTS } from './fixtures/mockMapEvents';
 import type { MapEvent } from '../../../types/events';
 
 describe('eventHelpers', () => {

--- a/src/components/CampusMap/__tests__/fixtures/mockMapEvents.ts
+++ b/src/components/CampusMap/__tests__/fixtures/mockMapEvents.ts
@@ -1,0 +1,37 @@
+import type { MapEvent } from '../../../../types/events';
+
+// Test-only fixture standing in for what used to be the exported
+// `MOCK_MAP_EVENTS` mock provider in `src/api/mapEvents.ts` (removed in Task 13,
+// which replaced the mock with a real Supabase-backed `fetchMapEvents`). Kept
+// here — not in production code — purely so CampusMap component/helper tests
+// have a small, varied, deterministic set of events to render against: three
+// societies, on- and off-campus, distinct categories/pins. Values mirror the
+// old mock dataset (same titles/venues/coords) so existing assertions
+// (society chip labels, "PEF Kvíz"/"Karaoke Night" text, category emoji) keep
+// holding without change.
+export const MOCK_MAP_EVENTS: MapEvent[] = [
+  {
+    id: 'mock-0', title: 'Erasmus Cup: Basketball', url: 'https://www.instagram.com/esnmendelubrno/',
+    date: '2026-07-10', endDate: null, time: '18:00', location: 'Sports centre', imageUrl: null,
+    organizerKey: 'mendelu', societyId: 'esn', coord: [16.588635, 49.215198], roomCode: null,
+    venueKind: 'campus', category: 'sports',
+  },
+  {
+    id: 'mock-1', title: 'PEF Kvíz', url: 'https://www.instagram.com/supefmendelu/',
+    date: '2026-07-11', endDate: null, time: '18:00', location: null, imageUrl: null,
+    organizerKey: 'pef', societyId: 'supef', coord: [16.614247, 49.209592], roomCode: 'Q01',
+    venueKind: 'campus', category: 'quiz',
+  },
+  {
+    id: 'mock-2', title: 'Tram Party', url: 'https://www.instagram.com/esnmendelubrno/',
+    date: '2026-07-17', endDate: null, time: '20:00', location: 'Česká (sraz)', imageUrl: null,
+    organizerKey: 'mendelu', societyId: 'esn', coord: [16.606389, 49.198056], roomCode: null,
+    venueKind: 'offcampus', category: 'party',
+  },
+  {
+    id: 'mock-3', title: 'Karaoke Night', url: 'https://au.mendelu.cz',
+    date: '2026-07-19', endDate: null, time: '19:00', location: 'FRRMS', imageUrl: null,
+    organizerKey: 'frrms', societyId: 'au_frrms', coord: [16.614393, 49.218171], roomCode: null,
+    venueKind: 'campus', category: 'karaoke',
+  },
+];

--- a/src/components/CampusMap/__tests__/fixtures/mockMapEvents.ts
+++ b/src/components/CampusMap/__tests__/fixtures/mockMapEvents.ts
@@ -12,13 +12,13 @@ import type { MapEvent } from '../../../../types/events';
 export const MOCK_MAP_EVENTS: MapEvent[] = [
   {
     id: 'mock-0', title: 'Erasmus Cup: Basketball', url: 'https://www.instagram.com/esnmendelubrno/',
-    date: '2026-07-10', endDate: null, time: '18:00', location: 'Sports centre', imageUrl: null,
+    date: '2026-07-10', endDate: null, time: '18:00', location: 'Sportovní centrum', imageUrl: null,
     organizerKey: 'mendelu', societyId: 'esn', coord: [16.588635, 49.215198], roomCode: null,
     venueKind: 'campus', category: 'sports',
   },
   {
     id: 'mock-1', title: 'PEF Kvíz', url: 'https://www.instagram.com/supefmendelu/',
-    date: '2026-07-11', endDate: null, time: '18:00', location: null, imageUrl: null,
+    date: '2026-07-11', endDate: null, time: '18:00', location: 'Q01', imageUrl: null,
     organizerKey: 'pef', societyId: 'supef', coord: [16.614247, 49.209592], roomCode: 'Q01',
     venueKind: 'campus', category: 'quiz',
   },

--- a/src/data/__tests__/eventCategories.test.ts
+++ b/src/data/__tests__/eventCategories.test.ts
@@ -1,34 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { inferCategory, CATEGORY_ICON, CATEGORY_EMOJI_SRC, CATEGORY_COLOR } from '../eventCategories';
+import { CATEGORY_ICON, CATEGORY_EMOJI_SRC, CATEGORY_COLOR } from '../eventCategories';
 import type { EventCategory } from '../../types/events';
 
 const ALL_CATEGORIES: EventCategory[] = ['party', 'boardgames', 'trip', 'quiz', 'sports', 'film', 'karaoke', 'culture', 'social', 'other'];
-
-describe('inferCategory', () => {
-  const cases: Array<[string, EventCategory]> = [
-    ['Deskovky', 'boardgames'],
-    ['Trip to Ostrava', 'trip'],
-    ['PEF Kvíz', 'quiz'],
-    ['Akademické středy — ASY-Quiz', 'quiz'],
-    ['Erasmus Cup: Basketball', 'sports'],
-    ['Erasmus Cup: Volleyball', 'sports'],
-    ['Filmový klubík', 'film'],
-    ['BU Karaoke', 'karaoke'],
-    ['Country Presentation', 'culture'],
-    ['Tématické dny — Taiwanský den', 'culture'],
-    ['NEON Party', 'party'],
-    ['Tram Party', 'party'],
-    ['Beer Pong', 'party'],
-    ['International Student Ball', 'party'],
-    ['Tour de Pub', 'social'],
-    ['TINDELU', 'social'],
-    ['Únikovka', 'social'],
-    ['Something Unmapped', 'other'],
-  ];
-  it.each(cases)('maps %s → %s', (title, expected) => {
-    expect(inferCategory(title)).toBe(expected);
-  });
-});
 
 describe('category maps', () => {
   it('have a lucide icon, an emoji svg path, and a vivid colour for every category', () => {

--- a/src/data/eventCategories.ts
+++ b/src/data/eventCategories.ts
@@ -55,22 +55,3 @@ export const CATEGORY_EMOJI_SRC: Record<EventCategory, string> = {
   social: '/emoji/1f37b.svg',     // 🍻
   other: '/emoji/2728.svg',       // ✨
 };
-
-// Keyword → category, first match wins (specific before generic). The real
-// backend will carry an organizer-picked category; this is the mock seam.
-const RULES: Array<[EventCategory, RegExp]> = [
-  ['boardgames', /deskov|board\s?game/i],
-  ['trip', /\btrip\b|výlet|zájezd/i],
-  ['quiz', /kvíz|quiz/i],
-  ['karaoke', /karaoke/i],
-  ['film', /film|movie|kino/i],
-  ['sports', /sport|basket|volej|volley|fotbal|football|běh|\brun\b/i],
-  ['culture', /country|\bden\b|\bday\b|prezentace|presentation|tématick|kultur/i],
-  ['party', /party|párty|ples|ball|neon|tram|beer\s?pong|beerpong/i],
-  ['social', /pub|tinder|tindelu|únikov|escape|seznam|mixer|drink/i],
-];
-
-export function inferCategory(title: string): EventCategory {
-  for (const [cat, re] of RULES) if (re.test(title)) return cat;
-  return 'other';
-}

--- a/src/data/societies.ts
+++ b/src/data/societies.ts
@@ -10,6 +10,9 @@ export const SOCIETIES: Record<string, Society> = {
   esn: { id: 'esn', name: 'ESN MENDELU', shortName: 'ESN', color: '#00AEEF', glyph: '✷', logo: '/spolky/esn.jpg', facultyKey: 'mendelu' },
   supef: { id: 'supef', name: 'SU PEF', shortName: 'SUPEF', color: '#0046a0', glyph: 'SU', logo: '/spolky/supef.jpg', facultyKey: 'pef' },
   au_frrms: { id: 'au_frrms', name: 'AU FRRMS', shortName: 'AU FRRMS', color: '#c32897', glyph: 'AU', logo: '/spolky/au_frrms.jpg', facultyKey: 'frrms' },
+  af: { id: 'af', name: 'AF Spolek', shortName: 'AF', color: '#c87800', glyph: 'AF', logo: '/spolky/af.jpg', facultyKey: 'af' },
+  ldf: { id: 'ldf', name: 'LDF Spolek', shortName: 'LDF', color: '#0a5028', glyph: 'LDF', logo: '/spolky/ldf.jpg', facultyKey: 'ldf' },
+  zf: { id: 'zf', name: 'ZF Spolek', shortName: 'ZF', color: '#8c0a00', glyph: 'ZF', logo: '/spolky/zf.jpg', facultyKey: 'zf' },
 };
 
 export const ALL_SOCIETIES: Society[] = Object.values(SOCIETIES);

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,8 @@
 @import "tailwindcss";
+/* Explicit source so Tailwind scans the app when the Vite root isn't the repo
+   root (e.g. the dev-iframe/ MCP-debug server). Additive — a no-op for the
+   normal WXT build, which already auto-detects src/. */
+@source "./**/*.{ts,tsx,html}";
 
 /* Mobile = touch device + narrow viewport. Desktop split-screen stays desktop. */
 @custom-variant touch (@media (pointer: coarse) and (max-width: 767px));

--- a/src/injector/__tests__/iframeManager.test.ts
+++ b/src/injector/__tests__/iframeManager.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { resolveIframeSrc, resolveIframeOrigin } from '../iframeManager';
+
+afterEach(() => vi.unstubAllEnvs());
+
+describe('resolveIframeSrc', () => {
+  it('uses the packaged extension page by default (normal build)', () => {
+    // chrome.runtime.getURL is stubbed in src/test/setup.ts
+    expect(resolveIframeSrc()).toBe('chrome-extension://test-extension-id/main.html');
+  });
+
+  it('points at the web origin when VITE_IFRAME_ORIGIN is set (build:mcp)', () => {
+    vi.stubEnv('VITE_IFRAME_ORIGIN', 'http://localhost:5199');
+    expect(resolveIframeSrc()).toBe('http://localhost:5199/main.html');
+  });
+
+  it('does not append a double slash when origin has no trailing slash', () => {
+    vi.stubEnv('VITE_IFRAME_ORIGIN', 'http://localhost:5199');
+    expect(resolveIframeSrc()).not.toContain('//main.html');
+  });
+});
+
+describe('resolveIframeOrigin', () => {
+  it('is the packaged extension origin by default (no trailing slash)', () => {
+    // chrome.runtime.getURL('') is stubbed to chrome-extension://test-extension-id/
+    expect(resolveIframeOrigin()).toBe('chrome-extension://test-extension-id');
+  });
+
+  it('is the web origin when VITE_IFRAME_ORIGIN is set (build:mcp)', () => {
+    vi.stubEnv('VITE_IFRAME_ORIGIN', 'http://localhost:5199');
+    expect(resolveIframeOrigin()).toBe('http://localhost:5199');
+  });
+
+  it('matches the origin of resolveIframeSrc so the message handler accepts it', () => {
+    vi.stubEnv('VITE_IFRAME_ORIGIN', 'http://localhost:5199');
+    expect(new URL(resolveIframeSrc()).origin).toBe(resolveIframeOrigin());
+  });
+});

--- a/src/injector/iframeManager.ts
+++ b/src/injector/iframeManager.ts
@@ -1,5 +1,30 @@
 import { IFRAME_ID } from './config';
 
+/**
+ * Resolve the iframe's source URL. Normally the packaged extension page
+ * (`chrome-extension://…/main.html`). In the `build:mcp` build
+ * (`VITE_IFRAME_ORIGIN` set, e.g. `http://localhost:5199`) the app is served
+ * from a plain http origin instead, because Chrome MCP (claude-in-chrome) is
+ * itself an extension and cannot screenshot/script a *different* extension's
+ * `chrome-extension://` frame. Serving the UI from a web origin makes it
+ * introspectable. See docs/superpowers/specs/2026-07-04-mcp-web-origin-iframe-design.md
+ */
+export function resolveIframeSrc(): string {
+    const origin = import.meta.env.VITE_IFRAME_ORIGIN;
+    return origin ? `${origin}/main.html` : chrome.runtime.getURL('main.html');
+}
+
+/**
+ * The origin the iframe messages arrive from, used by the content-script message
+ * handlers to validate `event.origin`. Must match {@link resolveIframeSrc}'s
+ * origin — the packaged extension origin normally, or the `VITE_IFRAME_ORIGIN`
+ * web origin in the `build:mcp` build.
+ */
+export function resolveIframeOrigin(): string {
+    const origin = import.meta.env.VITE_IFRAME_ORIGIN;
+    return origin || chrome.runtime.getURL('').replace(/\/$/, '');
+}
+
 export let iframeElement: HTMLIFrameElement | null = null;
 let iframeReady = false;
 let messageQueue: unknown[] = [];
@@ -23,7 +48,7 @@ export function injectIframe() {
 
     iframeElement = document.createElement("iframe");
     iframeElement.id = IFRAME_ID;
-    iframeElement.src = chrome.runtime.getURL("main.html");
+    iframeElement.src = resolveIframeSrc();
 
     Object.assign(iframeElement.style, {
         position: "fixed", top: "0", left: "0", width: "100%", height: "100%",

--- a/src/injector/messageHandler.ts
+++ b/src/injector/messageHandler.ts
@@ -1,5 +1,5 @@
 import { Messages, isIframeMessage } from "../types/messages";
-import { iframeElement, sendToIframe, markIframeReady } from "./iframeManager";
+import { iframeElement, sendToIframe, markIframeReady, resolveIframeOrigin } from "./iframeManager";
 import { cachedData, syncAllData, runDriveBackupNow, runNotesBackupNow, setNotesSnapshot, setNotesHtmlOverride, isSyncing, refreshExams } from "./syncService";
 import { fetchFullSemesterSchedule } from "./dataFetchers";
 import { fetchExamData, registerExam, unregisterExam } from "../api/exams";
@@ -9,7 +9,7 @@ import { scrapedNavMenu } from "./sniper";
 
 let topUpPopupRef: Window | null = null;
 
-const IFRAME_ORIGIN = chrome.runtime.getURL('').replace(/\/$/, '');
+const IFRAME_ORIGIN = resolveIframeOrigin();
 
 export async function handleMessage(event: MessageEvent) {
     if (event.origin !== IFRAME_ORIGIN) return;

--- a/src/store/slices/__tests__/createMapSlice.test.ts
+++ b/src/store/slices/__tests__/createMapSlice.test.ts
@@ -1,9 +1,25 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 vi.mock('../../../api/campusMap', () => ({ fetchBuildingRooms: vi.fn() }));
+vi.mock('../../../api/mapEvents', () => ({ fetchMapEvents: vi.fn() }));
 import { fetchBuildingRooms } from '../../../api/campusMap';
+import { fetchMapEvents } from '../../../api/mapEvents';
 import { useAppStore } from '../../useAppStore';
 import type { RoomsCollection } from '../../../types/campusMap';
+import type { MapEvent } from '../../../types/events';
+
+// Fixture standing in for the real Supabase-backed fetchMapEvents (Task 13) —
+// one on-campus event (has a coord, so it's pin-able) and one off-campus
+// event (no coord), matching the variety the store-level tests exercise.
+const MOCK_EVENTS: MapEvent[] = [
+  { id: 'ev-1', title: 'PEF Kvíz', url: '', date: '2026-07-10', endDate: null, time: '18:00',
+    location: null, imageUrl: null, organizerKey: 'pef', societyId: 'supef',
+    coord: [16.614247, 49.209592], roomCode: 'Q01', venueKind: 'campus', category: 'quiz' },
+  { id: 'ev-2', title: 'Tram Party', url: 'https://www.instagram.com/esnmendelubrno/',
+    date: '2026-07-17', endDate: null, time: '20:00', location: 'Česká (sraz)', imageUrl: null,
+    organizerKey: 'mendelu', societyId: 'esn', coord: null, roomCode: null,
+    venueKind: 'offcampus', category: 'party' },
+];
 
 const fc = (id: number, floorId: number): RoomsCollection => ({ type: 'FeatureCollection',
   features: [{ type: 'Feature', geometry: { type: 'Polygon', coordinates: [[[16.6, 49.2]]] },
@@ -16,6 +32,8 @@ beforeEach(() => {
     roomsByBuilding: {}, mapLoadingBuilding: null, mapSearchQuery: '', mapSearchResults: [], mapFocusRequest: 0,
     mapEvents: [], mapEventsLoaded: false, mapPanelTab: 'places', eventFilter: 'all' });
   vi.mocked(fetchBuildingRooms).mockReset();
+  vi.mocked(fetchMapEvents).mockReset();
+  vi.mocked(fetchMapEvents).mockResolvedValue(MOCK_EVENTS);
 });
 
 describe('mapSlice', () => {

--- a/src/store/slices/createMapSlice.ts
+++ b/src/store/slices/createMapSlice.ts
@@ -116,7 +116,7 @@ export const createMapSlice: AppSlice<MapSlice> = (set, get) => ({
     // language switch would never re-fetch the localized dataset.
     if (get().mapEventsLoaded && get().mapEventsLanguage === language) return;
     try {
-      const events = await fetchMapEvents(language);
+      const events = await fetchMapEvents();
       set({ mapEvents: events, mapEventsLoaded: true, mapEventsLanguage: language });
     } catch (err) {
       logError('MapSlice.loadMapEvents', err);

--- a/src/store/slices/createMapSlice.ts
+++ b/src/store/slices/createMapSlice.ts
@@ -27,7 +27,6 @@ export const createMapSlice: AppSlice<MapSlice> = (set, get) => ({
   mapFocusRequest: 0,
   mapEvents: [],
   mapEventsLoaded: false,
-  mapEventsLanguage: null,
   mapPanelTab: 'events',
   eventFilter: 'all',
 
@@ -111,13 +110,10 @@ export const createMapSlice: AppSlice<MapSlice> = (set, get) => ({
   setEventFilter: (filter) => set({ eventFilter: filter }),
 
   loadMapEvents: async () => {
-    const language = get().language;
-    // Cache is keyed by language, not a one-shot flag — otherwise a later
-    // language switch would never re-fetch the localized dataset.
-    if (get().mapEventsLoaded && get().mapEventsLanguage === language) return;
+    if (get().mapEventsLoaded) return;
     try {
       const events = await fetchMapEvents();
-      set({ mapEvents: events, mapEventsLoaded: true, mapEventsLanguage: language });
+      set({ mapEvents: events, mapEventsLoaded: true });
     } catch (err) {
       logError('MapSlice.loadMapEvents', err);
     }

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -427,8 +427,6 @@ export interface MapSlice {
   // --- Society events on the map ---
   mapEvents: MapEvent[];
   mapEventsLoaded: boolean;
-  /** Language the cached events were built in; a switch re-fetches. */
-  mapEventsLanguage: Language | null;
   /** Which tab the top-right panel shows. */
   mapPanelTab: 'places' | 'events';
   /** Event scope: 'all' societies, or a specific societyId. */


### PR DESCRIPTION
## Why

Chrome MCP (`claude-in-chrome`) can't drive reIS on `is.mendelu.cz`: it is itself a Chrome extension, and Chrome forbids one extension from accessing another extension's frame. reIS renders its whole UI in a `chrome-extension://<id>/main.html` iframe, so every MCP screenshot / JS eval / click on the tab throws:

> `Cannot access a chrome-extension:// URL of different extension`

This is a hard Chrome security boundary — MCP can never access that frame. The app renders fine for a human; only automated introspection is blocked, and only under MCP.

## What

Serve the **real** iframe app from a web origin MCP *can* introspect, gated by `VITE_IFRAME_ORIGIN` so the normal build is untouched.

- `resolveIframeSrc()` / `resolveIframeOrigin()` in `iframeManager.ts` (+ `messageHandler.ts` origin check) switch the iframe between the packaged `chrome-extension://` page and a web origin.
- `dev-iframe/`: a Vite server that runs the real iframe app at `localhost:5199/main.html` — with a `chrome` stub, mock data, and the extension's static assets.
- `src/index.css`: additive `@source` so Tailwind scans `src/` when the Vite root isn't the repo root (no-op for the normal build).
- Scripts: `iframe-dev` (Tier 1, quick UI) and `build:mcp` (Tier 2, real data through the content script).

## Usage

- **Quick UI:** `npm run iframe-dev` → point Chrome MCP at `http://localhost:5199/main.html`.
- **Real data:** `npm run iframe-dev` + `npm run build:mcp` → load unpacked → `is.mendelu.cz/auth/`.

See `docs/superpowers/specs/2026-07-04-mcp-web-origin-iframe-design.md` and the new CLAUDE.md section.

## Verified

- Chrome MCP screenshots + clicks the live app (calendar, panels, modals).
- New unit tests for the src/origin resolver (6/6); no test regressions (the 5 failing ISKAM parser suites are a pre-existing missing-fixture gap on `main`).
- Normal `npm run build` and `npm run build:mcp` both pass; **no `localhost` leak in the normal build** (prod unaffected).

> Note: this branch was cut from local `main`, which is ahead of `origin/main` by 10 (society-map-events) commits, so the diff shows those until `main` is pushed. Only `feat(dev): …` (the last commit) is this PR's change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for loading map events from live data instead of only mocked content.
  * Expanded the society catalog with additional organizations.

* **Bug Fixes**
  * Improved iframe loading so the UI can run correctly from both the extension and a local web origin.
  * Tightened origin handling for iframe messaging to avoid cross-origin issues.

* **Documentation**
  * Added guidance for testing the UI in Chrome MCP and choosing the right local workflow.

* **Tests**
  * Updated and expanded tests for event mapping, iframe origin resolution, and map event loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->