### PR TITLE
feat(storage): real Zod schema for the 'success_rates' IDB store (was z.record(string, any))

### DIFF
--- a/src/types/schemas/__tests__/successRates.schema.test.ts
+++ b/src/types/schemas/__tests__/successRates.schema.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import {
+  SuccessRatesSchema,
+  SubjectSuccessRateSchema,
+  SuccessRateDataSchema,
+} from '../successRates.schema';
+import type { SubjectSuccessRate, SuccessRateData } from '../../documents';
+
+// A representative real subject success rate (mirrors what successRate.ts writes).
+const realSubjectRate: SubjectSuccessRate = {
+  courseCode: 'EBC-ALG',
+  lastUpdated: '2026-07-06T10:00:00.000Z',
+  predmetId: '160301',
+  stats: [
+    {
+      semesterName: 'ZS 2025/2026',
+      semesterId: '801',
+      year: 2025,
+      totalPass: 80,
+      totalFail: 20,
+      type: 'exam',
+      terms: [
+        {
+          term: '1',
+          grades: { A: 10, B: 20, C: 20, D: 15, E: 10, F: 5, FN: 5 },
+          pass: 75,
+          fail: 15,
+        },
+      ],
+    },
+  ],
+};
+
+const realAggregate: SuccessRateData = {
+  lastUpdated: '2026-07-06T10:00:00.000Z',
+  data: { 'EBC-ALG': realSubjectRate },
+};
+
+describe('SubjectSuccessRateSchema', () => {
+  it('accepts a representative real subject success rate (never drops valid data)', () => {
+    expect(SubjectSuccessRateSchema.safeParse(realSubjectRate).success).toBe(true);
+  });
+
+  it('accepts unknown/future fields via passthrough', () => {
+    const withExtra = {
+      ...realSubjectRate,
+      futureField: 'x',
+      stats: [{ ...realSubjectRate.stats[0], brandNewFlag: true }],
+    };
+    expect(SubjectSuccessRateSchema.safeParse(withExtra).success).toBe(true);
+  });
+
+  it('accepts an unexpected stats.type value (widened to string, no drift-drop)', () => {
+    const drift = {
+      ...realSubjectRate,
+      stats: [{ ...realSubjectRate.stats[0], type: 'new_kind' }],
+    };
+    expect(SubjectSuccessRateSchema.safeParse(drift).success).toBe(true);
+  });
+
+  it('rejects genuine corruption: null root', () => {
+    expect(SubjectSuccessRateSchema.safeParse(null).success).toBe(false);
+  });
+
+  it('rejects genuine corruption: stats is not an array', () => {
+    expect(SubjectSuccessRateSchema.safeParse({ ...realSubjectRate, stats: 'nope' }).success).toBe(
+      false
+    );
+  });
+
+  it('rejects genuine corruption: missing courseCode', () => {
+    const { courseCode: _courseCode, ...noCode } = realSubjectRate;
+    expect(SubjectSuccessRateSchema.safeParse(noCode).success).toBe(false);
+  });
+});
+
+describe('SuccessRateDataSchema', () => {
+  it('accepts a representative real aggregate payload (never drops valid data)', () => {
+    expect(SuccessRateDataSchema.safeParse(realAggregate).success).toBe(true);
+  });
+
+  it('rejects genuine corruption: data is not an object', () => {
+    expect(SuccessRateDataSchema.safeParse({ ...realAggregate, data: 'nope' }).success).toBe(false);
+  });
+
+  it('rejects genuine corruption: missing lastUpdated', () => {
+    const { lastUpdated: _lastUpdated, ...noLastUpdated } = realAggregate;
+    expect(SuccessRateDataSchema.safeParse(noLastUpdated).success).toBe(false);
+  });
+});
+
+describe('SuccessRatesSchema (union used by the IDB store)', () => {
+  it('accepts the aggregate shape (key "current")', () => {
+    expect(SuccessRatesSchema.safeParse(realAggregate).success).toBe(true);
+  });
+
+  it('accepts the bare per-subject shape (course-code keys, MockManager)', () => {
+    expect(SuccessRatesSchema.safeParse(realSubjectRate).success).toBe(true);
+  });
+
+  it('rejects genuine corruption: null', () => {
+    expect(SuccessRatesSchema.safeParse(null).success).toBe(false);
+  });
+});

--- a/src/types/schemas/successRates.schema.ts
+++ b/src/types/schemas/successRates.schema.ts
@@ -1,0 +1,80 @@
+import { z } from 'zod';
+import type { SuccessRateData, SubjectSuccessRate } from '../documents';
+
+// Runtime schema for the 'success_rates' IndexedDB store (was z.record(string, any)).
+//
+// Design: validate STRUCTURE, not domain. IndexedDBService.validate() is
+// fail-closed (a parse failure drops the value on write / hides it on read),
+// so the schema must never reject genuine data. Therefore:
+//  - only structural anchors are required (courseCode/stats, or lastUpdated/data);
+//  - every optional field stays optional here;
+//  - `.passthrough()` keeps unknown/future fields from failing a parse;
+//  - open-ended string unions (SemesterStats.type) are widened to string.
+// The store holds two shapes depending on the IDB key: the aggregate
+// SuccessRateData (key 'current', written by successRate.ts) or a bare
+// SubjectSuccessRate (per-course-code keys, written by MockManager). It
+// still catches real corruption: null/non-object roots, non-array `stats`,
+// or a missing `courseCode`/`lastUpdated`.
+
+const GradeStatsSchema = z
+  .object({
+    A: z.number(),
+    B: z.number(),
+    C: z.number(),
+    D: z.number(),
+    E: z.number(),
+    F: z.number(),
+    FN: z.number(),
+  })
+  .passthrough();
+
+const CreditStatsSchema = z
+  .object({
+    zap: z.number(),
+    nezap: z.number(),
+    zapNedost: z.number(),
+  })
+  .passthrough();
+
+const TermStatsSchema = z
+  .object({
+    term: z.string(),
+    grades: GradeStatsSchema,
+    creditGrades: CreditStatsSchema.optional(),
+    pass: z.number(),
+    fail: z.number(),
+  })
+  .passthrough();
+
+const SemesterStatsSchema = z
+  .object({
+    semesterName: z.string(),
+    semesterId: z.string(),
+    year: z.number(),
+    totalPass: z.number(),
+    totalFail: z.number(),
+    sourceUrl: z.string().optional(),
+    type: z.string(),
+    terms: z.array(TermStatsSchema),
+  })
+  .passthrough();
+
+export const SubjectSuccessRateSchema = z
+  .object({
+    courseCode: z.string(),
+    stats: z.array(SemesterStatsSchema),
+    lastUpdated: z.string(),
+    predmetId: z.string().optional(),
+  })
+  .passthrough() as unknown as z.ZodType<SubjectSuccessRate>;
+
+export const SuccessRateDataSchema = z
+  .object({
+    lastUpdated: z.string(),
+    data: z.record(z.string(), SubjectSuccessRateSchema),
+  })
+  .passthrough() as unknown as z.ZodType<SuccessRateData>;
+
+// 'success_rates' store - either the aggregate (key 'current') or a bare
+// per-subject entry (course-code keys, used by MockManager).
+export const SuccessRatesSchema = z.union([SuccessRateDataSchema, SubjectSuccessRateSchema]);

--- a/src/types/storage.ts
+++ b/src/types/storage.ts
@@ -4,6 +4,7 @@ import { ExamSubjectSchema } from './schemas/exams.schema';
 import { BlockLessonSchema } from './schemas/schedule.schema';
 import { SubjectsDataSchema } from './schemas/subjects.schema';
 import { FilesSchema } from './schemas/files.schema';
+import { SuccessRatesSchema } from './schemas/successRates.schema';
 import type { CalendarCustomEvent } from '../types/calendarTypes';
 import type { ClassmatesData } from '../types/classmates';
 import type { StudyPlan, DualLanguageStudyPlan } from '../types/studyPlan';
@@ -68,9 +69,6 @@ export const ScheduleSchema = z.array(BlockLessonSchema);
 
 // 'subjects' store - SubjectsData
 export const SubjectsSchema = SubjectsDataSchema;
-
-// 'success_rates' store - Validating partial object structure
-export const SuccessRatesSchema = z.record(z.string(), z.any());
 
 // 'classmates' store - { all: Classmate[], seminar: Classmate[] }
 export const ClassmatesSchema = z.custom<ClassmatesData>();


### PR DESCRIPTION
## Summary
- Replaces the `z.record(z.string(), z.any())` no-op schema for the `success_rates` IndexedDB store with a real structural Zod schema, following the `exams.schema.ts` template from #107 (and #108/#109/#110's earlier stores).
- The store holds two shapes depending on the IDB key: the aggregate `SuccessRateData` at key `'current'` (written by `src/api/successRate.ts`), and a bare `SubjectSuccessRate` at per-course-code keys (written by `MockManager`). The new `SuccessRatesSchema` is a union covering both.
- Only structural anchors are required (`courseCode`/`stats` for the bare shape, `lastUpdated`/`data` for the aggregate); every optional field stays optional; `.passthrough()` keeps unknown/future fields from failing a parse; `SemesterStats.type` is widened to `z.string()`.
- `IndexedDBService.validate()` is fail-closed, so the schema is deliberately permissive — it must never drop genuine data, only catch real corruption (null root, non-array `stats`, missing `courseCode`/`lastUpdated`).

## Test plan
- [x] `npm run typecheck` passes
- [x] New `successRates.schema.test.ts` covers real data (both shapes), field drift, passthrough (all pass) and null/wrong-type/missing-anchor (all reject)
- [x] `npm run build` succeeds
- [x] Changed files pass `npx prettier --check` and lint clean with `--max-warnings=0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ux36EGBmB8BHKuAety2RDZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stronger validation for saved success-rate data, supporting both aggregate and per-course record formats.
  * Existing and future fields are preserved, helping compatibility with newer data shapes.

* **Bug Fixes**
  * Improved rejection of corrupted or incomplete records, such as missing required fields or invalid root data.
  * Better handling of unexpected values in nested statistics without breaking valid records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->