### PR TITLE
chore(deps): pin @playwright/test to 1.60.x until Serenity catches up

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,12 @@ updates:
         versions: ["4.x"]
       - dependency-name: "@vitest/coverage-v8"
         versions: ["4.x"]
+      # @playwright/test > 1.60 — @serenity-js/playwright-test (latest 3.44.0)
+      # peers `@playwright/test ~1.60.0`, so 1.61+ fails npm ci. Block minor/major
+      # (1.60.x patches still flow) and drop it from the dev group so the group's
+      # other members can still merge. Lift when Serenity widens its peer range.
+      - dependency-name: "@playwright/test"
+        update-types: ["version-update:semver-minor", "version-update:semver-major"]
     groups:
       # Batch low-risk bumps into one PR each to cut noise. Majors are excluded
       # from groups so they arrive individually for careful review (they have


### PR DESCRIPTION
The regenerated dev-dependencies group PR (#95) fails all gates on `npm ci` ERESOLVE for the same reason #84 did: it bumps `@playwright/test` 1.60→1.61, but `@serenity-js/playwright-test` (latest 3.44.0, already installed) peers `@playwright/test ~1.60.0`. There's no newer Serenity that allows 1.61, so it's a genuine upstream block.

This ignores minor/major for `@playwright/test` (1.60.x **patches still flow**). Dependabot will then regenerate the dev group **without** playwright, so its other 7 members (tailwind/vite, testing-library, react-hooks, etc.) install cleanly and — with the now-fixed auto-merge workflow — merge on their own.

Lift this when Serenity widens its `@playwright/test` peer range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)