### PR TITLE
feat(security): Zod-validate postMessage + Supabase boundaries (audit #2)

### DIFF
--- a/src/api/studyJams.ts
+++ b/src/api/studyJams.ts
@@ -1,4 +1,17 @@
+import { z } from 'zod';
 import { supabase } from '../services/spolky/supabaseClient';
+import { logError } from '../utils/reportError';
+
+// Supabase results are `any`-typed; validate row shapes before use so a schema
+// drift or bad row can't corrupt UI state. On failure we fall back to the same
+// empty/null result as the error path.
+const KillerCourseSchema = z.object({ course_code: z.string(), course_name: z.string() });
+const RoleSchema = z.enum(['tutor', 'tutee']);
+const TutoringMatchSchema = z.object({
+    tutor_student_id: z.string(), tutee_student_id: z.string(), course_code: z.string(),
+});
+const AvailabilitySchema = z.object({ course_code: z.string(), role: RoleSchema });
+const DismissalSchema = z.object({ course_code: z.string() });
 
 export async function fetchKillerCourses(): Promise<{ course_code: string; course_name: string }[]> {
     const { data, error } = await supabase
@@ -7,7 +20,9 @@ export async function fetchKillerCourses(): Promise<{ course_code: string; cours
         .eq('is_active', true);
     if (error) return [];
 
-    return data ?? [];
+    const parsed = z.array(KillerCourseSchema).safeParse(data ?? []);
+    if (!parsed.success) { logError('Api.fetchKillerCourses', parsed.error); return []; }
+    return parsed.data;
 }
 
 export async function registerAvailability(
@@ -34,9 +49,11 @@ export async function fetchMyTutoringMatch(
         .or(`tutor_student_id.eq.${studentId},tutee_student_id.eq.${studentId}`)
         .limit(1)
         .maybeSingle();
-    if (error) return null;
+    if (error || data == null) return null;
 
-    return data as { tutor_student_id: string; tutee_student_id: string; course_code: string } | null;
+    const parsed = TutoringMatchSchema.safeParse(data);
+    if (!parsed.success) { logError('Api.fetchMyTutoringMatch', parsed.error); return null; }
+    return parsed.data;
 }
 
 export async function fetchMyAvailability(studentId: string): Promise<{ course_code: string; role: 'tutor' | 'tutee' }[]> {
@@ -46,7 +63,9 @@ export async function fetchMyAvailability(studentId: string): Promise<{ course_c
         .eq('student_id', studentId);
     if (error) return [];
 
-    return data as { course_code: string; role: 'tutor' | 'tutee' }[] ?? [];
+    const parsed = z.array(AvailabilitySchema).safeParse(data ?? []);
+    if (!parsed.success) { logError('Api.fetchMyAvailability', parsed.error); return []; }
+    return parsed.data;
 }
 
 export async function deleteAvailability(studentId: string, courseCode: string): Promise<void> {
@@ -84,5 +103,7 @@ export async function fetchMyDismissals(studentId: string): Promise<string[]> {
         .eq('student_id', studentId);
     if (error) return [];
 
-    return (data as { course_code: string }[] ?? []).map(r => r.course_code);
+    const parsed = z.array(DismissalSchema).safeParse(data ?? []);
+    if (!parsed.success) { logError('Api.fetchMyDismissals', parsed.error); return []; }
+    return parsed.data.map(r => r.course_code);
 }

--- a/src/services/spolky/spolkyService.ts
+++ b/src/services/spolky/spolkyService.ts
@@ -14,7 +14,9 @@ const NotificationRowSchema = z.object({
   link: z.string().nullable(),
   created_at: z.string(),
   expires_at: z.string(),
-  priority: z.string(),
+  // Constrain to the domain values; an unexpected DB value degrades to 'normal'
+  // rather than failing the whole array parse (which would drop every notification).
+  priority: z.enum(['normal', 'high']).catch('normal'),
 });
 
 /**
@@ -82,7 +84,7 @@ export async function fetchNotifications(): Promise<SpolekNotification[]> {
       link: n.link || undefined,
       createdAt: n.created_at,
       expiresAt: n.expires_at,
-      priority: n.priority as 'normal' | 'high'
+      priority: n.priority
     }));
   } catch {
     return [];

--- a/src/services/spolky/spolkyService.ts
+++ b/src/services/spolky/spolkyService.ts
@@ -1,9 +1,21 @@
+import { z } from 'zod';
 import type { SpolekNotification, AssociationProfile } from './types';
 import { FACULTY_TO_ASSOCIATION, ASSOCIATION_PROFILES } from './config';
 import { supabase } from './supabaseClient';
 import { logError } from '../../utils/reportError';
 
-// ... rest of imports
+// Runtime shape of a `notifications` row. Supabase results are `any`-typed, so
+// we validate before rendering user-facing content rather than trusting the DB.
+const NotificationRowSchema = z.object({
+  id: z.string(),
+  association_id: z.string(),
+  title: z.string(),
+  body: z.string().nullable(),
+  link: z.string().nullable(),
+  created_at: z.string(),
+  expires_at: z.string(),
+  priority: z.string(),
+});
 
 /**
  * Track that notifications were viewed (when bell icon opened)
@@ -56,18 +68,13 @@ export async function fetchNotifications(): Promise<SpolekNotification[]> {
       return [];
     }
 
-interface SupabaseNotification {
-  id: string;
-  association_id: string;
-  title: string;
-  body: string | null;
-  link: string | null;
-  created_at: string;
-  expires_at: string;
-  priority: string;
-}
+    const parsed = z.array(NotificationRowSchema).safeParse(data ?? []);
+    if (!parsed.success) {
+      logError('Spolky.fetchNotifications', parsed.error);
+      return [];
+    }
 
-    return (data || []).map((n: SupabaseNotification) => ({
+    return parsed.data.map((n) => ({
       id: n.id,
       associationId: n.association_id,
       title: n.title,

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -1,10 +1,14 @@
 import * as T from './messages/base';
+import { IframeToContentSchema, ContentToIframeSchema } from './messages/schema';
 
 export * from './messages/base';
 export type { ActionType, DataRequestType } from './messages/base';
 
-export function isIframeMessage(d: unknown): d is T.IframeToContentMessage { return typeof d === 'object' && d !== null && 'type' in d && ['REIS_READY', 'REIS_REQUEST_DATA', 'REIS_FETCH', 'REIS_ACTION', 'ISKAM_READY', 'ISKAM_FETCH_BLOCK'].includes((d as any).type); }
-export function isContentMessage(d: unknown): d is T.ContentToIframeMessage { return typeof d === 'object' && d !== null && 'type' in d && ['REIS_DATA', 'REIS_FETCH_RESULT', 'REIS_ACTION_RESULT', 'REIS_SYNC_UPDATE', 'REIS_POPUP_STATE', 'REIS_NAV_MENU', 'ISKAM_SYNC_UPDATE', 'ISKAM_BLOCK_RESULT', 'REIS_TELEMETRY_ERROR'].includes((d as any).type); }
+// Runtime-validated at the trust boundary via Zod (see ./messages/schema.ts):
+// the envelope + primitive fields are checked, so a malformed message is
+// dropped rather than cast blindly. Type predicates keep call sites unchanged.
+export function isIframeMessage(d: unknown): d is T.IframeToContentMessage { return IframeToContentSchema.safeParse(d).success; }
+export function isContentMessage(d: unknown): d is T.ContentToIframeMessage { return ContentToIframeSchema.safeParse(d).success; }
 
 export const Messages = {
     ready: (): T.ReadyMessage => ({ type: 'REIS_READY' }),

--- a/src/types/messages/__tests__/schema.test.ts
+++ b/src/types/messages/__tests__/schema.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { Messages, IskamMessages } from '../../messages';
+import { IframeToContentSchema, ContentToIframeSchema } from '../schema';
+
+// The core guarantee: every message the app actually constructs must pass its
+// schema. This is what protects us from an over-strict schema silently dropping
+// valid IPC traffic (which would break the whole extension).
+describe('message schemas accept every real factory message', () => {
+    it('accepts all Content→Iframe messages the factory can build', () => {
+        const msgs = [
+            Messages.data('all', { lastSync: 1 }),
+            Messages.data('exams', undefined, 'some error'),
+            Messages.fetchResult('id-1', true, 'data'),
+            Messages.fetchResult('id-2', false, undefined, 'err'),
+            Messages.actionResult('id-3', true, { ok: true }),
+            Messages.actionResult('id-4', false, undefined, 'err'),
+            Messages.syncUpdate({ lastSync: 123, schedule: {}, isSyncing: false }),
+            Messages.popupState(true),
+            Messages.navMenu([{ id: 'a', label: 'A', children: [{ id: 'c', label: 'C', href: '/x' }] }]),
+            Messages.telemetryError('Ctx.fn', new Error('boom')),
+            IskamMessages.iskamSyncUpdate(null, false, null),
+            IskamMessages.iskamSyncUpdate(null, true, 'auth'),
+        ];
+        for (const m of msgs) {
+            const r = ContentToIframeSchema.safeParse(m);
+            expect(r.success, `should accept ${m.type}`).toBe(true);
+        }
+    });
+
+    it('accepts all Iframe→Content messages the factory can build', () => {
+        const msgs = [
+            Messages.ready(),
+            Messages.requestData('schedule'),
+            Messages.fetch('https://is.mendelu.cz/x', { method: 'GET' }),
+            Messages.action('download_file', { fileId: 1 }),
+            IskamMessages.iskamReady(),
+        ];
+        for (const m of msgs) {
+            expect(IframeToContentSchema.safeParse(m).success, `should accept ${m.type}`).toBe(true);
+        }
+    });
+});
+
+describe('message schemas reject malformed input', () => {
+    it('rejects unknown / missing type', () => {
+        expect(ContentToIframeSchema.safeParse({ type: 'NOPE' }).success).toBe(false);
+        expect(ContentToIframeSchema.safeParse({}).success).toBe(false);
+        expect(ContentToIframeSchema.safeParse(null).success).toBe(false);
+        expect(IframeToContentSchema.safeParse('a string').success).toBe(false);
+    });
+
+    it('rejects wrong-shaped payloads for a known type', () => {
+        // REIS_FETCH with a non-string url must not pass.
+        expect(IframeToContentSchema.safeParse({ type: 'REIS_FETCH', id: 'x', url: 42 }).success).toBe(false);
+        // REIS_POPUP_STATE with non-boolean open.
+        expect(ContentToIframeSchema.safeParse({ type: 'REIS_POPUP_STATE', open: 'yes' }).success).toBe(false);
+        // REIS_ACTION with an unknown action enum value.
+        expect(IframeToContentSchema.safeParse({ type: 'REIS_ACTION', id: 'x', action: 'rm_rf', payload: {} }).success).toBe(false);
+    });
+});

--- a/src/types/messages/schema.ts
+++ b/src/types/messages/schema.ts
@@ -1,0 +1,93 @@
+import { z } from 'zod';
+
+/**
+ * Runtime schemas for the cross-context postMessage boundary (content script ↔
+ * iframe app). The envelope and all primitive structural fields are validated;
+ * `payload`/`data`/domain objects stay permissive (`z.unknown()` / bare object)
+ * because they are already typed `unknown` and are narrowed downstream — the
+ * goal here is to reject malformed *envelopes* before they are cast, not to
+ * re-type the whole domain. `z.object` strips unknown keys, so these schemas
+ * stay lenient toward additive changes and never drop a valid message.
+ */
+
+const dataRequestType = z.enum(['schedule', 'exams', 'subjects', 'files', 'all']);
+const actionType = z.enum([
+    'register_exam', 'unregister_exam', 'toggle_outlook_sync', 'download_file',
+    'download_document', 'trigger_sync', 'trigger_drive_backup', 'push_notes',
+    'refresh_exams', 'open_url', 'logout',
+]);
+
+// ── Iframe → Content ────────────────────────────────────────────────────────
+const ReadyMsg = z.object({ type: z.literal('REIS_READY') });
+const RequestDataMsg = z.object({ type: z.literal('REIS_REQUEST_DATA'), dataType: dataRequestType });
+const FetchRequestMsg = z.object({
+    type: z.literal('REIS_FETCH'),
+    id: z.string(),
+    url: z.string(),
+    options: z.object({
+        method: z.string().optional(),
+        headers: z.record(z.string(), z.string()).optional(),
+        body: z.string().optional(),
+        responseType: z.enum(['text', 'image']).optional(),
+    }).optional(),
+});
+const ActionRequestMsg = z.object({
+    type: z.literal('REIS_ACTION'),
+    id: z.string(),
+    action: actionType,
+    payload: z.unknown(),
+});
+const IskamReadyMsg = z.object({ type: z.literal('ISKAM_READY') });
+const IskamFetchBlockMsg = z.object({
+    type: z.literal('ISKAM_FETCH_BLOCK'),
+    id: z.string(), blockId: z.string(), od: z.string(), doo: z.string(),
+});
+
+export const IframeToContentSchema = z.discriminatedUnion('type', [
+    ReadyMsg, RequestDataMsg, FetchRequestMsg, ActionRequestMsg, IskamReadyMsg, IskamFetchBlockMsg,
+]);
+
+// ── Content → Iframe ────────────────────────────────────────────────────────
+const DataResponseMsg = z.object({
+    type: z.literal('REIS_DATA'), dataType: dataRequestType, data: z.unknown(), error: z.string().optional(),
+});
+const FetchResultMsg = z.object({
+    type: z.literal('REIS_FETCH_RESULT'), id: z.string(), success: z.boolean(),
+    data: z.string().optional(), error: z.string().optional(),
+});
+const ActionResultMsg = z.object({
+    type: z.literal('REIS_ACTION_RESULT'), id: z.string(), success: z.boolean(),
+    data: z.unknown().optional(), error: z.string().optional(),
+});
+// `data` is the SyncedData envelope — validate it is an object (the consumer
+// casts and reads fields off it); domain fields stay unvalidated by design.
+const SyncUpdateMsg = z.object({
+    type: z.literal('REIS_SYNC_UPDATE'),
+    data: z.object({ lastSync: z.number().optional() }),
+});
+const PopupStateMsg = z.object({ type: z.literal('REIS_POPUP_STATE'), open: z.boolean() });
+const NavChild = z.object({ id: z.string(), label: z.string(), labelEn: z.string().optional(), href: z.string() });
+const NavCategory = z.object({
+    id: z.string(), label: z.string(), icon: z.string().optional(),
+    expandable: z.boolean().optional(), children: z.array(NavChild),
+});
+const NavMenuMsg = z.object({ type: z.literal('REIS_NAV_MENU'), categories: z.array(NavCategory) });
+const IskamSyncUpdateMsg = z.object({
+    type: z.literal('ISKAM_SYNC_UPDATE'),
+    data: z.object({
+        iskamData: z.unknown(),
+        isSyncing: z.boolean(),
+        error: z.enum(['auth', 'network']).nullable(),
+    }),
+});
+const IskamBlockResultMsg = z.object({
+    type: z.literal('ISKAM_BLOCK_RESULT'), id: z.string(), rooms: z.array(z.unknown()),
+});
+const TelemetryErrorMsg = z.object({
+    type: z.literal('REIS_TELEMETRY_ERROR'), context: z.string(), message: z.string(),
+});
+
+export const ContentToIframeSchema = z.discriminatedUnion('type', [
+    DataResponseMsg, FetchResultMsg, ActionResultMsg, SyncUpdateMsg, PopupStateMsg,
+    NavMenuMsg, IskamSyncUpdateMsg, IskamBlockResultMsg, TelemetryErrorMsg,
+]);


### PR DESCRIPTION
Closes audit gap #2 — the two **untrusted runtime boundaries** were trusted via hand-rolled type guards / casts. Both now validate with Zod.

## postMessage (content script ↔ iframe)
- New `z.discriminatedUnion` schemas in `src/types/messages/schema.ts` mirroring every message shape. Envelope + primitive fields are validated; `payload`/`data`/domain objects stay permissive (already `unknown`, narrowed downstream) so valid traffic is never dropped.
- `isIframeMessage` / `isContentMessage` now `safeParse` instead of sniffing `.type` against a string array — **same signatures**, so all three call sites (`messageHandler`, `iskamMessageHandler`, `useAppLogic`) are unchanged.
- Test asserts **every message the real factories build passes its schema** (the guarantee against over-strictness breaking IPC) and that malformed input is rejected.

## Supabase reads (results are `any`-typed)
- `fetchNotifications` (user-facing feed) + all four `studyJams` reads now `z.array(Schema).safeParse` the response; on failure they log and fall back to the same empty/null result as the error path — **no behavior regression**.

## Verification
0 new `tsc` errors · changed-file lint clean · targeted tests **16 passed** · `npm run build` ✔

> Note: this branch was cut before #77 merged, so `tsc -b` still shows the 4 pre-existing errors #77 fixes (untouched here). Rebase after #77 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of incoming and outgoing app messages, reducing issues caused by malformed data.
  * Added safer handling for API responses so invalid or unexpected results no longer surface as broken data.
  * Notifications and study-related data now fail gracefully with empty or no-result fallbacks when data shape checks fail.
* **Tests**
  * Added coverage for message schema validation, including valid cases and malformed inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->