### PR TITLE
feat(storage): real Zod schema for the 'document_notes' IDB store (was z.custom no-op)

### DIFF
--- a/src/types/schemas/__tests__/documentNotes.schema.test.ts
+++ b/src/types/schemas/__tests__/documentNotes.schema.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { DocumentNoteSchema } from '../documentNotes.schema';
+import type { DocumentNote } from '../../documents';
+
+const realData: DocumentNote = {
+  note: 'Remember to review chapter 3 before the exam.',
+  updatedAt: 1751800000000,
+  fileName: 'Prezentace 1.pdf',
+};
+
+describe('DocumentNoteSchema', () => {
+  it('accepts a representative real document note (never drops valid data)', () => {
+    expect(DocumentNoteSchema.safeParse(realData).success).toBe(true);
+  });
+
+  it('accepts a note missing the optional fileName', () => {
+    const { fileName: _fileName, ...noFileName } = realData;
+    expect(DocumentNoteSchema.safeParse(noFileName).success).toBe(true);
+  });
+
+  it('accepts unknown/future fields via passthrough', () => {
+    expect(DocumentNoteSchema.safeParse({ ...realData, futureField: 'x' }).success).toBe(true);
+  });
+
+  it('rejects genuine corruption: null root', () => {
+    expect(DocumentNoteSchema.safeParse(null).success).toBe(false);
+  });
+
+  it('rejects genuine corruption: updatedAt is not a number', () => {
+    expect(DocumentNoteSchema.safeParse({ ...realData, updatedAt: 'nope' }).success).toBe(false);
+  });
+
+  it('rejects genuine corruption: missing note', () => {
+    const { note: _note, ...noNote } = realData;
+    expect(DocumentNoteSchema.safeParse(noNote).success).toBe(false);
+  });
+});

--- a/src/types/schemas/documentNotes.schema.ts
+++ b/src/types/schemas/documentNotes.schema.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod';
+import type { DocumentNote } from '../documents';
+
+// Runtime schema for the 'document_notes' IndexedDB store (was a `z.custom` no-op).
+//
+// Design: validate STRUCTURE, not domain. IndexedDBService.validate() is
+// fail-closed (a parse failure drops the value on write / hides it on read),
+// so the schema must never reject genuine data. Therefore:
+//  - only structural anchors are required (note, updatedAt);
+//  - the optional fileName field stays optional here;
+//  - `.passthrough()` keeps unknown/future fields from failing a parse.
+// It still catches real corruption: null/non-object roots or a missing
+// `note`/`updatedAt`.
+
+export const DocumentNoteSchema = z
+  .object({
+    note: z.string(),
+    updatedAt: z.number(),
+    fileName: z.string().optional(),
+  })
+  .passthrough() as unknown as z.ZodType<DocumentNote>;

--- a/src/types/storage.ts
+++ b/src/types/storage.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { SyllabusRequirements, DocumentNote } from '../types/documents';
+import type { SyllabusRequirements } from '../types/documents';
 import { ExamSubjectSchema } from './schemas/exams.schema';
 import { BlockLessonSchema } from './schemas/schedule.schema';
 import { SubjectsDataSchema } from './schemas/subjects.schema';
@@ -12,6 +12,7 @@ import { StudyPlanOrDualLanguageSchema } from './schemas/studyPlan.schema';
 import { CvicneTestsSchema } from './schemas/cvicneTests.schema';
 import { OdevzdavarnySchema } from './schemas/odevzdavarny.schema';
 import { ErasmusCountryDataSchema } from './schemas/erasmus.schema';
+import { DocumentNoteSchema } from './schemas/documentNotes.schema';
 import type { CalendarCustomEvent } from '../types/calendarTypes';
 import type { IskamData } from './iskam';
 import type { SubjectZaznamnik } from './zaznamnik';
@@ -69,9 +70,6 @@ export const ScheduleSchema = z.array(BlockLessonSchema);
 
 // 'subjects' store - SubjectsData
 export const SubjectsSchema = SubjectsDataSchema;
-
-// 'document_notes' store - DocumentNote
-export const DocumentNoteSchema = z.custom<DocumentNote>();
 
 // 'note_images' store - normalized image blobs, keyed by content hash
 export const NoteImageSchema = z.object({


### PR DESCRIPTION
## Summary
- Replaces the `z.custom<DocumentNote>()` no-op schema for the `document_notes` IndexedDB store with a real structural Zod schema, following the `exams.schema.ts` template from #107.
- Only structural anchors are required (`note`, `updatedAt`); the optional `fileName` field stays optional; `.passthrough()` keeps unknown/future fields from failing a parse.
- `IndexedDBService.validate()` is fail-closed, so the schema is deliberately permissive — it must never drop genuine data, only catch real corruption (null root, non-number `updatedAt`, missing `note`).

## Test plan
- [x] `npm run typecheck` passes
- [x] New `documentNotes.schema.test.ts` covers real data, missing-optional-field, passthrough (all pass) and null/wrong-type/missing-anchor (all reject)
- [x] `npm run build` succeeds
- [x] Changed files pass `npx prettier --check` and lint clean with `--max-warnings=0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ux36EGBmB8BHKuAety2RDZ