### PR TITLE
chore(deps): also ignore eslint 10 (same typescript-eslint blocker)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,9 +15,11 @@ updates:
       # Lift when typescript-eslint supports TS 6.
       - dependency-name: "typescript"
         versions: ["6.x"]
-      # @eslint/js 10 drags in eslint 10, which conflicts with the eslint peer
-      # range used transitively by typescript-eslint. Lift when typescript-eslint
-      # supports eslint 10.
+      # eslint 10 / @eslint/js 10 conflict with the eslint peer range used
+      # transitively by typescript-eslint. Both must move together. Lift when
+      # typescript-eslint supports eslint 10.
+      - dependency-name: "eslint"
+        versions: ["10.x"]
       - dependency-name: "@eslint/js"
         versions: ["10.x"]
       # vite 8 — @wxt-dev/module-react and @tailwindcss/vite peers cap at vite 7.


### PR DESCRIPTION
Follow-up to #96. `eslint` 9→10 (#102) fails `npm ci` ERESOLVE for the same reason `@eslint/js` 10 does — `typescript-eslint`'s eslint peer range excludes 10. They must move together, so ignore `eslint` 10.x alongside `@eslint/js` 10.x. Lift both when typescript-eslint supports eslint 10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)