### PR TITLE
fix(security): harden IS-origin checks + least-privilege workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   # UI/UX gate: lints ONLY the files changed in this PR with --max-warnings=0,
   # so theme/i18n violations (and any other warning) hard-block new or edited code

--- a/.github/workflows/deploy-supabase-functions.yml
+++ b/.github/workflows/deploy-supabase-functions.yml
@@ -8,6 +8,9 @@ on:
       - 'supabase/functions/**'
   workflow_dispatch: # Allows manual triggering from the GitHub Actions UI
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/src/injector/__tests__/isMendeluUrl.test.ts
+++ b/src/injector/__tests__/isMendeluUrl.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { isIsMendeluUrl } from '../isMendeluUrl';
+
+describe('isIsMendeluUrl', () => {
+    it('accepts https URLs on the exact is.mendelu.cz origin', () => {
+        expect(isIsMendeluUrl('https://is.mendelu.cz')).toBe(true);
+        expect(isIsMendeluUrl('https://is.mendelu.cz/auth/dok_server/slozka.pl?id=1')).toBe(true);
+        expect(isIsMendeluUrl('https://is.mendelu.cz:443/auth/')).toBe(true);
+    });
+
+    it('rejects look-alike hosts that the old startsWith check let through', () => {
+        // The core vulnerability: startsWith('https://is.mendelu.cz') matched these.
+        expect(isIsMendeluUrl('https://is.mendelu.cz.evil.com/steal')).toBe(false);
+        expect(isIsMendeluUrl('https://is.mendelu.czattacker.example')).toBe(false);
+    });
+
+    it('rejects other schemes and hosts', () => {
+        expect(isIsMendeluUrl('http://is.mendelu.cz/auth/')).toBe(false); // not https
+        expect(isIsMendeluUrl('https://evil.com/is.mendelu.cz')).toBe(false);
+        expect(isIsMendeluUrl('https://sub.is.mendelu.cz/')).toBe(false); // different host
+    });
+
+    it('rejects malformed / non-URL input without throwing', () => {
+        expect(isIsMendeluUrl('not a url')).toBe(false);
+        expect(isIsMendeluUrl('')).toBe(false);
+        expect(isIsMendeluUrl('javascript:alert(1)')).toBe(false);
+    });
+});

--- a/src/injector/documentDownloader.ts
+++ b/src/injector/documentDownloader.ts
@@ -4,8 +4,10 @@
  * a cross-site fetch from the iframe app would get a login page instead.
  * Resolves only once the blob is saved, giving the UI a true completion signal.
  */
+import { isIsMendeluUrl } from './isMendeluUrl';
+
 export async function downloadDocumentInPage(url: string, filename: string): Promise<void> {
-  if (!url.startsWith('https://is.mendelu.cz')) throw new Error('Refusing non-IS document URL');
+  if (!isIsMendeluUrl(url)) throw new Error('Refusing non-IS document URL');
   const res = await fetch(url, { credentials: 'include' });
   if (res.status === 401 || res.status === 403) {
     // Genuine session-expiry — the caller redirects to login on this signal only.

--- a/src/injector/isMendeluUrl.ts
+++ b/src/injector/isMendeluUrl.ts
@@ -1,0 +1,16 @@
+/**
+ * True only when `url` is an absolute https URL whose origin is exactly
+ * https://is.mendelu.cz. Used to gate credentialed (cookie-bearing) fetches
+ * in the content script.
+ *
+ * A substring/`startsWith` check is unsafe here: `startsWith('https://is.mendelu.cz')`
+ * also matches `https://is.mendelu.cz.evil.com`, which would send the IS session
+ * cookie to an attacker-controlled host. Comparing the parsed origin closes that gap.
+ */
+export function isIsMendeluUrl(url: string): boolean {
+    try {
+        return new URL(url).origin === 'https://is.mendelu.cz';
+    } catch {
+        return false;
+    }
+}

--- a/src/injector/messageHandler.ts
+++ b/src/injector/messageHandler.ts
@@ -7,6 +7,7 @@ import { fetchSubjects } from "../api/subjects";
 import type { DataRequestType } from "../types/messages";
 import { scrapedNavMenu } from "./sniper";
 import { downloadDocumentInPage } from "./documentDownloader";
+import { isIsMendeluUrl } from "./isMendeluUrl";
 
 let topUpPopupRef: Window | null = null;
 
@@ -68,7 +69,7 @@ function blobToDataUrl(blob: Blob): Promise<string> {
 async function handleFetchRequest(id: string, url: string, options?: { method?: string; headers?: Record<string, string>; body?: string; responseType?: 'text' | 'image' }) {
     try {
         let text: string;
-        if (url.startsWith('https://is.mendelu.cz')) {
+        if (isIsMendeluUrl(url)) {
             const response = await fetch(url, {
                 method: options?.method ?? "GET", headers: options?.headers,
                 body: options?.body, credentials: "include",


### PR DESCRIPTION
Resolves the 5 real CodeQL alerts from the newly-enabled code scanning. The other 12 alerts were triaged and dismissed (false-positives: NBSP→space normalizations, XML-escaped values, layered sanitization, hardcoded dev-script input; won't-fix: frozen IS HTML parsers over trusted first-party markup, non-security telemetry correlation ID).

## Changes

**Credentialed-fetch origin hardening (CodeQL `js/incomplete-url-substring-sanitization`, high)**
- New tested helper `src/injector/isMendeluUrl.ts` — `new URL(url).origin === 'https://is.mendelu.cz'`.
- Wired into `documentDownloader.ts` and `messageHandler.ts`, replacing `url.startsWith('https://is.mendelu.cz')`.
- Why it matters: the old substring check also matched `https://is.mendelu.cz.evil.com`, so a look-alike URL would pass and receive the IS session cookie (`credentials: 'include'`). Practical risk was low (URLs originate from our own origin-validated iframe) but the check is now correct.

**Least-privilege workflow permissions (CodeQL `actions/missing-workflow-permissions`, medium ×3)**
- Added top-level `permissions: contents: read` to `ci.yml`, `publish.yml`, `deploy-supabase-functions.yml`. None write to the repo (they build/lint or deploy via store/Supabase secrets).

## Verification
- New `isMendeluUrl.test.ts` (4 cases incl. the `.evil.com` bypass) + existing `documentDownloader` / `iskamMessageHandler` suites: **12 passing**.
- `npm run build`: ✔ success. Changed-files ESLint `--max-warnings=0`: clean.
- Pre-existing typecheck debt in Erasmus/Exam files is unrelated to this PR (present on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)