### PR TITLE
chore: Prettier + changed-files format gate (audit fix)

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,58 @@
+name: Format
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  # Prettier check on ONLY the files changed in this PR — same incremental
+  # philosophy as the lint gate. Enforces formatting on new/edited code while
+  # the pre-existing (unformatted) backlog stays tolerated until swept.
+  format-gate:
+    name: Format (changed files)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - name: Resolve base ref
+        id: base
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            echo "sha=$PR_BASE_SHA" >> "$GITHUB_OUTPUT"
+          else
+            echo "sha=$PUSH_BEFORE_SHA" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Prettier --check changed files
+        env:
+          BASE_SHA: ${{ steps.base.outputs.sha }}
+        run: |
+          BASE="$BASE_SHA"
+          if ! git cat-file -e "$BASE" 2>/dev/null; then
+            BASE="$(git rev-parse HEAD~1 2>/dev/null || echo "")"
+          fi
+          if [ -n "$BASE" ]; then
+            CHANGED="$(git diff --name-only --diff-filter=ACMR "$BASE" HEAD -- '*.ts' '*.tsx' '*.json' '*.css' | grep -vE 'package-lock\.json$' || true)"
+          else
+            CHANGED=""
+          fi
+          if [ -z "$CHANGED" ]; then
+            echo "No formattable changes."
+            exit 0
+          fi
+          echo "Checking formatting on:"
+          echo "$CHANGED"
+          echo "$CHANGED" | xargs npx prettier --check

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,8 @@
+node_modules
+dist
+.output
+.wxt
+coverage
+package-lock.json
+.agent
+*.md

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,7 @@
+{
+  "printWidth": 100,
+  "singleQuote": true,
+  "semi": true,
+  "trailingComma": "es5",
+  "tabWidth": 2
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,6 +3,7 @@ import globals from 'globals'
 import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
 import tseslint from 'typescript-eslint'
+import eslintConfigPrettier from 'eslint-config-prettier'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
@@ -14,6 +15,8 @@ export default defineConfig([
       tseslint.configs.recommended,
       reactHooks.configs.flat.recommended,
       reactRefresh.configs.vite,
+      // Must be last: turns off any ESLint rules that would conflict with Prettier.
+      eslintConfigPrettier,
     ],
     languageOptions: {
       ecmaVersion: 2020,

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
         "concurrently": "^9.2.1",
         "dotenv": "^17.2.3",
         "eslint": "^9.39.1",
+        "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.24",
         "fake-indexeddb": "^6.2.5",
@@ -69,6 +70,7 @@
         "happy-dom": "^20.0.11",
         "jsdom": "^27.0.1",
         "postcss": "^8.5.16",
+        "prettier": "^3.9.4",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.46.4",
         "vite": "^6.0.0",
@@ -6050,6 +6052,22 @@
         }
       }
     },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
     "node_modules/eslint-plugin-react-hooks": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.0.1.tgz",
@@ -9463,6 +9481,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
+      "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "test:serenity": "xvfb-run -a playwright test e2e/serenity/specs",
     "test:smoke": "xvfb-run -a playwright test e2e/serenity/specs/smoke.spec.ts",
     "test:e2e:setup": "playwright install chromium",
-    "typecheck": "tsc -b"
+    "typecheck": "tsc -b",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
   },
   "dependencies": {
     "@fontsource/inter": "^5.2.8",
@@ -78,6 +80,7 @@
     "concurrently": "^9.2.1",
     "dotenv": "^17.2.3",
     "eslint": "^9.39.1",
+    "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "fake-indexeddb": "^6.2.5",
@@ -85,6 +88,7 @@
     "happy-dom": "^20.0.11",
     "jsdom": "^27.0.1",
     "postcss": "^8.5.16",
+    "prettier": "^3.9.4",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.46.4",
     "vite": "^6.0.0",


### PR DESCRIPTION
Closes the audit's one outright ❌ (formatting unenforced). Adds Prettier **without** a repo-wide reformat (which would conflict with the 6 open PRs) — enforcement is incremental, mirroring the existing lint gate.

- `prettier` + `eslint-config-prettier`; `.prettierrc.json` (100 cols, single quotes, 2-space), `.prettierignore`.
- `format` / `format:check` scripts.
- `eslint.config.js` extends `eslint-config-prettier` last (no-op safety net today — the config has no stylistic rules — but prevents future conflicts).
- **New standalone `format.yml`** gate: `prettier --check` on **changed files only**. Separate workflow so it doesn't collide with #77's `ci.yml` edits.

Verified: prettier --check clean on this PR's files · eslint loads · `npm run build` ✔

🤖 Generated with [Claude Code](https://claude.com/claude-code)