### PR TITLE
feat(messages): validate SyncedData primitives + reuse IskamDataSchema (Tier 1 #2a)

### DIFF
--- a/src/types/messages/__tests__/schema.syncUpdate.test.ts
+++ b/src/types/messages/__tests__/schema.syncUpdate.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { ContentToIframeSchema } from '../schema';
+
+// Exercises the two payloads deepened in Tier 1 #2a: REIS_SYNC_UPDATE.data
+// (SyncedData, coarse shape guards) and ISKAM_SYNC_UPDATE.data.iskamData
+// (reuses the strict store IskamDataSchema). The load-bearing property is
+// fail-closed safety: these must NEVER reject a real payload (whole-payload
+// blast radius = empty app), while still catching gross corruption.
+
+const parse = (m: unknown) => ContentToIframeSchema.safeParse(m).success;
+
+const realSync = {
+  type: 'REIS_SYNC_UPDATE',
+  data: {
+    lastSync: 1_720_000_000_000,
+    isSyncing: false,
+    schedule: [{ id: 'l1' }],
+    exams: [{ version: 1, id: 'EBC-ALG' }],
+    cvicneTests: [],
+    classmates: { 'EBC-ALG': { all: [] } },
+    zaznamnik: { 'EBC-ALG': null },
+    notes: { 'EBC-ALG': { f1: { note: 'x', fileName: 'a.pdf' } } },
+    subjects: { anyShape: true },
+    studyPlan: { cz: {}, en: {} },
+  },
+};
+
+const validIskamData = {
+  konta: [],
+  ubytovani: [],
+  reservations: [],
+  pendingPayments: [],
+  foodTransactions: [],
+  lastTopUp: null,
+  syncedAt: 0,
+};
+
+describe('REIS_SYNC_UPDATE (SyncedData) schema', () => {
+  it('accepts a representative real sync payload (never drops valid data)', () => {
+    expect(parse(realSync)).toBe(true);
+  });
+
+  it('accepts a minimal payload (only lastSync)', () => {
+    expect(parse({ type: 'REIS_SYNC_UPDATE', data: { lastSync: 1 } })).toBe(true);
+  });
+
+  it('accepts unknown/future top-level fields (additive tolerance)', () => {
+    expect(parse({ type: 'REIS_SYNC_UPDATE', data: { lastSync: 1, brandNewField: 42 } })).toBe(
+      true
+    );
+  });
+
+  it('accepts schedule as a dual-language {cz,en} object (domain fields stay permissive)', () => {
+    // syncService sends schedule as {cz,en}, not a flat array — must not drop it.
+    expect(
+      parse({ type: 'REIS_SYNC_UPDATE', data: { lastSync: 1, schedule: { cz: [], en: [] } } })
+    ).toBe(true);
+  });
+
+  it('rejects gross corruption: data is null', () => {
+    expect(parse({ type: 'REIS_SYNC_UPDATE', data: null })).toBe(false);
+  });
+
+  it('rejects gross corruption: lastSync is not a number', () => {
+    expect(parse({ type: 'REIS_SYNC_UPDATE', data: { lastSync: 'soon' } })).toBe(false);
+  });
+});
+
+describe('ISKAM_SYNC_UPDATE (iskamData) schema', () => {
+  const msg = (iskamData: unknown) => ({
+    type: 'ISKAM_SYNC_UPDATE',
+    data: { iskamData, isSyncing: false, error: null },
+  });
+
+  it('accepts valid IskamData', () => {
+    expect(parse(msg(validIskamData))).toBe(true);
+  });
+
+  it('accepts null iskamData (pre-first-sync state)', () => {
+    expect(parse(msg(null))).toBe(true);
+  });
+
+  it('rejects gross corruption: iskamData is a string', () => {
+    expect(parse(msg('nope'))).toBe(false);
+  });
+});

--- a/src/types/messages/schema.ts
+++ b/src/types/messages/schema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { IskamDataSchema } from '../storage';
 
 /**
  * Runtime schemas for the cross-context postMessage boundary (content script ↔
@@ -10,84 +11,152 @@ import { z } from 'zod';
  * stay lenient toward additive changes and never drop a valid message.
  */
 
+// SyncedData is the persisted sync payload pushed content→iframe on EVERY sync.
+// `isContentMessage` is fail-closed with WHOLE-PAYLOAD blast radius: if this
+// schema rejects, the entire sync update is dropped and the whole app shows an
+// empty state. So we guard ONLY the three stably-typed primitives (+ that the
+// envelope is an object). Every domain field is left permissive on purpose:
+// they are typed `unknown`/variable and legitimately arrive in different shapes
+// down different sync paths — e.g. syncService sends `exams` as a flat array but
+// `schedule` as a dual-language `{cz,en}` object, and the factory emits
+// `schedule: {}`. Their deep content is already validated at the IDB boundary
+// (StoreSchemas); guarding their shape here would risk dropping a whole payload.
+// z.object passes extra keys, so all of them (and future additions) flow through.
+const SyncedDataSchema = z.object({
+  lastSync: z.number().optional(),
+  isSyncing: z.boolean().optional(),
+  error: z.string().optional(),
+});
+
 const dataRequestType = z.enum(['schedule', 'exams', 'subjects', 'files', 'all']);
 const actionType = z.enum([
-    'register_exam', 'unregister_exam', 'toggle_outlook_sync', 'download_file',
-    'download_document', 'trigger_sync', 'trigger_drive_backup', 'push_notes',
-    'refresh_exams', 'open_url', 'logout',
+  'register_exam',
+  'unregister_exam',
+  'toggle_outlook_sync',
+  'download_file',
+  'download_document',
+  'trigger_sync',
+  'trigger_drive_backup',
+  'push_notes',
+  'refresh_exams',
+  'open_url',
+  'logout',
 ]);
 
 // ── Iframe → Content ────────────────────────────────────────────────────────
 const ReadyMsg = z.object({ type: z.literal('REIS_READY') });
-const RequestDataMsg = z.object({ type: z.literal('REIS_REQUEST_DATA'), dataType: dataRequestType });
+const RequestDataMsg = z.object({
+  type: z.literal('REIS_REQUEST_DATA'),
+  dataType: dataRequestType,
+});
 const FetchRequestMsg = z.object({
-    type: z.literal('REIS_FETCH'),
-    id: z.string(),
-    url: z.string(),
-    options: z.object({
-        method: z.string().optional(),
-        headers: z.record(z.string(), z.string()).optional(),
-        body: z.string().optional(),
-        responseType: z.enum(['text', 'image']).optional(),
-    }).optional(),
+  type: z.literal('REIS_FETCH'),
+  id: z.string(),
+  url: z.string(),
+  options: z
+    .object({
+      method: z.string().optional(),
+      headers: z.record(z.string(), z.string()).optional(),
+      body: z.string().optional(),
+      responseType: z.enum(['text', 'image']).optional(),
+    })
+    .optional(),
 });
 const ActionRequestMsg = z.object({
-    type: z.literal('REIS_ACTION'),
-    id: z.string(),
-    action: actionType,
-    payload: z.unknown(),
+  type: z.literal('REIS_ACTION'),
+  id: z.string(),
+  action: actionType,
+  payload: z.unknown(),
 });
 const IskamReadyMsg = z.object({ type: z.literal('ISKAM_READY') });
 const IskamFetchBlockMsg = z.object({
-    type: z.literal('ISKAM_FETCH_BLOCK'),
-    id: z.string(), blockId: z.string(), od: z.string(), doo: z.string(),
+  type: z.literal('ISKAM_FETCH_BLOCK'),
+  id: z.string(),
+  blockId: z.string(),
+  od: z.string(),
+  doo: z.string(),
 });
 
 export const IframeToContentSchema = z.discriminatedUnion('type', [
-    ReadyMsg, RequestDataMsg, FetchRequestMsg, ActionRequestMsg, IskamReadyMsg, IskamFetchBlockMsg,
+  ReadyMsg,
+  RequestDataMsg,
+  FetchRequestMsg,
+  ActionRequestMsg,
+  IskamReadyMsg,
+  IskamFetchBlockMsg,
 ]);
 
 // ── Content → Iframe ────────────────────────────────────────────────────────
 const DataResponseMsg = z.object({
-    type: z.literal('REIS_DATA'), dataType: dataRequestType, data: z.unknown(), error: z.string().optional(),
+  type: z.literal('REIS_DATA'),
+  dataType: dataRequestType,
+  data: z.unknown(),
+  error: z.string().optional(),
 });
 const FetchResultMsg = z.object({
-    type: z.literal('REIS_FETCH_RESULT'), id: z.string(), success: z.boolean(),
-    data: z.string().optional(), error: z.string().optional(),
+  type: z.literal('REIS_FETCH_RESULT'),
+  id: z.string(),
+  success: z.boolean(),
+  data: z.string().optional(),
+  error: z.string().optional(),
 });
 const ActionResultMsg = z.object({
-    type: z.literal('REIS_ACTION_RESULT'), id: z.string(), success: z.boolean(),
-    data: z.unknown().optional(), error: z.string().optional(),
+  type: z.literal('REIS_ACTION_RESULT'),
+  id: z.string(),
+  success: z.boolean(),
+  data: z.unknown().optional(),
+  error: z.string().optional(),
 });
-// `data` is the SyncedData envelope — validate it is an object (the consumer
-// casts and reads fields off it); domain fields stay unvalidated by design.
 const SyncUpdateMsg = z.object({
-    type: z.literal('REIS_SYNC_UPDATE'),
-    data: z.object({ lastSync: z.number().optional() }),
+  type: z.literal('REIS_SYNC_UPDATE'),
+  data: SyncedDataSchema,
 });
 const PopupStateMsg = z.object({ type: z.literal('REIS_POPUP_STATE'), open: z.boolean() });
-const NavChild = z.object({ id: z.string(), label: z.string(), labelEn: z.string().optional(), href: z.string() });
+const NavChild = z.object({
+  id: z.string(),
+  label: z.string(),
+  labelEn: z.string().optional(),
+  href: z.string(),
+});
 const NavCategory = z.object({
-    id: z.string(), label: z.string(), icon: z.string().optional(),
-    expandable: z.boolean().optional(), children: z.array(NavChild),
+  id: z.string(),
+  label: z.string(),
+  icon: z.string().optional(),
+  expandable: z.boolean().optional(),
+  children: z.array(NavChild),
 });
 const NavMenuMsg = z.object({ type: z.literal('REIS_NAV_MENU'), categories: z.array(NavCategory) });
 const IskamSyncUpdateMsg = z.object({
-    type: z.literal('ISKAM_SYNC_UPDATE'),
-    data: z.object({
-        iskamData: z.unknown(),
-        isSyncing: z.boolean(),
-        error: z.enum(['auth', 'network']).nullable(),
-    }),
+  type: z.literal('ISKAM_SYNC_UPDATE'),
+  data: z.object({
+    // Reuses the store's IskamDataSchema — safe because it's a single
+    // coherent object gated identically at the IDB 'iskam' boundary, so no
+    // data that currently reaches IDB is newly dropped here. Nullable: the
+    // payload carries null before the first successful ISKAM sync.
+    iskamData: IskamDataSchema.nullable(),
+    isSyncing: z.boolean(),
+    error: z.enum(['auth', 'network']).nullable(),
+  }),
 });
 const IskamBlockResultMsg = z.object({
-    type: z.literal('ISKAM_BLOCK_RESULT'), id: z.string(), rooms: z.array(z.unknown()),
+  type: z.literal('ISKAM_BLOCK_RESULT'),
+  id: z.string(),
+  rooms: z.array(z.unknown()),
 });
 const TelemetryErrorMsg = z.object({
-    type: z.literal('REIS_TELEMETRY_ERROR'), context: z.string(), message: z.string(),
+  type: z.literal('REIS_TELEMETRY_ERROR'),
+  context: z.string(),
+  message: z.string(),
 });
 
 export const ContentToIframeSchema = z.discriminatedUnion('type', [
-    DataResponseMsg, FetchResultMsg, ActionResultMsg, SyncUpdateMsg, PopupStateMsg,
-    NavMenuMsg, IskamSyncUpdateMsg, IskamBlockResultMsg, TelemetryErrorMsg,
+  DataResponseMsg,
+  FetchResultMsg,
+  ActionResultMsg,
+  SyncUpdateMsg,
+  PopupStateMsg,
+  NavMenuMsg,
+  IskamSyncUpdateMsg,
+  IskamBlockResultMsg,
+  TelemetryErrorMsg,
 ]);


### PR DESCRIPTION
**Tier 1 #2a** — deepens the postMessage boundary's two sync payloads (was the last unguarded IPC surface after the IDB StoreSchemas pass).

### REIS_SYNC_UPDATE.data (SyncedData)
Guards the three **stably-typed primitives** (`lastSync`, `isSyncing`, `error`) + that the envelope is an object. **Domain fields stay permissive by design** — this is the load-bearing judgment call: `isContentMessage` is **fail-closed with whole-payload blast radius**, and the domain fields legitimately arrive in different shapes down different sync paths (`syncService` sends `exams` as a flat array but `schedule` as a dual-language `{cz,en}` object; the factory emits `schedule: {}`). Their deep content is already validated at the IDB boundary, so guarding shape here would risk dropping an entire sync → empty app. The existing factory test (`schedule: {}`) caught an earlier over-strict draft.

### ISKAM_SYNC_UPDATE.data.iskamData
Reuses the store's **`IskamDataSchema`** (was `z.unknown()`). Safe + consistent: the same schema already gates the IDB `iskam` store, so no data that currently reaches IDB is newly dropped. Nullable for the pre-first-sync state.

### Test
Both-directions: real payloads (incl. dual-language `schedule`, valid + null `iskamData`) pass; corruption (`data: null`, non-number `lastSync`, string `iskamData`) rejected.

Verified: typecheck 0, **full suite 1157 pass**, build ✔.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened message validation for sync updates, rejecting malformed payloads and handling pre-first-sync states correctly.
  * Improved support for expected optional fields and future-safe extra fields in message data.
  * Added coverage for valid and invalid sync message scenarios to reduce regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->