### PR TITLE
feat(storage): structural Zod schema for the 'meta' IDB store (was z.any())

### DIFF
--- a/src/types/schemas/__tests__/meta.schema.test.ts
+++ b/src/types/schemas/__tests__/meta.schema.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { MetaSchema } from '../meta.schema';
+
+describe('MetaSchema (generic heterogeneous KV bucket)', () => {
+  it('accepts a boolean flag (e.g. dev_features_enabled)', () => {
+    expect(MetaSchema.safeParse(true).success).toBe(true);
+  });
+
+  it('accepts a string (e.g. an ISO timestamp or token)', () => {
+    expect(MetaSchema.safeParse('2026-07-06T10:00:00.000Z').success).toBe(true);
+  });
+
+  it('accepts a number', () => {
+    expect(MetaSchema.safeParse(42).success).toBe(true);
+  });
+
+  it('accepts null', () => {
+    expect(MetaSchema.safeParse(null).success).toBe(true);
+  });
+
+  it('accepts an array of primitives (e.g. recent_searches, read_notifications)', () => {
+    expect(MetaSchema.safeParse(['EBC-ALG', 'EBC-MAT']).success).toBe(true);
+  });
+
+  it('accepts a nested plain object (e.g. course_deadlines, notifications_cache)', () => {
+    const nested = {
+      'EBC-ALG': { deadline: '2026-08-01', reminders: [1, 2, 3] },
+      meta: { fetchedAt: '2026-07-06T10:00:00.000Z', flags: { synced: true } },
+    };
+    expect(MetaSchema.safeParse(nested).success).toBe(true);
+  });
+
+  it('rejects genuine corruption: undefined', () => {
+    expect(MetaSchema.safeParse(undefined).success).toBe(false);
+  });
+
+  it('rejects genuine corruption: a function value nested in an object', () => {
+    expect(MetaSchema.safeParse({ callback: () => {} }).success).toBe(false);
+  });
+
+  it('rejects genuine corruption: a symbol', () => {
+    expect(MetaSchema.safeParse(Symbol('x')).success).toBe(false);
+  });
+});

--- a/src/types/schemas/meta.schema.ts
+++ b/src/types/schemas/meta.schema.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+
+// Runtime schema for the 'meta' IndexedDB store (was z.any()).
+//
+// Unlike every other store, 'meta' is a genuine heterogeneous key-value bucket:
+// dozens of unrelated call sites (feature flags, sync timestamps, UI hints,
+// tokens, caches, dismissal flags, arrays of ids...) each own a single key and
+// store a value of whatever shape suits them — there is no single TS type for
+// "a meta value". Enumerating every key's shape here would be both huge and
+// fragile: any site not accounted for would have its legitimate value dropped
+// by IndexedDBService.validate() (fail-closed).
+//
+// So the tightening that's actually safe here is structural at the JSON-value
+// level, not per-key: accept any value the structured-clone/IDB round-trip can
+// legitimately hold (string/number/boolean/null/array/plain object, arbitrarily
+// nested), and reject only genuine corruption — undefined, functions, symbols,
+// or other values that were never valid to store in the first place.
+const MetaValueSchema: z.ZodType<unknown> = z.lazy(() =>
+  z.union([
+    z.string(),
+    z.number(),
+    z.boolean(),
+    z.null(),
+    z.array(MetaValueSchema),
+    z.record(z.string(), MetaValueSchema),
+  ])
+);
+
+export const MetaSchema = MetaValueSchema;

--- a/src/types/storage.ts
+++ b/src/types/storage.ts
@@ -5,6 +5,7 @@ import { BlockLessonSchema } from './schemas/schedule.schema';
 import { SubjectsDataSchema } from './schemas/subjects.schema';
 import { FilesSchema } from './schemas/files.schema';
 import { SuccessRatesSchema } from './schemas/successRates.schema';
+import { MetaSchema } from './schemas/meta.schema';
 import type { CalendarCustomEvent } from '../types/calendarTypes';
 import type { ClassmatesData } from '../types/classmates';
 import type { StudyPlan, DualLanguageStudyPlan } from '../types/studyPlan';
@@ -72,9 +73,6 @@ export const SubjectsSchema = SubjectsDataSchema;
 
 // 'classmates' store - { all: Classmate[], seminar: Classmate[] }
 export const ClassmatesSchema = z.custom<ClassmatesData>();
-
-// 'meta' store - Generic metadata object
-export const MetaSchema = z.any();
 
 // 'grade_history' store - GradeHistory
 export const GradeHistorySchema = z.custom<GradeHistory>();


### PR DESCRIPTION
## Summary
- Replaces the `z.any()` no-op schema for the `meta` IndexedDB store with a real (if necessarily generic) Zod schema.
- Unlike the previously-tightened stores (`exams`, `schedule`, `subjects`, `files`, `success_rates`), `meta` is a genuine heterogeneous key-value bucket — 50+ unrelated call sites (feature flags, sync timestamps, UI hints, tokens, caches, id arrays, nested config objects) each own a single key and store whatever shape suits them. There is no single TS type for "a meta value" to anchor a per-field schema on the way the other stores had.
- Enumerating every key's shape would be large and fragile: any site not accounted for would have its legitimate value silently dropped by `IndexedDBService.validate()` (fail-closed).
- Instead, this tightens at the JSON-value level: accepts any value the IDB/structured-clone round-trip can legitimately hold (`string | number | boolean | null | array | plain object`, arbitrarily nested via `z.lazy`), and rejects only genuine corruption that was never valid to store (`undefined`, functions, symbols).

## Test plan
- [x] `npm run typecheck` passes
- [x] New `meta.schema.test.ts` covers booleans/strings/numbers/null/arrays/nested objects (all pass) and undefined/functions/symbols (all reject)
- [x] `npm run test:run` — full suite passes (1081/1081 relevant tests; 5 pre-existing unrelated failures from missing local `.agent/fixtures/` HTML files, not caused by this change)
- [x] `npm run build` succeeds
- [x] Changed files pass `npx prettier --check` and lint clean with `--max-warnings=0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ux36EGBmB8BHKuAety2RDZ