### PR TITLE
ci: add typecheck + unit-test jobs (audit fix #1)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      # Batch low-risk bumps into one PR each to cut noise. Majors are excluded
+      # from groups so they arrive individually for careful review (they have
+      # broken the test suite before — the vite 8 / vitest 4 group).
+      dev-dependencies:
+        dependency-type: "development"
+        update-types: ["minor", "patch"]
+      production-dependencies:
+        dependency-type: "production"
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,3 +61,32 @@ jobs:
           echo "Linting changed files:"
           echo "$CHANGED"
           echo "$CHANGED" | xargs npx eslint --max-warnings=0
+
+  # Full type check across the whole project (tsc -b). Unlike the lint gate this
+  # covers ALL files, so a type error in an unchanged file can no longer merge.
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run typecheck
+
+  # Full unit-test suite. The iskam parser specs read HTML fixtures from the
+  # gitignored .agent/ dir (real IS Mendelu HTML, intentionally not committed),
+  # so they are excluded here — they can only run locally with those fixtures.
+  test:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npx vitest run --exclude '**/parsers/iskam/__tests__/**'

--- a/src/components/ErasmusPanel/ErasmusSemesterSection.tsx
+++ b/src/components/ErasmusPanel/ErasmusSemesterSection.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from '@/hooks/useTranslation';
 import { useCourseName } from '@/hooks/ui/useCourseName';
 import { isCompulsoryGroup, isCoreElectiveGroup, isElectiveGroup } from '@/utils/studyPlanUtils';
 import { isTransferableCourse } from './isTransferableCourse';
-import type { SemesterBlock } from '@/types/studyPlan';
+import type { SemesterBlock, SubjectStatus } from '@/types/studyPlan';
 
 interface Props {
   block: SemesterBlock;

--- a/src/components/ExamPanel/__tests__/useExamActions.test.ts
+++ b/src/components/ExamPanel/__tests__/useExamActions.test.ts
@@ -48,7 +48,7 @@ vi.mock('../../../store/useAppStore', () => {
     fetchExams: mockFetchExams,
     triggerExamsRefresh: mockTriggerExamsRefresh,
   };
-  const mockUseAppStore = vi.fn((selector: (s: typeof mockState) => unknown) => selector(mockState)) as ((selector: (s: typeof mockState) => unknown) => unknown) & { getState: () => typeof mockState };
+  const mockUseAppStore = vi.fn((selector: (s: typeof mockState) => unknown) => selector(mockState)) as unknown as ((selector: (s: typeof mockState) => unknown) => unknown) & { getState: () => typeof mockState };
   mockUseAppStore.getState = () => mockState;
   return {
     useAppStore: mockUseAppStore,

--- a/src/store/slices/createErasmusSlice.ts
+++ b/src/store/slices/createErasmusSlice.ts
@@ -324,7 +324,7 @@ export const createErasmusSlice: AppSlice<ErasmusSlice> = (set, get) => ({
       if (tableAOptions && tableAOptions.length > 0) {
         set({ erasmusTableAOptions: tableAOptions });
       } else {
-        const oldTableA = await IndexedDBService.get('meta', TABLE_A_COURSES_KEY) as unknown[] | null;
+        const oldTableA = await IndexedDBService.get('meta', TABLE_A_COURSES_KEY) as ErasmusUniversityOption['courses'] | null;
         if (oldTableA && oldTableA.length > 0) {
            const initial = [{ id: 'opt-initial', institutionName: '', erasmusCode: '', country: '', link: '', courses: oldTableA }];
            set({ erasmusTableAOptions: initial });

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -38,7 +38,6 @@ export default defineConfig({
       gecko: {
         id: 'reis-extension@mendelu.cz',
         strict_min_version: '140.0',
-        // @ts-expect-error Firefox AMO requires data_collection_permissions
         data_collection_permissions: {
           required: ['none'],
           optional: [],


### PR DESCRIPTION
Closes the #1 audit gap: **CI only lints changed files**, so type errors and failing tests in unchanged files can merge to `main`. Adds two CI jobs and clears the pre-existing blockers that were keeping them red.

## CI jobs (`.github/workflows/ci.yml`)
- **Typecheck** — `tsc -b` across the whole project (all files, not just the diff).
- **Unit tests** — full vitest suite, excluding the `parsers/iskam` specs that read gitignored `.agent/` HTML fixtures (real IS Mendelu data, intentionally not committed).

## Type fixes (all pre-existing on `main`, made typecheck green)
- `ErasmusSemesterSection.tsx` — import the missing `SubjectStatus` type.
- `createErasmusSlice.ts` — type the legacy TableA migration as the option's `courses` shape, not `unknown[]`.
- `useExamActions.test.ts` — `as unknown as` for the intentional mock cast.
- `wxt.config.ts` — remove a now-unused `@ts-expect-error` (WXT types caught up).

## Dependabot config (`.github/dependabot.yml`)
Weekly npm + github-actions updates, grouped minor/patch (dev + prod) to cut PR noise; majors arrive individually for review. Pairs with the auto-merge workflow (PR #76).

## Verification
`tsc -b`: **0 errors** · vitest: **939 passed** (iskam-fixture specs excluded) · `npm run build`: ✔

## Follow-up (not in this PR)
- The `typecheck` + `test` checks should be **added to branch-protection required checks** once this lands (I can't edit protection — one command in the chat).
- iskam parser specs need CI coverage — requires committing *sanitized* fixtures or inlining them (privacy-sensitive; separate task).

🤖 Generated with [Claude Code](https://claude.com/claude-code)