### PR TITLE
feat(storage): real Zod schema for the 'exams' IDB store

### DIFF
--- a/src/types/schemas/__tests__/exams.schema.test.ts
+++ b/src/types/schemas/__tests__/exams.schema.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import { ExamSubjectSchema } from '../exams.schema';
+import type { ExamSubject } from '../../exams';
+
+const ExamsSchema = z.array(ExamSubjectSchema);
+
+// A representative real exam subject (mirrors what syncExams writes).
+const realSubject: ExamSubject = {
+  version: 1,
+  id: 'EBC-ALG',
+  name: 'Algebra',
+  nameCs: 'Algebra',
+  nameEn: 'Algebra',
+  code: 'EBC-ALG',
+  sections: [
+    {
+      id: 's1',
+      name: 'zkouška',
+      type: 'exam',
+      status: 'available',
+      terms: [
+        {
+          id: 't1',
+          date: '12.06.2026',
+          time: '09:00',
+          capacity: { occupied: 10, total: 20, raw: '10/20' },
+          room: 'Q01',
+          attemptTypes: ['regular', 'retake1'],
+        },
+      ],
+    },
+  ],
+};
+
+describe('ExamSubjectSchema', () => {
+  it('accepts a representative real exam subject (never drops valid data)', () => {
+    expect(ExamsSchema.safeParse([realSubject]).success).toBe(true);
+  });
+
+  it('accepts unknown/future IS fields via passthrough', () => {
+    const withExtra = {
+      ...realSubject,
+      futureField: 'x',
+      sections: [{ ...realSubject.sections[0], brandNewFlag: true }],
+    };
+    expect(ExamSubjectSchema.safeParse(withExtra).success).toBe(true);
+  });
+
+  it('accepts an unexpected section.status value (widened to string, no drift-drop)', () => {
+    const drift = {
+      ...realSubject,
+      sections: [{ ...realSubject.sections[0], status: 'brand_new_status' }],
+    };
+    expect(ExamSubjectSchema.safeParse(drift).success).toBe(true);
+  });
+
+  it('rejects genuine corruption: null root', () => {
+    expect(ExamSubjectSchema.safeParse(null).success).toBe(false);
+  });
+
+  it('rejects genuine corruption: sections is not an array', () => {
+    expect(ExamSubjectSchema.safeParse({ ...realSubject, sections: 'nope' }).success).toBe(false);
+  });
+
+  it('rejects genuine corruption: missing id', () => {
+    const { id: _id, ...noId } = realSubject;
+    expect(ExamSubjectSchema.safeParse(noId).success).toBe(false);
+  });
+});

--- a/src/types/schemas/exams.schema.ts
+++ b/src/types/schemas/exams.schema.ts
@@ -1,0 +1,83 @@
+import { z } from 'zod';
+import type { ExamSubject } from '../exams';
+
+// Runtime schema for the 'exams' IndexedDB store (was a `z.custom` no-op).
+//
+// Design: validate STRUCTURE, not domain. IndexedDBService.validate() is
+// fail-closed (a parse failure drops the value on write / hides it on read),
+// so the schema must never reject genuine data. Therefore:
+//  - only structural anchors are required (ids, arrays that always exist);
+//  - every optional TS field stays optional here;
+//  - `.passthrough()` keeps unknown/future IS fields from failing a parse;
+//  - open-ended string unions (status, attemptTypes) are widened to string so
+//    a new IS value can't drop a whole exam.
+// It still catches real corruption: null/non-object roots, a non-array
+// `sections`/`terms`, or a missing `id`/`code`.
+
+const ExamCapacitySchema = z
+  .object({ occupied: z.number(), total: z.number(), raw: z.string() })
+  .passthrough();
+
+const ExamTermSchema = z
+  .object({
+    id: z.string(),
+    date: z.string(),
+    time: z.string(),
+    capacity: ExamCapacitySchema.optional(),
+    full: z.boolean().optional(),
+    room: z.string().optional(),
+    teacher: z.string().optional(),
+    teacherId: z.string().optional(),
+    roomCs: z.string().optional(),
+    roomEn: z.string().optional(),
+    registrationStart: z.string().optional(),
+    registrationEnd: z.string().optional(),
+    deregistrationDeadline: z.string().optional(),
+    attemptTypes: z.array(z.string()).optional(),
+    canRegisterNow: z.boolean().optional(),
+    sectionForm: z.string().optional(),
+    sectionFormCs: z.string().optional(),
+    sectionFormEn: z.string().optional(),
+    watchdogUrl: z.string().optional(),
+    blockReasonUrl: z.string().optional(),
+    detailUrl: z.string().optional(),
+  })
+  .passthrough();
+
+const ExamSectionSchema = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    nameCs: z.string().optional(),
+    nameEn: z.string().optional(),
+    type: z.string(),
+    status: z.string(),
+    registeredTerm: z
+      .object({
+        id: z.string().optional(),
+        date: z.string(),
+        time: z.string(),
+        room: z.string().optional(),
+        teacher: z.string().optional(),
+        teacherId: z.string().optional(),
+        roomCs: z.string().optional(),
+        roomEn: z.string().optional(),
+        deregistrationDeadline: z.string().optional(),
+      })
+      .passthrough()
+      .optional(),
+    terms: z.array(ExamTermSchema),
+  })
+  .passthrough();
+
+export const ExamSubjectSchema = z
+  .object({
+    version: z.literal(1),
+    id: z.string(),
+    name: z.string(),
+    nameCs: z.string().optional(),
+    nameEn: z.string().optional(),
+    code: z.string(),
+    sections: z.array(ExamSectionSchema),
+  })
+  .passthrough() as unknown as z.ZodType<ExamSubject>;

--- a/src/types/storage.ts
+++ b/src/types/storage.ts
@@ -1,6 +1,12 @@
 import { z } from 'zod';
-import type { ParsedFile, SyllabusRequirements, SubjectsData, GradeHistory, DocumentNote } from '../types/documents';
-import type { ExamSubject } from '../types/exams';
+import type {
+  ParsedFile,
+  SyllabusRequirements,
+  SubjectsData,
+  GradeHistory,
+  DocumentNote,
+} from '../types/documents';
+import { ExamSubjectSchema } from './schemas/exams.schema';
 import type { BlockLesson, CalendarCustomEvent } from '../types/calendarTypes';
 import type { ClassmatesData } from '../types/classmates';
 import type { StudyPlan, DualLanguageStudyPlan } from '../types/studyPlan';
@@ -12,50 +18,49 @@ import type { SubjectZaznamnik } from './zaznamnik';
 
 // --- Base Types using Zod ---
 
-
 export const ParsedFileSchema = z.custom<ParsedFile>();
 export const SyllabusRequirementsSchema = z.custom<SyllabusRequirements>();
-export const ExamSubjectSchema = z.custom<ExamSubject>();
 export const BlockLessonSchema = z.custom<BlockLesson>();
 export const CalendarCustomEventSchema = z.object({
-    id: z.string(),
-    title: z.string(),
-    date: z.string(),
-    startTime: z.string(),
-    endTime: z.string(),
-    room: z.string().optional(),
+  id: z.string(),
+  title: z.string(),
+  date: z.string(),
+  startTime: z.string(),
+  endTime: z.string(),
+  room: z.string().optional(),
 });
 export type { CalendarCustomEvent };
 export const CalendarCustomEventsSchema = z.array(CalendarCustomEventSchema);
 
 export const HiddenItemsSchema = z.object({
-    courses: z.array(z.object({
-        courseCode: z.string(),
-        courseName: z.string(),
-        type: z.enum(['lecture', 'seminar', 'all']).optional()
-    })),
-    events: z.array(z.object({
-        id: z.string(),
-        courseCode: z.string(),
-        courseName: z.string(),
-        date: z.string()
-    }))
+  courses: z.array(
+    z.object({
+      courseCode: z.string(),
+      courseName: z.string(),
+      type: z.enum(['lecture', 'seminar', 'all']).optional(),
+    })
+  ),
+  events: z.array(
+    z.object({
+      id: z.string(),
+      courseCode: z.string(),
+      courseName: z.string(),
+      date: z.string(),
+    })
+  ),
 });
 export const SubjectsDataSchema = z.custom<SubjectsData>();
-export const StudyPlanSchema = z.union([
-    z.custom<StudyPlan>(),
-    z.custom<DualLanguageStudyPlan>()
-]);
+export const StudyPlanSchema = z.union([z.custom<StudyPlan>(), z.custom<DualLanguageStudyPlan>()]);
 
 // --- Storage Value Schemas ---
 
 // 'files' store - can be legacy array or dual-language object
 export const FilesSchema = z.union([
-    z.array(ParsedFileSchema),
-    z.object({
-        cz: z.array(ParsedFileSchema),
-        en: z.array(ParsedFileSchema)
-    })
+  z.array(ParsedFileSchema),
+  z.object({
+    cz: z.array(ParsedFileSchema),
+    en: z.array(ParsedFileSchema),
+  }),
 ]);
 
 // 'assessments' store - Legacy, kept for backward compatibility
@@ -63,11 +68,11 @@ export const AssessmentsSchema = z.array(z.unknown());
 
 // 'syllabuses' store - can be legacy single-language or dual-language object
 export const SyllabusSchema = z.union([
-    SyllabusRequirementsSchema,
-    z.object({
-        cz: SyllabusRequirementsSchema,
-        en: SyllabusRequirementsSchema
-    })
+  SyllabusRequirementsSchema,
+  z.object({
+    cz: SyllabusRequirementsSchema,
+    en: SyllabusRequirementsSchema,
+  }),
 ]);
 
 // 'exams' store - Array of ExamSubject
@@ -96,122 +101,136 @@ export const DocumentNoteSchema = z.custom<DocumentNote>();
 
 // 'note_images' store - normalized image blobs, keyed by content hash
 export const NoteImageSchema = z.object({
-    hash: z.string(),
-    // Blob is passed through without a runtime instanceof check — IndexedDB
-    // round-trips it natively, and a strict check is brittle across structured-
-    // clone realms (matches how ParsedFile/SubjectsData are handled here).
-    blob: z.custom<Blob>(),
-    mime: z.string(),
-    w: z.number(),
-    h: z.number(),
-    createdAt: z.number(),
+  hash: z.string(),
+  // Blob is passed through without a runtime instanceof check — IndexedDB
+  // round-trips it natively, and a strict check is brittle across structured-
+  // clone realms (matches how ParsedFile/SubjectsData are handled here).
+  blob: z.custom<Blob>(),
+  mime: z.string(),
+  w: z.number(),
+  h: z.number(),
+  createdAt: z.number(),
 });
 
 // 'iskam' store - WebISKAM dashboard snapshot (konta + ubytovani + freshness)
 export const IskamDataSchema = z.object({
-    konta: z.array(z.object({
-        name: z.string(),
-        nameCs: z.string().optional(),
-        nameEn: z.string().optional(),
-        balance: z.number(),
-        balanceText: z.string(),
-        topUpHref: z.string().nullable(),
-        transactionsHref: z.string().nullable(),
-    })),
-    ubytovani: z.array(z.object({
-        dorm: z.string(),
-        block: z.string(),
-        room: z.string(),
-        startDate: z.string(),
-        endDate: z.string(),
-        status: z.string(),
-        contractHref: z.string().nullable(),
-    })),
-    profile: z.object({
-        fullName: z.string(),
-        email: z.string(),
-    }).optional(),
-    reservations: z.array(z.object({
-        facility: z.string(),
-        room: z.string(),
-        startDate: z.string(),
-        endDate: z.string(),
-        price: z.string().optional(),
-    })),
-    pendingPayments: z.array(z.object({
-        dueDate: z.string(),
-        description: z.string(),
-        amount: z.string(),
-    })),
-    foodTransactions: z.array(z.object({
-        datetime: z.string(),
-        settledDate: z.string(),
-        type: z.string(),
-        description: z.string(),
-        topUp: z.number().nullable(),
-        payment: z.number().nullable(),
-        balance: z.number(),
-    })),
-    lastTopUp: z.number().nullable(),
-    syncedAt: z.number(),
+  konta: z.array(
+    z.object({
+      name: z.string(),
+      nameCs: z.string().optional(),
+      nameEn: z.string().optional(),
+      balance: z.number(),
+      balanceText: z.string(),
+      topUpHref: z.string().nullable(),
+      transactionsHref: z.string().nullable(),
+    })
+  ),
+  ubytovani: z.array(
+    z.object({
+      dorm: z.string(),
+      block: z.string(),
+      room: z.string(),
+      startDate: z.string(),
+      endDate: z.string(),
+      status: z.string(),
+      contractHref: z.string().nullable(),
+    })
+  ),
+  profile: z
+    .object({
+      fullName: z.string(),
+      email: z.string(),
+    })
+    .optional(),
+  reservations: z.array(
+    z.object({
+      facility: z.string(),
+      room: z.string(),
+      startDate: z.string(),
+      endDate: z.string(),
+      price: z.string().optional(),
+    })
+  ),
+  pendingPayments: z.array(
+    z.object({
+      dueDate: z.string(),
+      description: z.string(),
+      amount: z.string(),
+    })
+  ),
+  foodTransactions: z.array(
+    z.object({
+      datetime: z.string(),
+      settledDate: z.string(),
+      type: z.string(),
+      description: z.string(),
+      topUp: z.number().nullable(),
+      payment: z.number().nullable(),
+      balance: z.number(),
+    })
+  ),
+  lastTopUp: z.number().nullable(),
+  syncedAt: z.number(),
 }) as z.ZodType<IskamData>;
 
 // 'zaznamnik' store - PH + VT assessment data per subject (nullable on parse failure)
 const PhArchSchema = z.object({
-    name: z.string(),
-    empty: z.boolean(),
-    columns: z.array(z.string()),
-    values: z.array(z.string()),
+  name: z.string(),
+  empty: z.boolean(),
+  columns: z.array(z.string()),
+  values: z.array(z.string()),
 });
 const PhSectionSchema = z.object({
-    label: z.string(),
-    arches: z.array(PhArchSchema),
+  label: z.string(),
+  arches: z.array(PhArchSchema),
 });
 const SubjectPhSchema = z.object({
-    sections: z.array(PhSectionSchema),
-    fetchedAt: z.number(),
+  sections: z.array(PhSectionSchema),
+  fetchedAt: z.number(),
 });
 const VtTestAttemptSchema = z.object({
-    name: z.string(),
-    score: z.number(),
-    maxScore: z.number(),
-    successPct: z.number(),
-    submittedAt: z.string(),
-    teacher: z.string(),
-    hasDetail: z.boolean(),
+  name: z.string(),
+  score: z.number(),
+  maxScore: z.number(),
+  successPct: z.number(),
+  submittedAt: z.string(),
+  teacher: z.string(),
+  hasDetail: z.boolean(),
 });
 const SubjectVtSchema = z.object({
-    tests: z.array(VtTestAttemptSchema),
-    fetchedAt: z.number(),
+  tests: z.array(VtTestAttemptSchema),
+  fetchedAt: z.number(),
 });
-export const ZaznamnikSchema = z.object({
+export const ZaznamnikSchema = z
+  .object({
     ph: SubjectPhSchema,
     vt: SubjectVtSchema,
-}).nullable() as z.ZodType<SubjectZaznamnik | null>;
+  })
+  .nullable() as z.ZodType<SubjectZaznamnik | null>;
 
 // Map store names to their schemas for runtime validation
 export const StoreSchemas = {
-    files: FilesSchema,
-    assessments: AssessmentsSchema,
-    syllabuses: SyllabusSchema,
-    exams: ExamsSchema,
-    schedule: ScheduleSchema,
-    subjects: SubjectsSchema,
-    classmates: ClassmatesSchema,
-    hidden_items: HiddenItemsSchema,
-    custom_events: CalendarCustomEventSchema,
-    success_rates: SuccessRatesSchema,
-    meta: MetaSchema,
-    grade_history: GradeHistorySchema,
-    study_plan: StudyPlanSchema,
-    cvicne_tests: z.array(z.custom<CvicnyTest>()),
-    odevzdavarny: z.array(z.custom<Odevzdavarna>()),
-    erasmus: z.custom<ErasmusCountryData>(),
-    document_notes: DocumentNoteSchema,
-    note_images: NoteImageSchema,
-    iskam: IskamDataSchema,
-    zaznamnik: ZaznamnikSchema,
-    map_rooms: z.custom<import('../types/campusMap').RoomsCollection>(),
+  files: FilesSchema,
+  assessments: AssessmentsSchema,
+  syllabuses: SyllabusSchema,
+  exams: ExamsSchema,
+  schedule: ScheduleSchema,
+  subjects: SubjectsSchema,
+  classmates: ClassmatesSchema,
+  hidden_items: HiddenItemsSchema,
+  custom_events: CalendarCustomEventSchema,
+  success_rates: SuccessRatesSchema,
+  meta: MetaSchema,
+  grade_history: GradeHistorySchema,
+  study_plan: StudyPlanSchema,
+  cvicne_tests: z.array(z.custom<CvicnyTest>()),
+  odevzdavarny: z.array(z.custom<Odevzdavarna>()),
+  erasmus: z.custom<ErasmusCountryData>(),
+  document_notes: DocumentNoteSchema,
+  note_images: NoteImageSchema,
+  iskam: IskamDataSchema,
+  zaznamnik: ZaznamnikSchema,
+  map_rooms: z.custom<import('../types/campusMap').RoomsCollection>(),
 };
 
 export type StoreName = keyof typeof StoreSchemas;


### PR DESCRIPTION
**First slice of Tier 1 #1** (IndexedDB `StoreSchemas` hardening) — the template for the remaining stores.

Replaces the `z.custom<ExamSubject>()` no-op with a structural schema. Because `IndexedDBService.validate()` is **fail-closed** (a parse failure silently drops on write / hides on read), the schema is deliberately **permissive-but-structural**: it rejects genuine corruption (null root, non-array `sections`, missing `id`) but never drops valid data — optionals stay optional, `.passthrough()` tolerates future IS fields, and open-ended unions (`status`, `attemptTypes`) are widened to `string`.

Test asserts **both directions**: real data + field-drift + passthrough all pass; corruption is rejected.

Verified: typecheck 0, 6 new tests pass, build ✔. No runtime behavior change for valid data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)