### PR TITLE
feat(storage): real Zod schema for the 'subjects' IDB store (was z.custom no-op)

### DIFF
--- a/src/types/schemas/__tests__/subjects.schema.test.ts
+++ b/src/types/schemas/__tests__/subjects.schema.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { SubjectsDataSchema } from '../subjects.schema';
+import type { SubjectsData } from '../../documents';
+
+// A representative real subjects payload (mirrors what syncSubjects writes).
+const realData: SubjectsData = {
+  version: 1,
+  lastUpdated: '2026-07-06T10:00:00.000Z',
+  data: {
+    'EBC-ALG': {
+      displayName: 'Algebra',
+      fullName: 'Algebra (EBC-ALG)',
+      nameCs: 'Algebra',
+      nameEn: 'Algebra',
+      subjectCode: 'EBC-ALG',
+      subjectId: '123456',
+      folderUrl: 'https://is.mendelu.cz/dok_server/folder.pl?id=1',
+      fetchedAt: '2026-07-06T10:00:00.000Z',
+      hasPrubezne: true,
+      hasTest: false,
+      autoHref: null,
+    },
+  },
+};
+
+describe('SubjectsDataSchema', () => {
+  it('accepts a representative real subjects payload (never drops valid data)', () => {
+    expect(SubjectsDataSchema.safeParse(realData).success).toBe(true);
+  });
+
+  it('accepts unknown/future IS fields via passthrough', () => {
+    const withExtra = {
+      ...realData,
+      futureField: 'x',
+      data: {
+        ...realData.data,
+        'EBC-ALG': { ...realData.data['EBC-ALG'], brandNewFlag: true },
+      },
+    };
+    expect(SubjectsDataSchema.safeParse(withExtra).success).toBe(true);
+  });
+
+  it('accepts a subject entry missing all optional fields', () => {
+    const minimal = {
+      version: 1,
+      lastUpdated: '2026-07-06T10:00:00.000Z',
+      data: {
+        'EBC-ALG': {
+          displayName: 'Algebra',
+          fullName: 'Algebra (EBC-ALG)',
+          subjectCode: 'EBC-ALG',
+          folderUrl: 'https://is.mendelu.cz/dok_server/folder.pl?id=1',
+          fetchedAt: '2026-07-06T10:00:00.000Z',
+        },
+      },
+    };
+    expect(SubjectsDataSchema.safeParse(minimal).success).toBe(true);
+  });
+
+  it('rejects genuine corruption: null root', () => {
+    expect(SubjectsDataSchema.safeParse(null).success).toBe(false);
+  });
+
+  it('rejects genuine corruption: data is not an object', () => {
+    expect(SubjectsDataSchema.safeParse({ ...realData, data: 'nope' }).success).toBe(false);
+  });
+
+  it('rejects genuine corruption: subject entry missing subjectCode', () => {
+    const { subjectCode: _subjectCode, ...noCode } = realData.data['EBC-ALG'];
+    const corrupted = { ...realData, data: { 'EBC-ALG': noCode } };
+    expect(SubjectsDataSchema.safeParse(corrupted).success).toBe(false);
+  });
+
+  it('rejects genuine corruption: missing version', () => {
+    const { version: _version, ...noVersion } = realData;
+    expect(SubjectsDataSchema.safeParse(noVersion).success).toBe(false);
+  });
+});

--- a/src/types/schemas/subjects.schema.ts
+++ b/src/types/schemas/subjects.schema.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod';
+import type { SubjectsData } from '../documents';
+
+// Runtime schema for the 'subjects' IndexedDB store (was a `z.custom` no-op).
+//
+// Design: validate STRUCTURE, not domain. IndexedDBService.validate() is
+// fail-closed (a parse failure drops the value on write / hides it on read),
+// so the schema must never reject genuine data. Therefore:
+//  - only structural anchors are required (version, lastUpdated, data record);
+//  - every optional SubjectInfo field stays optional here;
+//  - `.passthrough()` keeps unknown/future IS fields from failing a parse.
+// It still catches real corruption: null/non-object roots, a non-object
+// `data`, or a subject entry missing its `subjectCode`/`folderUrl` anchors.
+
+const SubjectInfoSchema = z
+  .object({
+    displayName: z.string(),
+    fullName: z.string(),
+    nameCs: z.string().optional(),
+    nameEn: z.string().optional(),
+    subjectCode: z.string(),
+    subjectId: z.string().optional(),
+    skupinaId: z.string().optional(),
+    folderUrl: z.string(),
+    fetchedAt: z.string(),
+    hasPrubezne: z.boolean().optional(),
+    hasTest: z.boolean().optional(),
+    autoHref: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+export const SubjectsDataSchema = z
+  .object({
+    version: z.number(),
+    lastUpdated: z.string(),
+    data: z.record(z.string(), SubjectInfoSchema),
+  })
+  .passthrough() as unknown as z.ZodType<SubjectsData>;

--- a/src/types/storage.ts
+++ b/src/types/storage.ts
@@ -2,12 +2,12 @@ import { z } from 'zod';
 import type {
   ParsedFile,
   SyllabusRequirements,
-  SubjectsData,
   GradeHistory,
   DocumentNote,
 } from '../types/documents';
 import { ExamSubjectSchema } from './schemas/exams.schema';
 import { BlockLessonSchema } from './schemas/schedule.schema';
+import { SubjectsDataSchema } from './schemas/subjects.schema';
 import type { CalendarCustomEvent } from '../types/calendarTypes';
 import type { ClassmatesData } from '../types/classmates';
 import type { StudyPlan, DualLanguageStudyPlan } from '../types/studyPlan';
@@ -49,7 +49,6 @@ export const HiddenItemsSchema = z.object({
     })
   ),
 });
-export const SubjectsDataSchema = z.custom<SubjectsData>();
 export const StudyPlanSchema = z.union([z.custom<StudyPlan>(), z.custom<DualLanguageStudyPlan>()]);
 
 // --- Storage Value Schemas ---


### PR DESCRIPTION
## Summary
- Replaces the `z.custom<SubjectsData>()` no-op schema for the `subjects` IndexedDB store with a real structural Zod schema, following the `exams.schema.ts` template from #107 (and #108's `schedule` schema).
- Only structural anchors are required (`version`, `lastUpdated`, `data` record); every optional `SubjectInfo` field stays optional; `.passthrough()` keeps unknown/future IS fields from failing a parse.
- `IndexedDBService.validate()` is fail-closed, so the schema is deliberately permissive — it must never drop genuine data, only catch real corruption (null root, non-object `data`, or a subject entry missing `subjectCode`/`version`).
- Note: `src/schemas/subjectSchema.ts` already has a `SubjectsDataSchema` too, but that one validates the raw IS API response (stricter — `folderUrl` must be a URL, `version` a literal `1`). This PR's schema is a separate, more permissive one scoped to IDB storage round-trips; left the API-layer file untouched.

## Test plan
- [x] `npm run typecheck` passes
- [x] New `subjects.schema.test.ts` covers real data, field drift, passthrough, minimal-optional-fields (all pass) and null/wrong-type/missing-anchor (all reject)
- [x] `npm run build` succeeds
- [x] Changed non-test files lint clean with `--max-warnings=0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ux36EGBmB8BHKuAety2RDZ