### PR TITLE
feat(storage): real Zod schema for the 'classmates' IDB store (was z.custom no-op)

### DIFF
--- a/src/types/schemas/__tests__/classmates.schema.test.ts
+++ b/src/types/schemas/__tests__/classmates.schema.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { ClassmatesSchema } from '../classmates.schema';
+import type { ClassmatesData } from '../../classmates';
+
+// A representative real classmate list (mirrors what fetchClassmatesForSubject writes).
+const realData: ClassmatesData = [
+  {
+    personId: 12345,
+    photoUrl: 'https://is.mendelu.cz/auth/lide/foto.pl?id=12345',
+    name: 'Jan Novák',
+    studyInfo: 'PEF, 2. ročník',
+    messageUrl: 'https://is.mendelu.cz/auth/posta/napsat.pl?id=12345',
+  },
+];
+
+describe('ClassmatesSchema', () => {
+  it('accepts a representative real classmate list (never drops valid data)', () => {
+    expect(ClassmatesSchema.safeParse(realData).success).toBe(true);
+  });
+
+  it('accepts an empty list (no classmates found)', () => {
+    expect(ClassmatesSchema.safeParse([]).success).toBe(true);
+  });
+
+  it('accepts an entry missing the optional messageUrl', () => {
+    const { messageUrl: _messageUrl, ...noMessageUrl } = realData[0];
+    expect(ClassmatesSchema.safeParse([noMessageUrl]).success).toBe(true);
+  });
+
+  it('accepts unknown/future fields via passthrough', () => {
+    const withExtra = [{ ...realData[0], futureField: 'x' }];
+    expect(ClassmatesSchema.safeParse(withExtra).success).toBe(true);
+  });
+
+  it('rejects genuine corruption: null root', () => {
+    expect(ClassmatesSchema.safeParse(null).success).toBe(false);
+  });
+
+  it('rejects genuine corruption: not an array', () => {
+    expect(ClassmatesSchema.safeParse(realData[0]).success).toBe(false);
+  });
+
+  it('rejects genuine corruption: entry missing personId', () => {
+    const { personId: _personId, ...noId } = realData[0];
+    expect(ClassmatesSchema.safeParse([noId]).success).toBe(false);
+  });
+});

--- a/src/types/schemas/classmates.schema.ts
+++ b/src/types/schemas/classmates.schema.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+import type { ClassmatesData } from '../classmates';
+
+// Runtime schema for the 'classmates' IndexedDB store (was a `z.custom` no-op).
+//
+// Design: validate STRUCTURE, not domain. IndexedDBService.validate() is
+// fail-closed (a parse failure drops the value on write / hides it on read),
+// so the schema must never reject genuine data. Therefore:
+//  - only structural anchors are required (personId, photoUrl, name, studyInfo);
+//  - the optional messageUrl field stays optional here;
+//  - `.passthrough()` keeps unknown/future fields from failing a parse.
+// It still catches real corruption: null/non-array roots or an entry missing
+// its `personId`/`name`.
+
+const ClassmateSchema = z
+  .object({
+    personId: z.number(),
+    photoUrl: z.string(),
+    name: z.string(),
+    studyInfo: z.string(),
+    messageUrl: z.string().optional(),
+  })
+  .passthrough();
+
+export const ClassmatesSchema = z.array(ClassmateSchema) as unknown as z.ZodType<ClassmatesData>;

--- a/src/types/storage.ts
+++ b/src/types/storage.ts
@@ -6,8 +6,8 @@ import { SubjectsDataSchema } from './schemas/subjects.schema';
 import { FilesSchema } from './schemas/files.schema';
 import { SuccessRatesSchema } from './schemas/successRates.schema';
 import { MetaSchema } from './schemas/meta.schema';
+import { ClassmatesSchema } from './schemas/classmates.schema';
 import type { CalendarCustomEvent } from '../types/calendarTypes';
-import type { ClassmatesData } from '../types/classmates';
 import type { StudyPlan, DualLanguageStudyPlan } from '../types/studyPlan';
 import type { CvicnyTest } from '../api/cvicneTests';
 import type { Odevzdavarna } from '../api/odevzdavarny';
@@ -70,9 +70,6 @@ export const ScheduleSchema = z.array(BlockLessonSchema);
 
 // 'subjects' store - SubjectsData
 export const SubjectsSchema = SubjectsDataSchema;
-
-// 'classmates' store - { all: Classmate[], seminar: Classmate[] }
-export const ClassmatesSchema = z.custom<ClassmatesData>();
 
 // 'grade_history' store - GradeHistory
 export const GradeHistorySchema = z.custom<GradeHistory>();


### PR DESCRIPTION
## Summary
- Replaces the `z.custom<ClassmatesData>()` no-op schema for the `classmates` IndexedDB store with a real structural Zod schema, following the `exams.schema.ts` template from #107.
- Only structural anchors are required (`personId`, `photoUrl`, `name`, `studyInfo`); the optional `messageUrl` field stays optional; `.passthrough()` keeps unknown/future fields from failing a parse.
- Also corrects a stale comment above the old schema claiming the store's value was `{ all: Classmate[], seminar: Classmate[] }` — the actual `ClassmatesData` type (and every real call site) is a flat `Classmate[]`.
- `IndexedDBService.validate()` is fail-closed, so the schema is deliberately permissive — it must never drop genuine data, only catch real corruption (null root, non-array root, missing `personId`).

## Test plan
- [x] `npm run typecheck` passes
- [x] New `classmates.schema.test.ts` covers real data, empty list, missing-optional-field, passthrough (all pass) and null/wrong-type/missing-anchor (all reject)
- [x] `npm run build` succeeds
- [x] Changed files pass `npx prettier --check` and lint clean with `--max-warnings=0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ux36EGBmB8BHKuAety2RDZ