### PR TITLE
feat(eduroam): manual EAP-TLS Android flow (do not merge until edge fn deployed)

### DIFF
--- a/src/api/eduroam.ts
+++ b/src/api/eduroam.ts
@@ -3,6 +3,8 @@
 // credentials, same as file downloads). All assembly stays client-side; the
 // private key is never sent anywhere. See src/services/eduroam for the generator.
 
+import { parseCertNotAfter, parseCertSubjectCN } from '../services/eduroam/certExpiry';
+
 const CERT_URL = 'https://is.mendelu.cz/auth/wifi/certifikat.pl';
 
 export interface EduroamCertMaterial {
@@ -14,6 +16,10 @@ export interface EduroamCertMaterial {
   password: string | null;
   /** True when no cert existed and a fresh one had to be generated. */
   generated: boolean;
+  /** Client-cert expiry, parsed from the DER cert; null if it can't be read. */
+  validUntil: Date | null;
+  /** EAP-TLS identity = the cert's subject CN (`<login>@mendelu.cz`); null if unreadable. */
+  identity: string | null;
 }
 
 /**
@@ -77,10 +83,20 @@ export async function fetchEduroamCertMaterial(): Promise<EduroamCertMaterial> {
     if (!hasCert) throw new Error('eduroam: certificate generation did not produce a certificate');
   }
 
-  const [rootCaDer, clientP12] = await Promise.all([
+  const [rootCaDer, clientP12, userDer] = await Promise.all([
     getBytes(`${CERT_URL}?get=root-der;lang=cz`),
     getBytes(`${CERT_URL}?get=user-p12;lang=cz`),
+    // The unencrypted DER cert lets us read the expiry without the .p12 password.
+    getBytes(`${CERT_URL}?get=user-der;lang=cz`).catch(() => null),
   ]);
 
-  return { rootCaDer, clientP12, password, generated };
+  let validUntil: Date | null = null;
+  let identity: string | null = null;
+  if (userDer) {
+    // Both are nice-to-haves parsed from the DER cert; never fail setup over them.
+    try { validUntil = parseCertNotAfter(userDer); } catch { validUntil = null; }
+    try { identity = parseCertSubjectCN(userDer); } catch { identity = null; }
+  }
+
+  return { rootCaDer, clientP12, password, generated, validUntil, identity };
 }

--- a/src/api/eduroamTransfer.ts
+++ b/src/api/eduroamTransfer.ts
@@ -30,13 +30,14 @@ export async function putTransfer(profileBytes: Uint8Array, ttlSeconds = 480): P
 }
 
 /** Which on-phone format the receiver should serve this transfer as. */
-export type TransferFormat = 'ios' | 'android';
+export type TransferFormat = 'ios' | 'android' | 'p12';
 
 /**
  * The QR target: the receiver endpoint for this transfer id. `fmt` selects the
  * response MIME/filename on the receiver (`ios` = Apple config profile, the
- * default and unchanged; `android` = `.eap-config` for geteduroam). The hint is
- * not a secret — the uploaded bytes are identical regardless.
+ * default and unchanged; `android` = `.eap-config` for geteduroam; `p12` = the
+ * raw password-protected PKCS#12 for the manual Android EAP-TLS path). The hint
+ * is not a secret — the uploaded bytes are whatever was put for this id.
  */
 export function buildTransferUrl(id: string, fmt: TransferFormat = 'ios'): string {
   const base = `${RECEIVER_URL}?id=${encodeURIComponent(id)}`;

--- a/src/components/Eduroam/DeviceAccordion.tsx
+++ b/src/components/Eduroam/DeviceAccordion.tsx
@@ -11,6 +11,7 @@ interface DeviceAccordionProps {
   status: EduroamStatus;
   qrDataUrl: string | null;
   password: string | null;
+  identity: string | null;
   onRun: () => void;
   onOpenSettings: () => void;
 }

--- a/src/components/Eduroam/EduroamDrawer.tsx
+++ b/src/components/Eduroam/EduroamDrawer.tsx
@@ -11,7 +11,7 @@ export function EduroamDrawer() {
   const { t } = useTranslation();
   const isOpen = useAppStore((s) => s.isEduroamOpen);
   const setOpen = useAppStore((s) => s.setIsEduroamOpen);
-  const { status, password, qrDataUrl, error, run, reset, selectTarget, openProfilesSettings } = useEduroamSetup();
+  const { status, password, identity, qrDataUrl, error, run, reset, selectTarget, openProfilesSettings } = useEduroamSetup();
   const [selected, setSelected] = useState<EduroamTarget | null>(null);
 
   const close = () => { setOpen(false); setSelected(null); reset(); };
@@ -50,6 +50,7 @@ export function EduroamDrawer() {
           status={status}
           qrDataUrl={qrDataUrl}
           password={password}
+          identity={identity}
           onRun={() => selected && run(selected)}
           onOpenSettings={openProfilesSettings}
         />

--- a/src/components/Eduroam/EduroamTutorial.tsx
+++ b/src/components/Eduroam/EduroamTutorial.tsx
@@ -11,6 +11,8 @@ interface EduroamTutorialProps {
   status: EduroamStatus;
   qrDataUrl: string | null;
   password: string | null;
+  /** The cert's subject CN = the exact EAP-TLS Identity to type (Android manual flow). */
+  identity: string | null;
   onRun: () => void;
   onOpenSettings: () => void;
 }
@@ -52,7 +54,7 @@ function ActionButton({ action, status, onRun, onOpenSettings }: {
   );
 }
 
-export function EduroamTutorial({ target, status, qrDataUrl, password, onRun, onOpenSettings }: EduroamTutorialProps) {
+export function EduroamTutorial({ target, status, qrDataUrl, password, identity, onRun, onOpenSettings }: EduroamTutorialProps) {
   const { t } = useTranslation();
   const manual = EDUROAM_MANUAL[target];
   const [zoom, setZoom] = useState<string | null>(null);
@@ -97,6 +99,21 @@ export function EduroamTutorial({ target, status, qrDataUrl, password, onRun, on
 
             {step.password && password && (
               <PasswordChip password={password} label={t('eduroam.pwdLabel')} />
+            )}
+
+            {step.fields && (
+              <dl className="rounded-field bg-base-200 border border-base-content/10 p-3 text-sm flex flex-col gap-1.5">
+                {(['network', 'security', 'eap', 'caCert', 'userCert', 'identity'] as const).map((k) => (
+                  <div key={k} className="flex justify-between gap-3">
+                    <dt className="text-base-content/60 shrink-0">{t(manualKey(target, 'fields', k, 'label'))}</dt>
+                    <dd className="font-medium text-right break-all">
+                      {/* Show the student's real identity (cert CN) when we could read it,
+                          otherwise the generic "your login@mendelu.cz" hint. */}
+                      {k === 'identity' && identity ? identity : t(manualKey(target, 'fields', k, 'value'))}
+                    </dd>
+                  </div>
+                ))}
+              </dl>
             )}
 
             {step.action && !showQr && (

--- a/src/components/Eduroam/__tests__/DeviceAccordion.test.tsx
+++ b/src/components/Eduroam/__tests__/DeviceAccordion.test.tsx
@@ -6,7 +6,7 @@ import { useAppStore } from '../../../store/useAppStore';
 afterEach(() => { cleanup(); useAppStore.setState({ language: 'en' }); });
 
 const base = {
-  status: 'idle' as const, qrDataUrl: null, password: null,
+  status: 'idle' as const, qrDataUrl: null, password: null, identity: null,
   onSelect: () => {}, onRestart: () => {}, onRun: () => {}, onOpenSettings: () => {},
 };
 

--- a/src/components/Eduroam/__tests__/EduroamTutorial.test.tsx
+++ b/src/components/Eduroam/__tests__/EduroamTutorial.test.tsx
@@ -6,17 +6,37 @@ import { useAppStore } from '../../../store/useAppStore';
 afterEach(() => { cleanup(); useAppStore.setState({ language: 'en' }); });
 
 const base = {
-  status: 'idle' as const, qrDataUrl: null, password: null,
+  status: 'idle' as const, qrDataUrl: null, password: null, identity: null,
   onRun: () => {}, onOpenSettings: () => {},
 };
 
 describe('EduroamTutorial', () => {
-  it('renders the do-once block only for android/windows', () => {
+  it('renders the geteduroam do-once block only for windows, not android', () => {
+    useAppStore.setState({ language: 'en' });
+    const { rerender } = render(<EduroamTutorial target="windows" {...base} />);
+    expect(screen.getByText('Install geteduroam for Windows')).toBeTruthy();
+    // Android is the manual EAP-TLS flow now — no geteduroam anywhere.
+    rerender(<EduroamTutorial target="android" {...base} />);
+    expect(screen.queryByText(/geteduroam/i)).toBeNull();
+  });
+
+  it('android shows the manual Wi-Fi field values (EAP method / Identity)', () => {
+    useAppStore.setState({ language: 'en' });
+    render(<EduroamTutorial target="android" {...base} />);
+    expect(screen.getByText('EAP method')).toBeTruthy();
+    expect(screen.getByText('TLS')).toBeTruthy();
+    expect(screen.getByText('Identity')).toBeTruthy();
+  });
+
+  it('android fills the real identity when the cert CN was read', () => {
     useAppStore.setState({ language: 'en' });
     const { rerender } = render(<EduroamTutorial target="android" {...base} />);
-    expect(screen.getByText('Install the geteduroam app')).toBeTruthy();
-    rerender(<EduroamTutorial target="ios" {...base} />);
-    expect(screen.queryByText(/geteduroam app$/)).toBeNull();
+    // Fallback hint before we know the login.
+    expect(screen.getByText('your login@mendelu.cz')).toBeTruthy();
+    // Real value once identity is resolved.
+    rerender(<EduroamTutorial target="android" {...base} identity="xnovak@mendelu.cz" />);
+    expect(screen.getByText('xnovak@mendelu.cz')).toBeTruthy();
+    expect(screen.queryByText('your login@mendelu.cz')).toBeNull();
   });
 
   it('calls onRun when the action button is clicked', () => {

--- a/src/components/Eduroam/__tests__/manual.test.ts
+++ b/src/components/Eduroam/__tests__/manual.test.ts
@@ -31,13 +31,19 @@ describe('EDUROAM_MANUAL', () => {
     }
   });
 
-  it('only mac has an openSettings step; only android+windows have doOnceUrl', () => {
+  it('only mac has an openSettings step; only windows has doOnceUrl', () => {
     expect(EDUROAM_MANUAL.mac.steps.some((s) => s.action === 'openSettings')).toBe(true);
     expect(EDUROAM_MANUAL.ios.steps.some((s) => s.action === 'openSettings')).toBe(false);
-    expect(EDUROAM_MANUAL.android.doOnceUrl).toBeTruthy();
+    // Android is now the manual EAP-TLS flow — no geteduroam app to install.
+    expect(EDUROAM_MANUAL.android.doOnceUrl).toBeUndefined();
     expect(EDUROAM_MANUAL.windows.doOnceUrl).toBeTruthy();
     expect(EDUROAM_MANUAL.ios.doOnceUrl).toBeUndefined();
     expect(EDUROAM_MANUAL.mac.doOnceUrl).toBeUndefined();
+  });
+
+  it('android manual flow has a fields step and no doOnce', () => {
+    expect(EDUROAM_MANUAL.android.steps.some((s) => s.fields)).toBe(true);
+    expect(EDUROAM_MANUAL.android.doOnceUrl).toBeUndefined();
   });
 
   it('every referenced i18n key resolves to a string in both locales', () => {

--- a/src/components/Eduroam/manual.ts
+++ b/src/components/Eduroam/manual.ts
@@ -7,6 +7,8 @@ export interface StepMeta {
   action?: EduroamAction;
   /** Renders the real PasswordChip when a password is available. */
   password?: boolean;
+  /** Renders the manual Wi-Fi field-values block (Android manual EAP-TLS setup). */
+  fields?: boolean;
   /** Public path to a screenshot shown under the step (only where we have one). */
   img?: string;
 }
@@ -22,12 +24,14 @@ export const EDUROAM_MANUAL: Record<EduroamTarget, DeviceManual> = {
   ios: {
     steps: [{ action: 'qr' }, {}, {}, { password: true }],
   },
+  // Manual EAP-TLS path (no geteduroam): deliver the .p12, install it, then add
+  // the eduroam network by hand. Reliable at MENDELU (geteduroam isn't in eduroam
+  // discovery) and yields a normal saved network that lasts the cert's full year.
   android: {
-    doOnceUrl: 'https://play.google.com/store/apps/details?id=app.eduroam.geteduroam',
     steps: [
       { action: 'qr' },
-      { img: '/eduroam/android/2.webp' },
-      { password: true, img: '/eduroam/android/3.webp' },
+      { password: true },
+      { fields: true },
     ],
   },
   mac: {

--- a/src/hooks/data/__tests__/useEduroamSetup.test.ts
+++ b/src/hooks/data/__tests__/useEduroamSetup.test.ts
@@ -2,12 +2,15 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { saveAs } from 'file-saver';
 import { useEduroamSetup } from '../useEduroamSetup';
+import { putTransfer, buildTransferUrl } from '../../../api/eduroamTransfer';
 
 vi.mock('../../../api/eduroam', () => ({
   fetchEduroamCertMaterial: vi.fn().mockResolvedValue({
     rootCaDer: new Uint8Array(),
     clientP12: new Uint8Array(),
     password: 'pw123',
+    validUntil: null,
+    identity: 'xtest@mendelu.cz',
   }),
   fetchEduroamPassword: vi.fn().mockResolvedValue('pw123'),
 }));
@@ -69,5 +72,21 @@ describe('useEduroamSetup', () => {
     expect(result.current.password).toBe('pw123');
     expect(result.current.qrDataUrl).toBeNull();
     expect(saveAs).toHaveBeenCalledWith(expect.any(Blob), 'eduroam-reis.eap-config');
+  });
+
+  it("run('android') transfers the raw .p12 for manual install (fmt=p12)", async () => {
+    const { result } = renderHook(() => useEduroamSetup());
+
+    await act(async () => {
+      await result.current.run('android');
+    });
+
+    expect(result.current.status).toBe('done');
+    expect(result.current.qrDataUrl).toBe('data:image/png;base64,zz');
+    expect(result.current.password).toBe('pw123'); // still shown, for the cert install prompt
+    expect(result.current.identity).toBe('xtest@mendelu.cz'); // exact EAP-TLS Identity to type
+    // Delivers the PKCS#12 bytes themselves (not an .eap-config) and points the QR at fmt=p12.
+    expect(putTransfer).toHaveBeenCalledWith(expect.any(Uint8Array));
+    expect(buildTransferUrl).toHaveBeenCalledWith('tid', 'p12');
   });
 });

--- a/src/hooks/data/useEduroamSetup.ts
+++ b/src/hooks/data/useEduroamSetup.ts
@@ -20,6 +20,7 @@ export function useEduroamSetup() {
   const [status, setStatus] = useState<EduroamStatus>('idle');
   const [target, setTarget] = useState<EduroamTarget>(isMac ? 'mac' : 'ios');
   const [password, setPassword] = useState<string | null>(null);
+  const [identity, setIdentity] = useState<string | null>(null);
   const [qrDataUrl, setQrDataUrl] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -29,9 +30,10 @@ export function useEduroamSetup() {
     setStatus('working');
     setError(null);
     setPassword(null);
+    setIdentity(null);
     setQrDataUrl(null);
     try {
-      const { rootCaDer, clientP12, password: extractionPw } = await fetchEduroamCertMaterial();
+      const { rootCaDer, clientP12, password: extractionPw, validUntil, identity: certIdentity } = await fetchEduroamCertMaterial();
       const xml = generateEduroamMobileconfig({ rootCaDer, clientP12 });
 
       if (t === 'ios') {
@@ -40,21 +42,24 @@ export function useEduroamSetup() {
         const id = await putTransfer(new TextEncoder().encode(xml));
         setQrDataUrl(await QRCode.toDataURL(buildTransferUrl(id, 'ios'), { margin: 2, width: 320 }));
       } else if (t === 'android') {
-        // Android uses an .eap-config (geteduroam), delivered via the same transfer;
-        // the receiver serves it as application/eap-config for fmt=android.
-        const eap = generateEapConfig({ rootCaDer, clientP12 });
-        const id = await putTransfer(new TextEncoder().encode(eap));
-        setQrDataUrl(await QRCode.toDataURL(buildTransferUrl(id, 'android'), { margin: 2, width: 320 }));
+        // Manual EAP-TLS path: deliver the password-protected .p12 itself so the
+        // student installs the cert and adds the eduroam network by hand. This is
+        // the reliable route at MENDELU — geteduroam breaks (MENDELU isn't in the
+        // eduroam discovery catalogue), whereas a hand-added network is a normal
+        // saved network that lasts the cert's full ~365 days on any Android version.
+        const id = await putTransfer(clientP12);
+        setQrDataUrl(await QRCode.toDataURL(buildTransferUrl(id, 'p12'), { margin: 2, width: 320 }));
       } else if (t === 'windows') {
         // Windows: same .eap-config as Android, but reIS runs on this PC, so we
         // save it straight to disk. geteduroam (Windows) opens it on double-click.
-        const eap = generateEapConfig({ rootCaDer, clientP12 });
+        const eap = generateEapConfig({ rootCaDer, clientP12, validUntil: validUntil ?? undefined });
         saveAs(new Blob([eap], { type: 'application/eap-config' }), 'eduroam-reis.eap-config');
       } else {
         saveAs(new Blob([xml], { type: 'application/x-apple-aspen-config' }), 'eduroam-reis.mobileconfig');
       }
 
       setPassword(extractionPw);
+      setIdentity(certIdentity);
       setStatus('done');
     } catch (e) {
       logError('useEduroamSetup.run', e);
@@ -68,6 +73,7 @@ export function useEduroamSetup() {
     setStatus('idle');
     setError(null);
     setPassword(null);
+    setIdentity(null);
     setQrDataUrl(null);
     // Prefetch the extraction password so the chip can show it before Download.
     // Only populates when a cert already exists; first-time users get it from
@@ -81,6 +87,7 @@ export function useEduroamSetup() {
     setStatus('idle');
     setError(null);
     setPassword(null);
+    setIdentity(null);
     setQrDataUrl(null);
   }, []);
 
@@ -98,6 +105,7 @@ export function useEduroamSetup() {
     target,
     selectTarget,
     password,
+    identity,
     qrDataUrl,
     error,
     run,

--- a/src/i18n/__tests__/eduroamWindowsKeys.test.ts
+++ b/src/i18n/__tests__/eduroamWindowsKeys.test.ts
@@ -12,7 +12,9 @@ const FLAT_KEYS = [
 
 // device -> number of steps in the manual
 const DEVICE_STEPS: Record<string, number> = { ios: 4, android: 3, mac: 4, windows: 3 };
-const DO_ONCE_DEVICES = ['android', 'windows'] as const;
+// Android is now the manual EAP-TLS flow (no geteduroam app), so only Windows
+// keeps a do-once install-the-app step.
+const DO_ONCE_DEVICES = ['windows'] as const;
 
 function leaf(obj: unknown, path: string): unknown {
   return path.split('.').reduce<unknown>(

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -636,27 +636,32 @@
         }
       },
       "android": {
-        "hint": "Aplikace geteduroam",
-        "doOnce": {
-          "title": "Nainstaluj aplikaci geteduroam",
-          "cta": "Stáhnout z Google Play"
-        },
+        "hint": "Ruční nastavení (nejspolehlivější)",
         "steps": [
           {
-            "text": "Klepni na Vytvořit QR kód",
+            "text": "Klepni na Vytvořit QR kód, naskenuj ho a stáhni soubor s certifikátem",
             "shot": "Vygenerovaný QR kód v panelu reIS"
           },
           {
-            "text": "Naskenuj ho a klepni na stažený soubor, aby se otevřel v geteduroam",
-            "shot": "Stažení → otevření souboru v geteduroam"
+            "text": "Otevři stažený soubor a nainstaluj certifikát — po výzvě zadej toto heslo a pojmenuj ho libovolně",
+            "shot": "Výzva Androidu k instalaci certifikátu"
           },
           {
-            "text": "Zadej heslo certifikátu",
-            "shot": "Výzva geteduroam na heslo"
+            "text": "Ručně přidej Wi-Fi síť s názvem eduroam a těmito hodnotami, pak dej Připojit:",
+            "shot": "Ruční dialog Wi-Fi (EAP) v Androidu",
+            "warn": "Uživatelský certifikát musí být ten, který jsi právě nainstaloval (obsahuje tvůj klíč) — na to se snadno zapomene. Když je Připojit šedé, chybí pole Identita."
           }
         ],
+        "fields": {
+          "network": { "label": "Název sítě (SSID)", "value": "eduroam" },
+          "security": { "label": "Zabezpečení", "value": "WPA/WPA2/WPA3-Enterprise" },
+          "eap": { "label": "Metoda EAP", "value": "TLS" },
+          "caCert": { "label": "Certifikát CA", "value": "Neověřovat" },
+          "userCert": { "label": "Uživatelský certifikát", "value": "nainstalovaný certifikát" },
+          "identity": { "label": "Identita", "value": "tvůj login@mendelu.cz" }
+        },
         "done": {
-          "text": "Hotovo — na fakultě se k eduroam připojíš automaticky",
+          "text": "Připoj se — tato uložená síť zůstane a připojí tě, kdykoli jsi na fakultě",
           "shot": "Telefon připojený k eduroam"
         }
       },

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -636,27 +636,32 @@
         }
       },
       "android": {
-        "hint": "geteduroam app",
-        "doOnce": {
-          "title": "Install the geteduroam app",
-          "cta": "Get it on Google Play"
-        },
+        "hint": "Manual setup (most reliable)",
         "steps": [
           {
-            "text": "Tap Create QR code",
+            "text": "Tap Create QR code, scan it, and download the certificate file",
             "shot": "The generated QR code in the reIS drawer"
           },
           {
-            "text": "Scan it, then tap the downloaded file to open it in geteduroam",
-            "shot": "Download → opening the file in geteduroam"
+            "text": "Open the downloaded file to install the certificate — enter this password when asked, and give it any name",
+            "shot": "Android's install-certificate prompt"
           },
           {
-            "text": "Enter the certificate password",
-            "shot": "geteduroam password prompt"
+            "text": "Add a Wi-Fi network named eduroam by hand with these settings, then Connect:",
+            "shot": "Android's manual Wi-Fi (EAP) dialog",
+            "warn": "The User certificate must be the one you just installed (it holds your key) — that's the field that's easy to miss. If Connect stays greyed out, the Identity field is empty."
           }
         ],
+        "fields": {
+          "network": { "label": "Network name (SSID)", "value": "eduroam" },
+          "security": { "label": "Security", "value": "WPA/WPA2/WPA3-Enterprise" },
+          "eap": { "label": "EAP method", "value": "TLS" },
+          "caCert": { "label": "CA certificate", "value": "Don't validate" },
+          "userCert": { "label": "User certificate", "value": "the cert you installed" },
+          "identity": { "label": "Identity", "value": "your login@mendelu.cz" }
+        },
         "done": {
-          "text": "Set up — you'll connect to eduroam automatically when you're on campus",
+          "text": "Connect — this saved network stays put and works whenever you're on campus",
           "shot": "Phone connected to eduroam"
         }
       },

--- a/src/services/eduroam/certExpiry.test.ts
+++ b/src/services/eduroam/certExpiry.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { parseCertNotAfter, formatValidUntil, parseCertSubjectCN } from './certExpiry';
+
+// Fixtures generated with openssl (see scripts / commit notes):
+//  - v1: no [0] version field, notAfter 2027-07-04 09:42:47 UTC
+//  - v3: has [0] version (clientAuth EKU) — the MENDELU cert shape —
+//        notAfter 2027-07-05 09:43:38 UTC
+const V1_DER_B64 =
+  'MIICtjCCAZ4CCQCIbkVkRyMnvjANBgkqhkiG9w0BAQsFADAdMRswGQYDVQQDDBJmaXh0dXJlQG1lbmRlbHUuY3owHhcNMjYwNzA0MDk0MjQ3WhcNMjcwNzA0MDk0MjQ3WjAdMRswGQYDVQQDDBJmaXh0dXJlQG1lbmRlbHUuY3owggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC/zK1sgkU4lRYYs+hZA/C4rVUMWmZTefh1e8wL9/o6BeLNRU5w7lrid7jwTr5Ws3rVfFPvCyP5rCYMCDXEcIWING4frbB3xCsHmd+VDt3KEKcWKLosUJ2AlhMberAaDfdz0LIHjSKu91yjFP7QdG81CSzAC1DKL38FW3bi3LJ36ijGulqjZdmYHmYHEPf7AG5SfIcmMSixiaJKDfVTs+TfuByChR9vVXDdtgr9nfDhfAkOWQ1tULsvfTKzGAreQ2Hp0bryxvhPxObRvT0HTnb2wX4ljd9tkwey4/DPLQWmrGw3juI3VtwzIw4KPdFKFlRWnTfcJ6MpKlLDlQ372YAxAgMBAAEwDQYJKoZIhvcNAQELBQADggEBALJVqMM9kL8t/Q58fQBkTj0Ws1UP/ByGnYVH3iPOWYtMm3RhiijumkbjE7SNtq3mpBwfyTjEufIuJvxyKLHNbzZyiZk6kDQmHPCNTsqtr2UpMtyECzvGP+h1zDOzVwF2mIn96xpa7iQt/W/tg7BP4b1G97djweNw+c8JZ+3YsmKsvTKtb2+SFIyvwDSK3GQmO3cnyCqKV2rGQU6k96gZclbXzQRD1E4x7vMU0M9wlQFX4xQ8Nqm5yZuZ2zG/Tg85rV3r7NFheuLofZdOfZXNvZLLtVmrG43Llz0QiJDSc+o1fsj0m0Nx0paNNYTfNCxlF0V7gYDZZJrf0+fcbQWznBs=';
+const V3_DER_B64 =
+  'MIIC0jCCAbqgAwIBAgIJAMTHcqGh7lL1MA0GCSqGSIb3DQEBCwUAMBwxGjAYBgNVBAMMEXYzdXNlckBtZW5kZWx1LmN6MB4XDTI2MDcwNDA5NDMzOFoXDTI3MDcwNTA5NDMzOFowHDEaMBgGA1UEAwwRdjN1c2VyQG1lbmRlbHUuY3owggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9g1sFEdRCFSMZ1di44I9NmbmtQdCMbz3XrhRDWV27/3jo91w/eIhShAifoxZXSILTrUmY3ejN2rpjys1ZOyvtsYNJZ5qblESz+mtScOL27JV01lV77AIHrWYKMhqiGjJV/1Pl538a86dSgx8312IqsO2cvH4k99+VTOcmlZ7H6XLnbJQsxv0x/PJstkj/NHZOGDONjqJrugXqM9lMaz/FatEDuwRUCTn2VO1HnIk+kYJbBnqzQdWBlHD/ar/aF97YtNNjX71pxn2b3mJGndlVW67BrkdLIuyK7YRvEzMJH4ApbIE3B1fcay2YRh00hY3jQ3Ku7gMb/rRxSYSxsEnlAgMBAAGjFzAVMBMGA1UdJQQMMAoGCCsGAQUFBwMCMA0GCSqGSIb3DQEBCwUAA4IBAQCEuywq26ff/Cu5z4YZTHcIeKz9wlhmlCoDjWOG2NQnmAUCig+uKoOQoTToB1OABqzsjF+1hX/CTi/JHEPOaS4y/Oh75SsICm2ZrR3bq3WBXX19vBh4cuKRvJfvLGVViDOCpj8mGUWSSTc5gg889xG+9gOhQfOKFx/vHhdygDXglN97OY6mVbiIVShQe9AJJ/z184iiANLp6QOoRM7z1iKNbOe6CZl/cMXeHXwWC+CWMPT7WYRAtdrUq5H6R1rq3xnA/B4/iv55T+AWnrF27VQcdmQ6UB8n1vVEu+IuBIe4aZssQenhyOFrx3Jtm9AOaaFM3bBH/uDm/K2Z6XjoxD98';
+
+const derFrom = (b64: string) => Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
+
+describe('parseCertNotAfter', () => {
+  it('reads notAfter from a v1 cert (no version field)', () => {
+    const d = parseCertNotAfter(derFrom(V1_DER_B64));
+    expect(d.toISOString()).toBe('2027-07-04T09:42:47.000Z');
+  });
+
+  it('reads notAfter from a v3 cert (skips the [0] version field)', () => {
+    const d = parseCertNotAfter(derFrom(V3_DER_B64));
+    expect(d.toISOString()).toBe('2027-07-05T09:43:38.000Z');
+  });
+
+  it('throws on non-certificate bytes', () => {
+    expect(() => parseCertNotAfter(new Uint8Array([0x02, 0x01, 0x01]))).toThrow(/certExpiry/);
+  });
+});
+
+describe('parseCertSubjectCN', () => {
+  it('reads the CN (= EAP-TLS identity) from a v1 cert', () => {
+    expect(parseCertSubjectCN(derFrom(V1_DER_B64))).toBe('fixture@mendelu.cz');
+  });
+
+  it('reads the CN from a v3 cert (skips the [0] version field)', () => {
+    expect(parseCertSubjectCN(derFrom(V3_DER_B64))).toBe('v3user@mendelu.cz');
+  });
+
+  it('throws on non-certificate bytes', () => {
+    expect(() => parseCertSubjectCN(new Uint8Array([0x02, 0x01, 0x01]))).toThrow(/certExpiry/);
+  });
+});
+
+describe('formatValidUntil', () => {
+  it('formats as geteduroam SERVER_DATE_FORMAT (UTC, no Z, no millis)', () => {
+    expect(formatValidUntil(new Date('2027-07-04T09:42:47.000Z'))).toBe('2027-07-04T09:42:47');
+  });
+
+  it('zero-pads all fields', () => {
+    expect(formatValidUntil(new Date('2027-01-02T03:04:05.000Z'))).toBe('2027-01-02T03:04:05');
+  });
+});

--- a/src/services/eduroam/certExpiry.ts
+++ b/src/services/eduroam/certExpiry.ts
@@ -1,0 +1,135 @@
+// Minimal ASN.1 DER walker that pulls `notAfter` out of an X.509 certificate.
+// Deliberately tiny: it only navigates Certificate → tbsCertificate → validity
+// → notAfter, enough to learn when the MENDELU client cert expires so the
+// generated eduroam profiles can advertise a real expiry. Not a general X.509
+// parser — do not extend it into one.
+
+interface Tlv {
+  tag: number;
+  valueStart: number;
+  end: number;
+}
+
+function readTlv(der: Uint8Array, pos: number): Tlv {
+  if (pos + 1 > der.length) throw new Error('certExpiry: truncated TLV');
+  const tag = der[pos];
+  let i = pos + 1;
+  let len = der[i++];
+  if (len & 0x80) {
+    const n = len & 0x7f;
+    if (n === 0 || n > 4) throw new Error('certExpiry: unsupported length form');
+    len = 0;
+    for (let k = 0; k < n; k++) len = (len << 8) | der[i++];
+  }
+  const end = i + len;
+  if (end > der.length) throw new Error('certExpiry: length exceeds buffer');
+  return { tag, valueStart: i, end };
+}
+
+function parseAsn1Time(tag: number, bytes: Uint8Array): Date {
+  const s = new TextDecoder().decode(bytes);
+  let year: number;
+  let rest: string;
+  if (tag === 0x17) {
+    // UTCTime: YYMMDDHHMMSSZ — RFC 5280 pivots the 2-digit year at 50.
+    const yy = parseInt(s.slice(0, 2), 10);
+    year = yy >= 50 ? 1900 + yy : 2000 + yy;
+    rest = s.slice(2);
+  } else if (tag === 0x18) {
+    // GeneralizedTime: YYYYMMDDHHMMSSZ
+    year = parseInt(s.slice(0, 4), 10);
+    rest = s.slice(4);
+  } else {
+    throw new Error(`certExpiry: unexpected time tag 0x${tag.toString(16)}`);
+  }
+  const month = parseInt(rest.slice(0, 2), 10);
+  const day = parseInt(rest.slice(2, 4), 10);
+  const hour = parseInt(rest.slice(4, 6), 10);
+  const minute = parseInt(rest.slice(6, 8), 10);
+  const second = /^\d\d/.test(rest.slice(8, 10)) ? parseInt(rest.slice(8, 10), 10) : 0;
+  const t = Date.UTC(year, month - 1, day, hour, minute, second);
+  if (Number.isNaN(t)) throw new Error('certExpiry: unparseable time');
+  return new Date(t);
+}
+
+/**
+ * Extract the `notAfter` timestamp from a DER-encoded X.509 certificate.
+ * Throws if the structure is not a recognizable certificate.
+ */
+export function parseCertNotAfter(der: Uint8Array): Date {
+  const cert = readTlv(der, 0); // Certificate ::= SEQUENCE
+  if (cert.tag !== 0x30) throw new Error('certExpiry: not a certificate SEQUENCE');
+  const tbs = readTlv(der, cert.valueStart); // tbsCertificate ::= SEQUENCE
+  if (tbs.tag !== 0x30) throw new Error('certExpiry: missing tbsCertificate');
+
+  let p = tbs.valueStart;
+  const first = readTlv(der, p);
+  if (first.tag === 0xa0) p = first.end; // [0] EXPLICIT version (v2/v3) — skip
+  p = readTlv(der, p).end; // serialNumber INTEGER
+  p = readTlv(der, p).end; // signature AlgorithmIdentifier SEQUENCE
+  p = readTlv(der, p).end; // issuer Name SEQUENCE
+
+  const validity = readTlv(der, p); // validity ::= SEQUENCE { notBefore, notAfter }
+  if (validity.tag !== 0x30) throw new Error('certExpiry: missing validity');
+  const notBefore = readTlv(der, validity.valueStart);
+  const notAfter = readTlv(der, notBefore.end);
+  return parseAsn1Time(notAfter.tag, der.subarray(notAfter.valueStart, notAfter.end));
+}
+
+/**
+ * Extract the subject Common Name (CN) from a DER-encoded X.509 certificate.
+ * For the MENDELU client cert this is `<login>@mendelu.cz` — exactly the value
+ * the student must type into Android's EAP-TLS "Identity" field. Returns null if
+ * no CN is present. Throws only if the bytes aren't a certificate.
+ */
+export function parseCertSubjectCN(der: Uint8Array): string | null {
+  const cert = readTlv(der, 0);
+  if (cert.tag !== 0x30) throw new Error('certExpiry: not a certificate SEQUENCE');
+  const tbs = readTlv(der, cert.valueStart);
+  if (tbs.tag !== 0x30) throw new Error('certExpiry: missing tbsCertificate');
+
+  let p = tbs.valueStart;
+  const first = readTlv(der, p);
+  if (first.tag === 0xa0) p = first.end; // [0] version
+  p = readTlv(der, p).end; // serialNumber
+  p = readTlv(der, p).end; // signature
+  p = readTlv(der, p).end; // issuer
+  p = readTlv(der, p).end; // validity
+  const subject = readTlv(der, p); // subject Name ::= SEQUENCE OF RDN
+  if (subject.tag !== 0x30) throw new Error('certExpiry: missing subject');
+
+  // Walk each RDN (SET) → AttributeTypeAndValue (SEQUENCE { OID, value }); the CN
+  // attribute type OID id-at-commonName = 2.5.4.3 encodes to bytes 55 04 03.
+  let q = subject.valueStart;
+  while (q < subject.end) {
+    const rdn = readTlv(der, q);
+    let a = rdn.valueStart;
+    while (a < rdn.end) {
+      const atv = readTlv(der, a);
+      const oid = readTlv(der, atv.valueStart);
+      const ob = der.subarray(oid.valueStart, oid.end);
+      if (ob.length === 3 && ob[0] === 0x55 && ob[1] === 0x04 && ob[2] === 0x03) {
+        const val = readTlv(der, oid.end);
+        return new TextDecoder().decode(der.subarray(val.valueStart, val.end));
+      }
+      a = atv.end;
+    }
+    q = rdn.end;
+  }
+  return null;
+}
+
+/**
+ * Format a Date for the eduroam `.eap-config` `<ValidUntil>` element.
+ * geteduroam's AndroidConfigParser binds Date with
+ * `SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss")` in UTC, so we must match that
+ * exactly (no trailing `Z`, no milliseconds). The result is also a valid
+ * `xs:dateTime`, so it still passes eap-metadata.xsd validation.
+ */
+export function formatValidUntil(d: Date): string {
+  const p = (n: number) => String(n).padStart(2, '0');
+  return (
+    `${d.getUTCFullYear()}-${p(d.getUTCMonth() + 1)}-${p(d.getUTCDate())}` +
+    `T${p(d.getUTCHours())}:${p(d.getUTCMinutes())}:${p(d.getUTCSeconds())}`
+  );
+}

--- a/src/services/eduroam/eapConfig.test.ts
+++ b/src/services/eduroam/eapConfig.test.ts
@@ -70,4 +70,28 @@ describe('generateEapConfig', () => {
     const xml = generateEapConfig({ rootCaDer: root, clientP12: p12 });
     expect(xml.indexOf('</CredentialApplicability>')).toBeLessThan(xml.indexOf('<ProviderInfo>'));
   });
+
+  it('omits ValidUntil when no expiry is supplied', () => {
+    const xml = generateEapConfig({ rootCaDer: root, clientP12: p12 });
+    expect(xml).not.toContain('<ValidUntil>');
+  });
+
+  it('emits ValidUntil in geteduroam SERVER_DATE_FORMAT when expiry is supplied', () => {
+    const xml = generateEapConfig({
+      rootCaDer: root,
+      clientP12: p12,
+      validUntil: new Date('2027-07-04T09:42:47.000Z'),
+    });
+    // UTC, no trailing Z, no milliseconds — matches AndroidConfigParser.
+    expect(xml).toContain('<ValidUntil>2027-07-04T09:42:47</ValidUntil>');
+  });
+
+  it('orders ValidUntil before AuthenticationMethods (XSD sequence)', () => {
+    const xml = generateEapConfig({
+      rootCaDer: root,
+      clientP12: p12,
+      validUntil: new Date('2027-07-04T09:42:47.000Z'),
+    });
+    expect(xml.indexOf('<ValidUntil>')).toBeLessThan(xml.indexOf('<AuthenticationMethods>'));
+  });
 });

--- a/src/services/eduroam/eapConfig.ts
+++ b/src/services/eduroam/eapConfig.ts
@@ -1,4 +1,5 @@
 import { bytesToBase64 } from './base64';
+import { formatValidUntil } from './certExpiry';
 
 const DEFAULT_SERVER_NAMES = ['aleph.mendelu.cz'];
 const DEFAULT_IDENTIFIER = 'cz.reis.eduroam';
@@ -15,6 +16,12 @@ export interface EapConfigInput {
   identifier?: string;
   /** Institution name geteduroam shows at import. Default "MENDELU eduroam (reIS)". */
   displayName?: string;
+  /**
+   * Client-certificate expiry. When provided, emitted as `<ValidUntil>` so
+   * geteduroam knows the real expiry and reminds the student to renew ~5 days
+   * before it — instead of the network dying silently at ~day 366.
+   */
+  validUntil?: Date;
 }
 
 function escapeXml(s: string): string {
@@ -44,6 +51,9 @@ export function generateEapConfig(input: EapConfigInput): string {
     '<?xml version="1.0" encoding="utf-8"?>',
     '<EAPIdentityProviderList xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="eap-metadata.xsd">',
     `  <EAPIdentityProvider ID="${escapeXml(identifier)}" namespace="urn:RFC4282:realm" version="1">`,
+    // ValidUntil is first in the eap-metadata.xsd sequence (before
+    // AuthenticationMethods). geteduroam parses it with SERVER_DATE_FORMAT.
+    ...(input.validUntil ? [`    <ValidUntil>${formatValidUntil(input.validUntil)}</ValidUntil>`] : []),
     '    <AuthenticationMethods>',
     '      <AuthenticationMethod>',
     '        <EAPMethod>',

--- a/src/services/eduroam/eapConfig.xsd.test.ts
+++ b/src/services/eduroam/eapConfig.xsd.test.ts
@@ -34,4 +34,16 @@ describe('generateEapConfig — XSD validity', () => {
     // execFileSync throws (non-zero exit) if the document does not validate.
     expect(() => execFileSync('xmllint', ['--noout', '--schema', xsd, file], { stdio: 'pipe' })).not.toThrow();
   });
+
+  it.runIf(hasXmllint())('validates with a ValidUntil element (still valid xs:dateTime)', () => {
+    const xml = generateEapConfig({
+      rootCaDer: new Uint8Array(Array.from({ length: 32 }, (_, i) => i + 1)),
+      clientP12: new Uint8Array(Array.from({ length: 64 }, (_, i) => (i * 7) & 0xff)),
+      validUntil: new Date('2027-07-04T09:42:47.000Z'),
+    });
+    expect(xml).toContain('<ValidUntil>2027-07-04T09:42:47</ValidUntil>');
+    const file = join(mkdtempSync(join(tmpdir(), 'eap-')), 'sample.eap-config');
+    writeFileSync(file, xml);
+    expect(() => execFileSync('xmllint', ['--noout', '--schema', xsd, file], { stdio: 'pipe' })).not.toThrow();
+  });
 });

--- a/supabase/functions/eduroam-receive/index.ts
+++ b/supabase/functions/eduroam-receive/index.ts
@@ -55,12 +55,17 @@ Deno.serve(async (req: Request) => {
   for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
 
   // Format hint from the QR URL selects the MIME/filename the phone receives.
-  // ios (default) = Apple config profile (unchanged); android = geteduroam .eap-config.
+  // ios (default) = Apple config profile (unchanged); android = geteduroam .eap-config;
+  // p12 = the raw password-protected PKCS#12 for the manual Android EAP-TLS path
+  // (Android's cert installer handles application/x-pkcs12 and prompts for the
+  // extraction password — same posture as ios, the password is never uploaded).
   const fmt = new URL(req.url).searchParams.get('fmt') ?? 'ios';
   const served =
     fmt === 'android'
       ? { contentType: 'application/eap-config', filename: 'eduroam.eap-config' }
-      : { contentType: 'application/x-apple-aspen-config', filename: 'eduroam-reis.mobileconfig' };
+      : fmt === 'p12'
+        ? { contentType: 'application/x-pkcs12', filename: 'eduroam.p12' }
+        : { contentType: 'application/x-apple-aspen-config', filename: 'eduroam-reis.mobileconfig' };
 
   return new Response(bytes, {
     headers: {


### PR DESCRIPTION
## ⚠️ Do not merge yet — draft for a "decide later" call

This PR is a **holding branch**. It rebuilds the Android eduroam tab as a manual EAP-TLS flow, but it **must not be merged until the `eduroam-receive` edge function is deployed** with the new `fmt=p12` branch. `main` intentionally stays on the current, working geteduroam Android implementation.

**Why merging early breaks Android:** the client now points the Android QR at `…&fmt=p12`. The *currently-deployed* edge function doesn't know `p12`, so it falls through to the iOS branch and serves the `.p12` as `application/x-apple-aspen-config` → Android won't recognise the file. The edge-fn source change is in this PR (`supabase/functions/eduroam-receive/index.ts`) but has **not** been deployed.

To activate before merging:
```
supabase functions deploy eduroam-receive --no-verify-jwt --project-ref zvbpgkmnrqyprtkyxkwn
```
(`--no-verify-jwt` is required — phones scan the QR with no auth.)

## Background

geteduroam is structurally broken at MENDELU: the university isn't in the eduroam **discovery catalogue**, so on any manual reconnect geteduroam fails with *"cannot find organisation."* Verified against a fresh clone of `geteduroam/android-app` and reproduced on a real Android device. The manual EAP-TLS cert path — install the `.p12`, add the `eduroam` network by hand — is a normal **saved network** that persists the cert's full ~365 days on any Android version. That's the durable answer for MENDELU.

## What's in here

- **`.p12` delivery** — new `p12` transfer format (`eduroamTransfer.ts`); Android branch of `useEduroamSetup.ts` transfers the raw password-protected `.p12`; `eduroam-receive` gains a `fmt=p12` branch serving `application/x-pkcs12`. Same security posture as iOS: the extraction password is never uploaded.
- **Step-by-step guide** — `manual.ts` Android rewritten (scan/download → install cert → add network) with a field-values block in `EduroamTutorial.tsx`: SSID `eduroam` · WPA/WPA2/WPA3-Enterprise · EAP **TLS** · CA **Don't validate** · **User cert = the installed cert** · Identity. geteduroam do-once dropped for Android, **kept for Windows**.
- **Identity auto-fill** — new `parseCertSubjectCN()` reads the cert's subject CN (`<login>@mendelu.cz`) and shows the student's *real* Identity (falls back to a generic hint if unreadable). Directly prevents the "CONNECT greyed out because Identity is empty" wall hit during testing.
- **`<ValidUntil>` in the (Windows) `.eap-config`** — so geteduroam warns ~5 days before the real cert expiry instead of the network dying silently. Format matches geteduroam's parser *and* the eduroam XSD.

## Verification

- 135 eduroam-area unit tests pass (1 env-skipped)
- ESLint clean on all changed files
- `typecheck` adds **0 new errors** (3 pre-existing Erasmus/Exam errors unchanged)
- Production build passes

No screenshots on the new Android steps yet (the old geteduroam webp captures were dropped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
