### PR TITLE
fix(security): clear 3 Dependabot alerts via targeted overrides (tmp/uuid/picomatch)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9500,9 +9500,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11249,9 +11249,9 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11735,13 +11735,17 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/validate-npm-package-name": {

--- a/package.json
+++ b/package.json
@@ -96,6 +96,9 @@
     "wxt": "^0.20.13"
   },
   "overrides": {
-    "shell-quote": "^1.8.4"
+    "shell-quote": "^1.8.4",
+    "tmp": "^0.2.7",
+    "uuid": "^11.1.1",
+    "picomatch@2": "^2.3.2"
   }
 }


### PR DESCRIPTION
Closes the 3 open Dependabot alerts — all `Development`-scoped **transitive** deps of the build/test toolchain (wxt→web-ext-run, serenity, vite/vitest), **none of which ship in the extension bundle** users install.

| Alert | Advisory | Fix |
|-------|----------|-----|
| #55 tmp `<0.2.6` | Path Traversal (High) | override `^0.2.7` (web-ext-run hard-pins 0.2.5; 0.2.6/0.2.7 are safe patches) |
| #54 uuid `<11.1.1` | Buffer bounds in v3/v5/v6 (Moderate) | override `^11.1.1` (web-ext-run's v4 usage doesn't even hit the bug; API-compatible) |
| #20 picomatch `<=2.3.1` | Method Injection in POSIX classes (Moderate) | override `picomatch@2` → `^2.3.2` |

The picomatch override is **scoped to the 2.x line** (`picomatch@2` selector) so vite/vitest keep their already-safe 4.0.5 and only the vulnerable 2.3.1 copies move to the 2.3.2 patch — no risky major downgrade.

**Verified locally:** `npm audit` 7→**0** vulnerabilities, typecheck 0, **1029 unit tests pass**, build ✔.

🤖 Generated with [Claude Code](https://claude.com/claude-code)