### PR TITLE
ci: Dependabot auto-merge workflow (patch/minor)

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,49 @@
+name: Dependabot auto-merge
+
+# Auto-approves and enables auto-merge for Dependabot PRs that are safe
+# (patch/minor bumps). Major bumps are intentionally left for a human — they
+# have broken the test suite before (e.g. the vite 8 / vitest 4 group).
+#
+# Auto-merge only completes once branch-protection required checks pass, so
+# this never bypasses CI or CodeQL — it just clicks "merge when green" for us.
+#
+# Note: uses `pull_request_target` (not `pull_request`) so the token has write
+# access on Dependabot PRs. It deliberately does NOT check out or run PR code,
+# so there is no untrusted-code-with-secrets risk.
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Approve the PR
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for patch and minor updates
+        if: steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Comment on major updates (left for manual review)
+        if: steps.meta.outputs.update-type == 'version-update:semver-major'
+        run: gh pr comment "$PR_URL" --body "🤖 Major version bump — auto-merge skipped. Review manually (majors have broken the test suite before)."
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds `.github/workflows/dependabot-auto-merge.yml` — auto-approves and enables auto-merge for **patch/minor** Dependabot PRs so they land hands-off once branch-protection checks pass. **Major** bumps are left for manual review (they've broken the test suite before — the vite 8 / vitest 4 group in the now-closed #70).

- Uses `pull_request_target` for a write-scoped token on Dependabot PRs; **does not check out or run PR code**, so no untrusted-code-with-secrets risk.
- `gh pr merge --auto` respects required checks — **bypasses nothing**.

## ⚠️ One manual step to make this actually work
GitHub does **not** emit the per-language `Analyze (javascript-typescript)` check on Dependabot PRs — only the `CodeQL` rollup (as a passing `neutral`). Since branch protection currently requires `Analyze (javascript-typescript)`, Dependabot PRs can never satisfy it and auto-merge would wait forever. Swap the required CodeQL context to the `CodeQL` rollup (present + passing on both human and Dependabot PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)