### PR TITLE
feat(storage): real Zod schema for the 'grade_history' IDB store (was z.custom no-op)

### DIFF
--- a/src/types/schemas/__tests__/gradeHistory.schema.test.ts
+++ b/src/types/schemas/__tests__/gradeHistory.schema.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { GradeHistorySchema } from '../gradeHistory.schema';
+import type { GradeHistory } from '../../documents';
+
+// A representative real grade history payload (mirrors what syncGradeHistory writes).
+const realData: GradeHistory = {
+  studium: '12345',
+  fetchedAt: '2026-07-06T10:00:00.000Z',
+  grades: [
+    {
+      period: 'ZS 2025/2026 - PEF',
+      predmetId: '159410',
+      courseCode: 'DSND',
+      courseName: 'Algoritmizace',
+      examType: 'zk',
+      attempt: 1,
+      gradeText: 'dobře plus (D)',
+      gradeLetter: 'D',
+      credits: 6,
+    },
+  ],
+};
+
+describe('GradeHistorySchema', () => {
+  it('accepts a representative real grade history payload (never drops valid data)', () => {
+    expect(GradeHistorySchema.safeParse(realData).success).toBe(true);
+  });
+
+  it('accepts unknown/future IS fields via passthrough', () => {
+    const withExtra = {
+      ...realData,
+      futureField: 'x',
+      grades: [{ ...realData.grades[0], brandNewFlag: true }],
+    };
+    expect(GradeHistorySchema.safeParse(withExtra).success).toBe(true);
+  });
+
+  it('accepts an unexpected examType value (widened to string, no drift-drop)', () => {
+    const drift = { ...realData, grades: [{ ...realData.grades[0], examType: 'new_kind' }] };
+    expect(GradeHistorySchema.safeParse(drift).success).toBe(true);
+  });
+
+  it('accepts a grade entry with null attempt/credits and no gradeLetter yet', () => {
+    const ungraded = {
+      ...realData,
+      grades: [{ ...realData.grades[0], attempt: null, credits: null, gradeLetter: '' }],
+    };
+    expect(GradeHistorySchema.safeParse(ungraded).success).toBe(true);
+  });
+
+  it('rejects genuine corruption: null root', () => {
+    expect(GradeHistorySchema.safeParse(null).success).toBe(false);
+  });
+
+  it('rejects genuine corruption: grades is not an array', () => {
+    expect(GradeHistorySchema.safeParse({ ...realData, grades: 'nope' }).success).toBe(false);
+  });
+
+  it('rejects genuine corruption: grade entry missing predmetId', () => {
+    const { predmetId: _predmetId, ...noPredmetId } = realData.grades[0];
+    expect(GradeHistorySchema.safeParse({ ...realData, grades: [noPredmetId] }).success).toBe(
+      false
+    );
+  });
+
+  it('rejects genuine corruption: missing studium', () => {
+    const { studium: _studium, ...noStudium } = realData;
+    expect(GradeHistorySchema.safeParse(noStudium).success).toBe(false);
+  });
+});

--- a/src/types/schemas/gradeHistory.schema.ts
+++ b/src/types/schemas/gradeHistory.schema.ts
@@ -1,0 +1,39 @@
+import { z } from 'zod';
+import type { GradeHistory } from '../documents';
+
+// Runtime schema for the 'grade_history' IndexedDB store (was a `z.custom` no-op).
+//
+// Design: validate STRUCTURE, not domain. IndexedDBService.validate() is
+// fail-closed (a parse failure drops the value on write / hides it on read),
+// so the schema must never reject genuine data. Therefore:
+//  - only structural anchors are required (studium, fetchedAt, grades array,
+//    and each grade's predmetId/courseName/examType/gradeText/gradeLetter);
+//  - every optional CourseGrade field stays optional here;
+//  - `.passthrough()` keeps unknown/future IS fields from failing a parse;
+//  - `examType` is an open-ended IS value ("zk" | "záp" | "zak" | ...), so it
+//    stays z.string() rather than an enum.
+// It still catches real corruption: null/non-object roots, a non-array
+// `grades`, or a grade entry missing its `predmetId`.
+
+const CourseGradeSchema = z
+  .object({
+    period: z.string(),
+    predmetId: z.string(),
+    courseCode: z.string().optional(),
+    courseName: z.string(),
+    courseNameEn: z.string().optional(),
+    examType: z.string(),
+    attempt: z.number().nullable(),
+    gradeText: z.string(),
+    gradeLetter: z.string(),
+    credits: z.number().nullable(),
+  })
+  .passthrough();
+
+export const GradeHistorySchema = z
+  .object({
+    studium: z.string(),
+    fetchedAt: z.string(),
+    grades: z.array(CourseGradeSchema),
+  })
+  .passthrough() as unknown as z.ZodType<GradeHistory>;

--- a/src/types/storage.ts
+++ b/src/types/storage.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { SyllabusRequirements, GradeHistory, DocumentNote } from '../types/documents';
+import type { SyllabusRequirements, DocumentNote } from '../types/documents';
 import { ExamSubjectSchema } from './schemas/exams.schema';
 import { BlockLessonSchema } from './schemas/schedule.schema';
 import { SubjectsDataSchema } from './schemas/subjects.schema';
@@ -7,6 +7,7 @@ import { FilesSchema } from './schemas/files.schema';
 import { SuccessRatesSchema } from './schemas/successRates.schema';
 import { MetaSchema } from './schemas/meta.schema';
 import { ClassmatesSchema } from './schemas/classmates.schema';
+import { GradeHistorySchema } from './schemas/gradeHistory.schema';
 import type { CalendarCustomEvent } from '../types/calendarTypes';
 import type { StudyPlan, DualLanguageStudyPlan } from '../types/studyPlan';
 import type { CvicnyTest } from '../api/cvicneTests';
@@ -70,9 +71,6 @@ export const ScheduleSchema = z.array(BlockLessonSchema);
 
 // 'subjects' store - SubjectsData
 export const SubjectsSchema = SubjectsDataSchema;
-
-// 'grade_history' store - GradeHistory
-export const GradeHistorySchema = z.custom<GradeHistory>();
 
 // 'document_notes' store - DocumentNote
 export const DocumentNoteSchema = z.custom<DocumentNote>();


### PR DESCRIPTION
## Summary
- Replaces the `z.custom<GradeHistory>()` no-op schema for the `grade_history` IndexedDB store with a real structural Zod schema, following the `exams.schema.ts` template from #107.
- Only structural anchors are required (`studium`, `fetchedAt`, `grades` array, and each grade's `predmetId`/`courseName`/`examType`/`gradeText`/`gradeLetter`); every optional `CourseGrade` field stays optional; `.passthrough()` keeps unknown/future IS fields from failing a parse; `examType` is widened to `z.string()` since it's an open-ended IS value (`"zk" | "záp" | "zak" | ...`).
- `IndexedDBService.validate()` is fail-closed, so the schema is deliberately permissive — it must never drop genuine data, only catch real corruption (null root, non-array `grades`, missing `predmetId`/`studium`).

## Test plan
- [x] `npm run typecheck` passes
- [x] New `gradeHistory.schema.test.ts` covers real data, field drift, passthrough, ungraded entries with null attempt/credits (all pass) and null/wrong-type/missing-anchor (all reject)
- [x] `npm run build` succeeds
- [x] Changed files pass `npx prettier --check` and lint clean with `--max-warnings=0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ux36EGBmB8BHKuAety2RDZ