### PR TITLE
feat(storage): real Zod schema for the 'syllabuses' IDB store (was z.custom union no-op)

### DIFF
--- a/src/types/schemas/__tests__/syllabus.schema.test.ts
+++ b/src/types/schemas/__tests__/syllabus.schema.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { SyllabusRequirementsSchema, SyllabusSchema } from '../syllabus.schema';
+import type { SyllabusRequirements } from '../../documents';
+
+const realData: SyllabusRequirements = {
+  version: 1,
+  language: 'cs',
+  courseId: '159410',
+  requirementsText: 'Požadavky na ukončení předmětu...',
+  requirementsTable: [
+    ['Typ', 'Body'],
+    ['Zkouška', '60'],
+  ],
+  courseInfo: {
+    courseName: 'Algoritmizace',
+    courseCode: 'DSND',
+    credits: '6',
+    garant: { name: 'prof. X', id: '123' },
+    teachers: [{ name: 'Dr. Y', roles: 'cvičící' }],
+    status: 'aktivní',
+  },
+  objectivesText: 'Studenti se naučí...',
+  contentText: 'Obsah předmětu...',
+};
+
+describe('SyllabusRequirementsSchema', () => {
+  it('accepts a representative real syllabus (never drops valid data)', () => {
+    expect(SyllabusRequirementsSchema.safeParse(realData).success).toBe(true);
+  });
+
+  it('accepts unknown/future IS fields via passthrough', () => {
+    const withExtra = {
+      ...realData,
+      futureField: 'x',
+      courseInfo: { ...realData.courseInfo, brandNewFlag: true },
+    };
+    expect(SyllabusRequirementsSchema.safeParse(withExtra).success).toBe(true);
+  });
+
+  it('accepts a minimal syllabus with only the required anchors', () => {
+    const minimal = { requirementsText: 'text', requirementsTable: [] };
+    expect(SyllabusRequirementsSchema.safeParse(minimal).success).toBe(true);
+  });
+
+  it('rejects genuine corruption: null root', () => {
+    expect(SyllabusRequirementsSchema.safeParse(null).success).toBe(false);
+  });
+
+  it('rejects genuine corruption: requirementsTable is not an array', () => {
+    expect(
+      SyllabusRequirementsSchema.safeParse({ ...realData, requirementsTable: 'nope' }).success
+    ).toBe(false);
+  });
+
+  it('rejects genuine corruption: missing requirementsText', () => {
+    const { requirementsText: _requirementsText, ...noText } = realData;
+    expect(SyllabusRequirementsSchema.safeParse(noText).success).toBe(false);
+  });
+});
+
+describe('SyllabusSchema (union used by the IDB store)', () => {
+  it('accepts the legacy single-language shape', () => {
+    expect(SyllabusSchema.safeParse(realData).success).toBe(true);
+  });
+
+  it('accepts the dual-language shape', () => {
+    expect(SyllabusSchema.safeParse({ cz: realData, en: realData }).success).toBe(true);
+  });
+
+  it('rejects genuine corruption: null', () => {
+    expect(SyllabusSchema.safeParse(null).success).toBe(false);
+  });
+});

--- a/src/types/schemas/syllabus.schema.ts
+++ b/src/types/schemas/syllabus.schema.ts
@@ -1,0 +1,58 @@
+import { z } from 'zod';
+import type { SyllabusRequirements } from '../documents';
+
+// Runtime schema for the 'syllabuses' IndexedDB store (was a `z.custom` union no-op).
+//
+// Design: validate STRUCTURE, not domain. IndexedDBService.validate() is
+// fail-closed (a parse failure drops the value on write / hides it on read),
+// so the schema must never reject genuine data. Therefore:
+//  - only structural anchors are required (requirementsText, requirementsTable);
+//  - every optional SyllabusRequirements/CourseMetadata field stays optional;
+//  - `.passthrough()` keeps unknown/future IS fields from failing a parse.
+// It still catches real corruption: null/non-object roots or a non-array
+// `requirementsTable`.
+
+const CourseMetadataSchema = z
+  .object({
+    courseName: z.string().nullable().optional(),
+    courseNameCs: z.string().nullable().optional(),
+    courseNameEn: z.string().nullable().optional(),
+    courseCode: z.string().nullable().optional(),
+    credits: z.string().nullable().optional(),
+    garant: z
+      .object({ name: z.string().nullable(), id: z.string().nullable().optional() })
+      .passthrough()
+      .nullable()
+      .optional(),
+    teachers: z
+      .array(
+        z
+          .object({ name: z.string(), id: z.string().nullable().optional(), roles: z.string() })
+          .passthrough()
+      )
+      .optional(),
+    status: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+export const SyllabusRequirementsSchema = z
+  .object({
+    version: z.number().optional(),
+    language: z.string().optional(),
+    courseId: z.string().optional(),
+    requirementsText: z.string(),
+    requirementsTable: z.array(z.array(z.string())),
+    courseInfo: CourseMetadataSchema.optional(),
+    objectivesText: z.string().nullable().optional(),
+    contentText: z.string().nullable().optional(),
+  })
+  .passthrough() as unknown as z.ZodType<SyllabusRequirements>;
+
+// 'syllabuses' store - can be legacy single-language or dual-language object
+export const SyllabusSchema = z.union([
+  SyllabusRequirementsSchema,
+  z.object({
+    cz: SyllabusRequirementsSchema,
+    en: SyllabusRequirementsSchema,
+  }),
+]);

--- a/src/types/storage.ts
+++ b/src/types/storage.ts
@@ -1,5 +1,4 @@
 import { z } from 'zod';
-import type { SyllabusRequirements } from '../types/documents';
 import { ExamSubjectSchema } from './schemas/exams.schema';
 import { BlockLessonSchema } from './schemas/schedule.schema';
 import { SubjectsDataSchema } from './schemas/subjects.schema';
@@ -13,13 +12,13 @@ import { CvicneTestsSchema } from './schemas/cvicneTests.schema';
 import { OdevzdavarnySchema } from './schemas/odevzdavarny.schema';
 import { ErasmusCountryDataSchema } from './schemas/erasmus.schema';
 import { DocumentNoteSchema } from './schemas/documentNotes.schema';
+import { SyllabusSchema } from './schemas/syllabus.schema';
 import type { CalendarCustomEvent } from '../types/calendarTypes';
 import type { IskamData } from './iskam';
 import type { SubjectZaznamnik } from './zaznamnik';
 
 // --- Base Types using Zod ---
 
-export const SyllabusRequirementsSchema = z.custom<SyllabusRequirements>();
 export const CalendarCustomEventSchema = z.object({
   id: z.string(),
   title: z.string(),
@@ -52,15 +51,6 @@ export const HiddenItemsSchema = z.object({
 
 // 'assessments' store - Legacy, kept for backward compatibility
 export const AssessmentsSchema = z.array(z.unknown());
-
-// 'syllabuses' store - can be legacy single-language or dual-language object
-export const SyllabusSchema = z.union([
-  SyllabusRequirementsSchema,
-  z.object({
-    cz: SyllabusRequirementsSchema,
-    en: SyllabusRequirementsSchema,
-  }),
-]);
 
 // 'exams' store - Array of ExamSubject
 export const ExamsSchema = z.array(ExamSubjectSchema);


### PR DESCRIPTION
## Summary
- Replaces the `z.union([z.custom<SyllabusRequirements>(), ...])` no-op schema for the `syllabuses` IndexedDB store with a real structural Zod schema, following the `exams.schema.ts` template from #107.
- Only structural anchors are required (`requirementsText`, `requirementsTable`); every optional `SyllabusRequirements`/`CourseMetadata` field stays optional; `.passthrough()` keeps unknown/future IS fields from failing a parse.
- Keeps the existing single-language vs. dual-language union shape (`SyllabusSchema`), just built on top of the new structural `SyllabusRequirementsSchema`.
- Note: `src/schemas/syllabusSchema.ts` already has a `SyllabusRequirementsSchema` too, but that one validates the raw IS API response (stricter). This PR's schema is a separate, more permissive one scoped to IDB storage round-trips — same pattern as the `subjects`/`subjectSchema.ts` split noted in #109.
- `IndexedDBService.validate()` is fail-closed, so the schema is deliberately permissive — it must never drop genuine data, only catch real corruption (null root, non-array `requirementsTable`, missing `requirementsText`).

## Test plan
- [x] `npm run typecheck` passes
- [x] New `syllabus.schema.test.ts` covers real data, passthrough, minimal-anchors-only, both union shapes (all pass) and null/wrong-type/missing-anchor (all reject)
- [x] `npm run build` succeeds
- [x] Changed files pass `npx prettier --check` and lint clean with `--max-warnings=0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ux36EGBmB8BHKuAety2RDZ