### PR TITLE
fix(society-admin): make map authoring interactions give visible feedback

### DIFF
--- a/src/components/CampusMap/ComposerRoomSearch.tsx
+++ b/src/components/CampusMap/ComposerRoomSearch.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { Check, MapPin, Search } from 'lucide-react';
 import roomsIndexJson from '../../data/map/rooms-index.json';
 import buildingsJson from '../../data/map/buildings.json';
-import { roomCodeToCoord } from './mapHelpers';
+import { roomCodeToCoord, searchRooms } from './mapHelpers';
 import type { RoomIndexEntry, BuildingsMeta } from '../../types/campusMap';
 
 const INDEX = roomsIndexJson as RoomIndexEntry[];
@@ -34,11 +34,9 @@ export function ComposerRoomSearch({
   }
 
   const ql = q.trim().toLowerCase();
-  const matches = ql
-    ? INDEX.filter(
-        (r) => r.code.toLowerCase().includes(ql) || r.name.toLowerCase().includes(ql)
-      ).slice(0, 6)
-    : [];
+  // Same ranked search as the top-left map search — exact hall names ("Q01")
+  // beat the dotted offices (Q01.09…) that precede them in the index.
+  const matches = searchRooms(q, INDEX);
 
   return (
     <div className="mt-2">

--- a/src/components/CampusMap/DraftPin.tsx
+++ b/src/components/CampusMap/DraftPin.tsx
@@ -1,0 +1,49 @@
+import { MapPin } from 'lucide-react';
+
+// The in-progress event location, shown while the composer is open and a point
+// has been placed. Distinct from saved EventPins (which are white emoji discs):
+// a filled, society-coloured teardrop with a pulsing halo so a freshly-placed
+// point is unmistakable on the map. Clicking it re-enters placing mode so the
+// society can nudge the location. (x, y) is a Leaflet LAYER point, exactly like
+// EventPin, so it rides pans/zooms with the basemap.
+export function DraftPin({
+  x,
+  y,
+  color,
+  label,
+  onClick,
+}: {
+  x: number;
+  y: number;
+  color: string;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className="pointer-events-auto absolute left-0 top-0 flex items-center justify-center leaflet-zoom-animated"
+      style={{ transform: `translate(${x}px, ${y}px) translate(-50%, -100%)` }}
+      title={label}
+      aria-label={label}
+      data-draft-pin="true"
+      onClick={onClick}
+    >
+      <span
+        className="absolute -z-10 rounded-full motion-safe:animate-ping"
+        style={{ width: 34, height: 34, backgroundColor: color, opacity: 0.35, bottom: 2 }}
+      />
+      <span
+        className="flex items-center justify-center rounded-full ring-2 ring-white"
+        style={{
+          width: 30,
+          height: 30,
+          backgroundColor: color,
+          boxShadow: '0 2px 6px rgba(0,0,0,.35)',
+        }}
+      >
+        <MapPin size={17} color="#fff" strokeWidth={2.5} />
+      </span>
+    </button>
+  );
+}

--- a/src/components/CampusMap/EventComposer.tsx
+++ b/src/components/CampusMap/EventComposer.tsx
@@ -6,6 +6,11 @@ import { createPost, updatePost, type PostInput } from '../../api/societyPosts';
 import { isScheduledEvent, goLiveDate } from './eventWindow';
 import { MiniCalendar } from './MiniCalendar';
 import { ComposerRoomSearch } from './ComposerRoomSearch';
+import { roomCodeToName } from './mapHelpers';
+import roomsIndexJson from '../../data/map/rooms-index.json';
+import type { RoomIndexEntry } from '../../types/campusMap';
+
+const INDEX = roomsIndexJson as RoomIndexEntry[];
 
 // Create/edit a society event. No <form> submit (sandboxed iframe blocks it);
 // Publish/Save is a button. Venue is either a free-placed off-campus point
@@ -35,7 +40,13 @@ export function EventComposer({ onDone }: { onDone: () => void }) {
   );
   const [room, setRoom] = useState<{ code: string; name: string; coord: [number, number] } | null>(
     editing && editing.venueKind === 'campus' && editing.roomCode && editing.coord
-      ? { code: editing.roomCode, name: editing.location ?? editing.roomCode, coord: editing.coord }
+      ? {
+          code: editing.roomCode,
+          // roomCode is the IS-internal code ("BA39N1009"); show the hall name
+          // ("Q01") in the picked-room chip, same as the search results do.
+          name: editing.location ?? roomCodeToName(editing.roomCode, INDEX),
+          coord: editing.coord,
+        }
       : null
   );
   const [busy, setBusy] = useState(false);

--- a/src/components/CampusMap/EventDetailCard.tsx
+++ b/src/components/CampusMap/EventDetailCard.tsx
@@ -4,10 +4,15 @@ import { CATEGORY_EMOJI_SRC } from '../../data/eventCategories';
 import { useAppStore } from '../../store/useAppStore';
 import { useTranslation } from '../../hooks/useTranslation';
 import { societyById } from '../../data/societies';
+import roomsIndexJson from '../../data/map/rooms-index.json';
+import { roomCodeToName } from './mapHelpers';
+import type { RoomIndexEntry } from '../../types/campusMap';
 import { parseEventDate } from './eventHelpers';
 import { EventRsvp } from './EventRsvp';
 import { deletePost } from '../../api/societyPosts';
 import type { MapEvent } from '../../types/events';
+
+const INDEX = roomsIndexJson as RoomIndexEntry[];
 
 // Bottom-left detail body for a selected society event. Minimal and info-first:
 // a small society avatar + title + host, then the facts (when / what / where),
@@ -95,7 +100,7 @@ export function EventDetailCard({ event }: { event: MapEvent }) {
               className="flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
               onClick={() => focusRoom(event.roomCode!)}
             >
-              <MapPin size={13} className="flex-shrink-0" /> {event.roomCode}
+              <MapPin size={13} className="flex-shrink-0" /> {roomCodeToName(event.roomCode, INDEX)}
             </button>
           ) : event.location ? (
             <div className="flex items-center gap-1.5 text-sm text-base-content/70">

--- a/src/components/CampusMap/EventDetailCard.tsx
+++ b/src/components/CampusMap/EventDetailCard.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { MapPin, ExternalLink, Clock } from 'lucide-react';
 import { CATEGORY_EMOJI_SRC } from '../../data/eventCategories';
 import { useAppStore } from '../../store/useAppStore';
@@ -9,22 +8,17 @@ import { roomCodeToName } from './mapHelpers';
 import type { RoomIndexEntry } from '../../types/campusMap';
 import { parseEventDate } from './eventHelpers';
 import { EventRsvp } from './EventRsvp';
-import { deletePost } from '../../api/societyPosts';
 import type { MapEvent } from '../../types/events';
 
 const INDEX = roomsIndexJson as RoomIndexEntry[];
 
-// Bottom-left detail body for a selected society event. Minimal and info-first:
-// a small society avatar + title + host, then the facts (when / what / where),
-// then the social block (attendance + Going/Interested RSVP) and More info. No
-// decorative colour band — the avatar carries the brand, the text carries the job.
+// Bottom-left detail body for a selected event — a read-only preview shown to
+// students and societies alike: a small society avatar + title + host, then the
+// facts (when / what / where), the social block (attendance + RSVP), and More
+// info. A society edits/deletes its own events from the "Moje akce" panel, so
+// this card carries no authoring controls (keeps management in one place).
 export function EventDetailCard({ event }: { event: MapEvent }) {
   const focusRoom = useAppStore((s) => s.focusRoomByCode);
-  const mode = useAppStore((s) => s.mapMode);
-  const myAssoc = useAppStore((s) => s.adminAssociationId);
-  const openComposer = useAppStore((s) => s.openComposer);
-  const loadSocietyPosts = useAppStore((s) => s.loadSocietyPosts);
-  const clearMapSelection = useAppStore((s) => s.clearMapSelection);
   const { t, language } = useTranslation();
   const soc = societyById(event.societyId);
   const locale = language === 'en' ? 'en-US' : 'cs-CZ';
@@ -33,25 +27,6 @@ export function EventDetailCard({ event }: { event: MapEvent }) {
     day: 'numeric',
     month: 'long',
   });
-  const mine = mode === 'society' && event.societyId === myAssoc;
-  const [confirming, setConfirming] = useState(false);
-  const [deleting, setDeleting] = useState(false);
-  const removeEvent = async () => {
-    if (deleting) return;
-    if (!confirming) {
-      setConfirming(true);
-      return;
-    }
-    setDeleting(true);
-    const res = await deletePost(event.id);
-    setDeleting(false);
-    if (res.error) {
-      setConfirming(false);
-      return;
-    }
-    clearMapSelection();
-    await loadSocietyPosts();
-  };
 
   return (
     <div className="overflow-hidden rounded-lg border border-base-300 bg-base-100">
@@ -112,26 +87,6 @@ export function EventDetailCard({ event }: { event: MapEvent }) {
         <div className="border-t border-base-300 pt-3">
           <EventRsvp eventId={event.id} accent={soc.color} />
         </div>
-
-        {mine && (
-          <div className="flex gap-2 border-t border-base-300 pt-3">
-            <button
-              type="button"
-              className="btn btn-outline btn-sm flex-1"
-              onClick={() => openComposer(event.id)}
-            >
-              {t('map.edit')}
-            </button>
-            <button
-              type="button"
-              className="btn btn-outline btn-error btn-sm flex-1"
-              disabled={deleting}
-              onClick={removeEvent}
-            >
-              {confirming ? t('map.deleteConfirm') : t('map.delete')}
-            </button>
-          </div>
-        )}
 
         {event.url && (
           <a

--- a/src/components/CampusMap/EventLayer.tsx
+++ b/src/components/CampusMap/EventLayer.tsx
@@ -6,6 +6,8 @@ import { useTranslation } from '../../hooks/useTranslation';
 import { filterEvents, groupEventsByVenue, type VenueGroup } from './eventHelpers';
 import { subscribeMapInstance } from './mapInstance';
 import { EventPin } from './EventPin';
+import { DraftPin } from './DraftPin';
+import { societyById } from '../../data/societies';
 import { isScheduledEvent } from './eventWindow';
 
 interface Placed {
@@ -44,9 +46,17 @@ export function EventLayer() {
   const activeBuildingId = useAppStore((s) => s.activeBuildingId);
   const selection = useAppStore((s) => s.mapSelection);
   const focusEvent = useAppStore((s) => s.focusEventById);
-  const { language } = useTranslation();
+  // The in-progress event location: only meaningful while the composer is open.
+  const composerOpen = useAppStore((s) => s.composerOpen);
+  const draftCoord = useAppStore((s) => s.draftCoord);
+  const assocId = useAppStore((s) => s.adminAssociationId);
+  const beginPlacing = useAppStore((s) => s.beginPlacing);
+  const { language, t } = useTranslation();
   const [placed, setPlaced] = useState<Placed[]>([]);
+  const [draftPt, setDraftPt] = useState<{ x: number; y: number } | null>(null);
   const [pane, setPane] = useState<HTMLElement | null>(null);
+  const activeDraft = composerOpen ? draftCoord : null;
+  const draftColor = (assocId ? societyById(assocId)?.color : null) ?? '#0046a0';
   // Events are loaded by the store (initializeStore + language handlers), not a
   // fetch-in-useEffect here — this layer stays presentational over store state.
 
@@ -57,11 +67,18 @@ export function EventLayer() {
 
   // Re-place pins when the visible groups change (filter toggle, data load).
   const groupsRef = useRef(groups);
+  const draftRef = useRef<[number, number] | null>(activeDraft);
   const scheduleRef = useRef<(() => void) | null>(null);
   useEffect(() => {
     groupsRef.current = groups;
     scheduleRef.current?.();
   }, [groups]);
+  // Re-project the draft point when it's placed/moved/cleared or the composer
+  // opens/closes, so the pin appears (and disappears) immediately.
+  useEffect(() => {
+    draftRef.current = activeDraft;
+    scheduleRef.current?.();
+  }, [activeDraft]);
 
   useEffect(() => {
     let map: L.Map | null = null;
@@ -72,6 +89,7 @@ export function EventLayer() {
     const recompute = () => {
       if (!map) {
         setPlaced([]);
+        setDraftPt(null);
         return;
       }
       placedZoom = map.getZoom();
@@ -80,6 +98,11 @@ export function EventLayer() {
         return { key: g.key, x: pt.x, y: pt.y, group: g };
       });
       setPlaced(next);
+      const d = draftRef.current;
+      if (d) {
+        const pt = map.latLngToLayerPoint([d[1], d[0]]);
+        setDraftPt({ x: pt.x, y: pt.y });
+      } else setDraftPt(null);
     };
     scheduleRef.current = recompute;
     // Pure panning needs no handler — the pane is a child of the map pane and
@@ -104,6 +127,11 @@ export function EventLayer() {
           return { key: g.key, x: pt.x, y: pt.y, group: g };
         })
       );
+      const d = draftRef.current;
+      if (d) {
+        const pt = proj._latLngToNewLayerPoint([d[1], d[0]], e.zoom, e.center).round();
+        setDraftPt({ x: pt.x, y: pt.y });
+      }
     };
     const bind = (m: L.Map) => {
       const p = m.getPane(PANE_NAME) ?? m.createPane(PANE_NAME);
@@ -127,6 +155,7 @@ export function EventLayer() {
       else {
         setPane(null);
         setPlaced([]);
+        setDraftPt(null);
       }
     });
     return () => {
@@ -136,7 +165,9 @@ export function EventLayer() {
     };
   }, []);
 
-  if (activeBuildingId !== null || !pane || placed.length === 0) return null;
+  // The draft pin can be the only thing to show (placing a first event with no
+  // saved events yet), so don't bail on an empty `placed` when a draft exists.
+  if (activeBuildingId !== null || !pane || (placed.length === 0 && !draftPt)) return null;
   const selectedId = selection?.kind === 'event' ? selection.event.id : null;
 
   return createPortal(
@@ -153,6 +184,15 @@ export function EventLayer() {
           onSelect={focusEvent}
         />
       ))}
+      {draftPt && (
+        <DraftPin
+          x={draftPt.x}
+          y={draftPt.y}
+          color={draftColor}
+          label={t('map.draftPinLabel')}
+          onClick={beginPlacing}
+        />
+      )}
     </>,
     pane
   );

--- a/src/components/CampusMap/EventRow.tsx
+++ b/src/components/CampusMap/EventRow.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import { MapPin } from 'lucide-react';
 import { CATEGORY_EMOJI_SRC } from '../../data/eventCategories';
 import { relativeDayLabel } from './eventHelpers';
@@ -6,7 +7,9 @@ import type { MapEvent } from '../../types/events';
 // Shared list row for both the public Events tab (EventsList) and the
 // organizer's own-events panel (MyEventsPanel). `subline` lets the caller
 // override the default "day · time" line — e.g. MyEventsPanel shows a
-// "goes live" countdown for scheduled events instead.
+// "goes live" countdown for scheduled events instead. `actions` renders
+// row-level controls (edit/delete) as siblings of the clickable body: the
+// body stays a single <button>, so the controls can't nest inside it.
 export function EventRow({
   event,
   locale,
@@ -14,6 +17,7 @@ export function EventRow({
   selected,
   onClick,
   subline,
+  actions,
 }: {
   event: MapEvent;
   locale: string;
@@ -21,38 +25,44 @@ export function EventRow({
   selected: boolean;
   onClick: () => void;
   subline?: string;
+  actions?: ReactNode;
 }) {
   const day =
     subline ?? `${relativeDayLabel(event.date, locale, t)}${event.time ? ` · ${event.time}` : ''}`;
   return (
-    <button
-      onClick={onClick}
-      className={`flex w-full items-center gap-3 border-l-2 px-3 py-2 text-left transition-colors ${
+    <div
+      className={`flex items-stretch border-l-2 transition-colors ${
         selected ? 'border-primary bg-primary/10' : 'border-transparent hover:bg-base-200'
       }`}
     >
-      {/* poster thumbnail; falls back to a neutral tile with the colour emoji */}
-      <span className="h-[52px] w-[52px] flex-shrink-0 overflow-hidden rounded-lg">
-        {event.imageUrl ? (
-          <img src={event.imageUrl} alt="" className="h-full w-full object-cover" />
-        ) : (
-          <span className="flex h-full w-full items-center justify-center bg-base-200">
-            <img src={CATEGORY_EMOJI_SRC[event.category]} alt="" className="h-7 w-7" />
-          </span>
-        )}
-      </span>
-      <span className="min-w-0 flex-1">
-        <span className="block truncate text-[13px] font-semibold text-base-content">
-          {event.title}
+      <button
+        onClick={onClick}
+        className="flex min-w-0 flex-1 items-center gap-3 px-3 py-2 text-left"
+      >
+        {/* poster thumbnail; falls back to a neutral tile with the colour emoji */}
+        <span className="h-[52px] w-[52px] flex-shrink-0 overflow-hidden rounded-lg">
+          {event.imageUrl ? (
+            <img src={event.imageUrl} alt="" className="h-full w-full object-cover" />
+          ) : (
+            <span className="flex h-full w-full items-center justify-center bg-base-200">
+              <img src={CATEGORY_EMOJI_SRC[event.category]} alt="" className="h-7 w-7" />
+            </span>
+          )}
         </span>
-        <span className="mt-0.5 block truncate text-[11px] text-base-content/60">{day}</span>
-        {event.location && (
-          <span className="mt-0.5 flex items-center gap-1 text-[11px] text-base-content/60">
-            <MapPin size={11} className="flex-shrink-0" />
-            <span className="truncate">{event.location}</span>
+        <span className="min-w-0 flex-1">
+          <span className="block truncate text-[13px] font-semibold text-base-content">
+            {event.title}
           </span>
-        )}
-      </span>
-    </button>
+          <span className="mt-0.5 block truncate text-[11px] text-base-content/60">{day}</span>
+          {event.location && (
+            <span className="mt-0.5 flex items-center gap-1 text-[11px] text-base-content/60">
+              <MapPin size={11} className="flex-shrink-0" />
+              <span className="truncate">{event.location}</span>
+            </span>
+          )}
+        </span>
+      </button>
+      {actions && <div className="flex flex-shrink-0 items-center gap-0.5 pr-1.5">{actions}</div>}
+    </div>
   );
 }

--- a/src/components/CampusMap/MapSidePanel.tsx
+++ b/src/components/CampusMap/MapSidePanel.tsx
@@ -1,8 +1,5 @@
-import type { ReactNode } from 'react';
-import { MapPin, PartyPopper, Sparkles } from 'lucide-react';
 import { useAppStore } from '../../store/useAppStore';
 import { useTranslation } from '../../hooks/useTranslation';
-import { societyById } from '../../data/societies';
 import { LandmarkPicker } from './LandmarkPicker';
 import { EventsList } from './EventsList';
 import { MyEventsPanel } from './MyEventsPanel';
@@ -21,12 +18,10 @@ export function MapSidePanel() {
   const tab = useAppStore((s) => s.mapPanelTab);
   const setTab = useAppStore((s) => s.setMapPanelTab);
   const role = useAppStore((s) => s.adminRole);
-  const assocId = useAppStore((s) => s.adminAssociationId);
   const { t } = useTranslation();
 
   const isSociety = mode === 'society';
   const active: TabKey = isSociety ? 'mine' : tab;
-  const soc = assocId ? societyById(assocId) : null;
 
   const select = (key: TabKey) => {
     if (key === 'mine') {
@@ -37,28 +32,29 @@ export function MapSidePanel() {
     setTab(key);
   };
 
-  const tabBtn = (key: TabKey, icon: ReactNode, label: string) => (
+  // Text-only, equal-width tabs so all three fit one row in the narrow panel:
+  // an icon + label ("Moje akce" / "My events") wraps and overflows the tab at
+  // a third of 288px. The labels are self-explanatory without icons.
+  const tabBtn = (key: TabKey, label: string) => (
     <button
       type="button"
       role="tab"
       id={`map-tab-${key}`}
       aria-selected={active === key}
       aria-controls="map-tabpanel"
-      className={`tab gap-1.5 ${active === key ? 'tab-active font-semibold' : ''}`}
+      className={`tab flex-1 whitespace-nowrap px-1 ${active === key ? 'tab-active font-semibold' : ''}`}
       onClick={() => select(key)}
     >
-      {icon}
       {label}
     </button>
   );
 
   return (
-    <div className="flex max-h-[80vh] w-64 flex-col overflow-hidden rounded-box border border-base-300 bg-base-100/95 shadow-popover-heavy backdrop-blur-sm">
-      <div role="tablist" className="tabs tabs-box tabs-sm m-1 mb-0 shrink-0">
-        {tabBtn('events', <PartyPopper size={13} />, t('map.events'))}
-        {tabBtn('places', <MapPin size={13} />, t('map.places'))}
-        {role === 'association' &&
-          tabBtn('mine', <Sparkles size={13} style={{ color: soc?.color }} />, t('map.myEvents'))}
+    <div className="flex max-h-[80vh] w-72 flex-col overflow-hidden rounded-box border border-base-300 bg-base-100/95 shadow-popover-heavy backdrop-blur-sm">
+      <div role="tablist" className="tabs tabs-box tabs-sm m-1 mb-0 shrink-0 flex-nowrap">
+        {tabBtn('events', t('map.events'))}
+        {tabBtn('places', t('map.places'))}
+        {role === 'association' && tabBtn('mine', t('map.myEvents'))}
       </div>
       <div
         id="map-tabpanel"

--- a/src/components/CampusMap/MiniCalendar.tsx
+++ b/src/components/CampusMap/MiniCalendar.tsx
@@ -5,6 +5,8 @@ import { toISO, parseISO, monthMatrix, addMonths } from './calendar';
 
 // Wide enough for seven comfortable circular day cells plus the card padding.
 const POPOVER_WIDTH = 288;
+// Minimum gap the popover keeps from the viewport edge.
+const MARGIN = 8;
 
 // Monday-first short weekday names in the caller's locale. 2024-01-01 is a
 // Monday, so offsetting from it gives Mon…Sun in whatever language the app is in
@@ -51,14 +53,19 @@ export function MiniCalendar({
   const monthName = new Date(view.y, view.m0, 1).toLocaleDateString(locale, { month: 'long' });
 
   // Anchor the popover under the trigger in viewport coords. It's portalled to
-  // <body> so the side-panel's overflow-hidden can't clip it; clamp to the
-  // viewport so it never spills off the right edge.
+  // <body> so the side-panel's overflow-hidden can't clip it. Right-align it to
+  // the trigger (the popover is wider than the field) so it keeps the panel's
+  // own inset from the edge instead of bleeding to the border; clamp into the
+  // viewport with a margin as a fallback.
   const updatePos = useCallback(() => {
     const el = btnRef.current;
     if (!el) return;
     const r = el.getBoundingClientRect();
-    const left = Math.min(r.left, window.innerWidth - POPOVER_WIDTH - 8);
-    setPos({ top: r.bottom + 4, left: Math.max(8, left) });
+    const left = Math.max(
+      MARGIN,
+      Math.min(r.right - POPOVER_WIDTH, window.innerWidth - POPOVER_WIDTH - MARGIN)
+    );
+    setPos({ top: r.bottom + 6, left });
   }, []);
 
   useEffect(() => {

--- a/src/components/CampusMap/MiniCalendar.tsx
+++ b/src/components/CampusMap/MiniCalendar.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { Calendar, ChevronDown, ChevronLeft, ChevronRight } from 'lucide-react';
 import { toISO, parseISO, monthMatrix, addMonths } from './calendar';
@@ -7,6 +7,9 @@ import { toISO, parseISO, monthMatrix, addMonths } from './calendar';
 const POPOVER_WIDTH = 288;
 // Minimum gap the popover keeps from the viewport edge.
 const MARGIN = 8;
+// Fallback height (header + weekday row + up to 6 day rows + padding) used only
+// until the popover has mounted and its real height can be measured.
+const POPOVER_EST_HEIGHT = 340;
 
 // Monday-first short weekday names in the caller's locale. 2024-01-01 is a
 // Monday, so offsetting from it gives Mon…Sun in whatever language the app is in
@@ -52,11 +55,13 @@ export function MiniCalendar({
     : placeholder;
   const monthName = new Date(view.y, view.m0, 1).toLocaleDateString(locale, { month: 'long' });
 
-  // Anchor the popover under the trigger in viewport coords. It's portalled to
+  // Anchor the popover to the trigger in viewport coords. It's portalled to
   // <body> so the side-panel's overflow-hidden can't clip it. Right-align it to
   // the trigger (the popover is wider than the field) so it keeps the panel's
   // own inset from the edge instead of bleeding to the border; clamp into the
-  // viewport with a margin as a fallback.
+  // viewport with a margin as a fallback. Vertically it prefers to sit below the
+  // trigger, but flips above (or clamps) when a low trigger would push the card
+  // off the bottom of the screen.
   const updatePos = useCallback(() => {
     const el = btnRef.current;
     if (!el) return;
@@ -65,10 +70,20 @@ export function MiniCalendar({
       MARGIN,
       Math.min(r.right - POPOVER_WIDTH, window.innerWidth - POPOVER_WIDTH - MARGIN)
     );
-    setPos({ top: r.bottom + 6, left });
+    const popH = popRef.current?.offsetHeight || POPOVER_EST_HEIGHT;
+    const below = r.bottom + 6;
+    const above = r.top - 6 - popH;
+    // Flip above only when below overflows AND above actually has room.
+    const top =
+      below + popH > window.innerHeight - MARGIN && above >= MARGIN
+        ? above
+        : Math.max(MARGIN, Math.min(below, window.innerHeight - popH - MARGIN));
+    setPos({ top, left });
   }, []);
 
-  useEffect(() => {
+  // Layout effect (not useEffect): position the popover before the browser
+  // paints, so it never flashes at its initial {0,0} for a frame.
+  useLayoutEffect(() => {
     if (!open) return;
     updatePos();
     const onPointerDown = (e: MouseEvent) => {

--- a/src/components/CampusMap/MiniCalendar.tsx
+++ b/src/components/CampusMap/MiniCalendar.tsx
@@ -3,8 +3,8 @@ import { createPortal } from 'react-dom';
 import { Calendar, ChevronDown, ChevronLeft, ChevronRight } from 'lucide-react';
 import { toISO, parseISO, monthMatrix, addMonths } from './calendar';
 
-// The 7×32px day grid + padding needs this much; narrower and the grid wraps.
-const POPOVER_WIDTH = 256;
+// Wide enough for seven comfortable circular day cells plus the card padding.
+const POPOVER_WIDTH = 288;
 
 // Monday-first short weekday names in the caller's locale. 2024-01-01 is a
 // Monday, so offsetting from it gives Mon…Sun in whatever language the app is in
@@ -36,6 +36,10 @@ export function MiniCalendar({
   const btnRef = useRef<HTMLButtonElement>(null);
   const popRef = useRef<HTMLDivElement>(null);
   const dow = useMemo(() => weekdayNames(locale), [locale]);
+  const todayISO = useMemo(() => {
+    const n = new Date();
+    return toISO(n.getFullYear(), n.getMonth(), n.getDate());
+  }, []);
   const label = value
     ? new Date(`${value}T00:00:00`).toLocaleDateString(locale, {
         weekday: 'short',
@@ -44,10 +48,7 @@ export function MiniCalendar({
         year: 'numeric',
       })
     : placeholder;
-  const monthLabel = new Date(view.y, view.m0, 1).toLocaleDateString(locale, {
-    month: 'long',
-    year: 'numeric',
-  });
+  const monthName = new Date(view.y, view.m0, 1).toLocaleDateString(locale, { month: 'long' });
 
   // Anchor the popover under the trigger in viewport coords. It's portalled to
   // <body> so the side-panel's overflow-hidden can't clip it; clamp to the
@@ -93,7 +94,7 @@ export function MiniCalendar({
         className={`input input-bordered flex w-full items-center gap-2 ${value ? '' : 'text-base-content/50'}`}
         onClick={() => setOpen((o) => !o)}
       >
-        <Calendar size={16} className="opacity-70" />
+        <Calendar size={16} className={value ? 'text-primary' : 'opacity-70'} />
         <span className="truncate">{label}</span>
         <ChevronDown
           size={16}
@@ -107,44 +108,59 @@ export function MiniCalendar({
             className="fixed z-[9999] rounded-box border border-base-300 bg-base-100 p-3 shadow-popover-heavy"
             style={{ top: pos.top, left: pos.left, width: POPOVER_WIDTH }}
           >
-            <div className="mb-2 flex items-center justify-between">
+            <div className="mb-3 flex items-center justify-between">
               <button
                 type="button"
-                className="btn btn-ghost btn-xs"
+                className="flex h-7 w-7 items-center justify-center rounded-full text-base-content/70 transition-colors hover:bg-base-content/10"
                 aria-label={t('map.prevMonth')}
                 onClick={() => setView((v) => addMonths(v.y, v.m0, -1))}
               >
                 <ChevronLeft size={16} />
               </button>
-              <span className="text-sm font-semibold capitalize">{monthLabel}</span>
+              <span className="text-sm">
+                <span className="font-semibold capitalize text-base-content">{monthName}</span>{' '}
+                <span className="text-base-content/50">{view.y}</span>
+              </span>
               <button
                 type="button"
-                className="btn btn-ghost btn-xs"
+                className="flex h-7 w-7 items-center justify-center rounded-full text-base-content/70 transition-colors hover:bg-base-content/10"
                 aria-label={t('map.nextMonth')}
                 onClick={() => setView((v) => addMonths(v.y, v.m0, 1))}
               >
                 <ChevronRight size={16} />
               </button>
             </div>
-            <div className="grid grid-cols-7 gap-0.5 text-center text-[10px] font-bold text-base-content/50">
+            <div className="mb-1 grid grid-cols-7 gap-1 text-center text-[10px] font-semibold uppercase tracking-wider">
               {dow.map((d, i) => (
-                <span key={i} className="py-1">
+                // Monday-first: indices 5 and 6 are Sat/Sun — the prime
+                // society-event days, faintly brand-tinted rather than plain gray.
+                <span key={i} className={i >= 5 ? 'text-primary/60' : 'text-base-content/40'}>
                   {d}
                 </span>
               ))}
             </div>
-            <div className="grid grid-cols-7 gap-0.5">
+            <div className="grid grid-cols-7 justify-items-center gap-1">
               {monthMatrix(view.y, view.m0)
                 .flat()
                 .map((d, i) => {
                   if (d === null) return <span key={i} />;
                   const iso = toISO(view.y, view.m0, d);
                   const sel = iso === value;
+                  const isToday = iso === todayISO;
                   return (
                     <button
                       key={i}
                       type="button"
-                      className={`btn btn-ghost btn-xs h-8 w-8 p-0 tabular-nums ${sel ? 'btn-primary' : ''}`}
+                      aria-pressed={sel}
+                      aria-current={isToday ? 'date' : undefined}
+                      className={[
+                        'flex h-8 w-8 items-center justify-center rounded-full text-sm tabular-nums transition-colors',
+                        sel
+                          ? 'bg-primary font-semibold text-primary-content hover:bg-primary/90'
+                          : isToday
+                            ? 'font-semibold text-primary ring-1 ring-inset ring-primary/50 hover:bg-primary/10'
+                            : 'text-base-content hover:bg-base-content/10',
+                      ].join(' ')}
                       onClick={() => {
                         onChange(iso);
                         setOpen(false);

--- a/src/components/CampusMap/MiniCalendar.tsx
+++ b/src/components/CampusMap/MiniCalendar.tsx
@@ -1,6 +1,10 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { Calendar, ChevronDown, ChevronLeft, ChevronRight } from 'lucide-react';
 import { toISO, parseISO, monthMatrix, addMonths } from './calendar';
+
+// The 7×32px day grid + padding needs this much; narrower and the grid wraps.
+const POPOVER_WIDTH = 256;
 
 // Monday-first short weekday names in the caller's locale. 2024-01-01 is a
 // Monday, so offsetting from it gives Mon…Sun in whatever language the app is in
@@ -28,7 +32,9 @@ export function MiniCalendar({
     () => parsed ?? { y: new Date().getFullYear(), m0: new Date().getMonth() }
   );
   const [open, setOpen] = useState(false);
-  const containerRef = useRef<HTMLDivElement>(null);
+  const [pos, setPos] = useState({ top: 0, left: 0 });
+  const btnRef = useRef<HTMLButtonElement>(null);
+  const popRef = useRef<HTMLDivElement>(null);
   const dow = useMemo(() => weekdayNames(locale), [locale]);
   const label = value
     ? new Date(`${value}T00:00:00`).toLocaleDateString(locale, {
@@ -43,30 +49,47 @@ export function MiniCalendar({
     year: 'numeric',
   });
 
+  // Anchor the popover under the trigger in viewport coords. It's portalled to
+  // <body> so the side-panel's overflow-hidden can't clip it; clamp to the
+  // viewport so it never spills off the right edge.
+  const updatePos = useCallback(() => {
+    const el = btnRef.current;
+    if (!el) return;
+    const r = el.getBoundingClientRect();
+    const left = Math.min(r.left, window.innerWidth - POPOVER_WIDTH - 8);
+    setPos({ top: r.bottom + 4, left: Math.max(8, left) });
+  }, []);
+
   useEffect(() => {
     if (!open) return;
+    updatePos();
     const onPointerDown = (e: MouseEvent) => {
-      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
+      const target = e.target as Node;
+      if (btnRef.current?.contains(target) || popRef.current?.contains(target)) return;
+      setOpen(false);
     };
     document.addEventListener('mousedown', onPointerDown);
-    return () => document.removeEventListener('mousedown', onPointerDown);
-  }, [open]);
+    // Reposition while open if anything scrolls/resizes under it (capture=true
+    // catches scroll on the panel/map, which don't bubble to window).
+    window.addEventListener('scroll', updatePos, true);
+    window.addEventListener('resize', updatePos);
+    return () => {
+      document.removeEventListener('mousedown', onPointerDown);
+      window.removeEventListener('scroll', updatePos, true);
+      window.removeEventListener('resize', updatePos);
+    };
+  }, [open, updatePos]);
 
   return (
-    // dropdown-open is required: DaisyUI 5 display:none's .dropdown-content
-    // unless the container is :focus-within or .dropdown-open, and focus is
-    // unreliable inside the extension iframe — state must drive visibility.
-    <div className={`dropdown w-full ${open ? 'dropdown-open' : ''}`} ref={containerRef}>
+    <>
       <button
+        ref={btnRef}
         type="button"
-        // No tabIndex: a <button> is already focusable, and marking it
-        // [tabindex] makes DaisyUI's `.dropdown:focus-within > [tabindex]:first-child`
-        // rule set pointer-events:none on it the instant mousedown focuses it —
-        // the click then lands on the parent .dropdown instead of the button, so
-        // onClick never fires and the picker never opens (only physical clicks hit
-        // this; a synthetic .click() dispatches straight to the element).
+        // No tabIndex: a <button> is already focusable. When this was a DaisyUI
+        // `.dropdown` trigger, marking it [tabindex] made
+        // `.dropdown:focus-within > [tabindex]:first-child { pointer-events:none }`
+        // fire on mousedown-focus, so the click landed on the parent and onClick
+        // never ran. The popover is now portalled, but keep it plain regardless.
         className={`input input-bordered flex w-full items-center gap-2 ${value ? '' : 'text-base-content/50'}`}
         onClick={() => setOpen((o) => !o)}
       >
@@ -77,61 +100,64 @@ export function MiniCalendar({
           className={`ml-auto opacity-50 transition-transform ${open ? 'rotate-180' : ''}`}
         />
       </button>
-      {open && (
-        <div
-          tabIndex={0}
-          className="dropdown-content z-[70] mt-1 w-64 rounded-box border border-base-300 bg-base-100 p-3 shadow-popover-heavy"
-        >
-          <div className="mb-2 flex items-center justify-between">
-            <button
-              type="button"
-              className="btn btn-ghost btn-xs"
-              aria-label={t('map.prevMonth')}
-              onClick={() => setView((v) => addMonths(v.y, v.m0, -1))}
-            >
-              <ChevronLeft size={16} />
-            </button>
-            <span className="text-sm font-semibold capitalize">{monthLabel}</span>
-            <button
-              type="button"
-              className="btn btn-ghost btn-xs"
-              aria-label={t('map.nextMonth')}
-              onClick={() => setView((v) => addMonths(v.y, v.m0, 1))}
-            >
-              <ChevronRight size={16} />
-            </button>
-          </div>
-          <div className="grid grid-cols-7 gap-0.5 text-center text-[10px] font-bold text-base-content/50">
-            {dow.map((d, i) => (
-              <span key={i} className="py-1">
-                {d}
-              </span>
-            ))}
-          </div>
-          <div className="grid grid-cols-7 gap-0.5">
-            {monthMatrix(view.y, view.m0)
-              .flat()
-              .map((d, i) => {
-                if (d === null) return <span key={i} />;
-                const iso = toISO(view.y, view.m0, d);
-                const sel = iso === value;
-                return (
-                  <button
-                    key={i}
-                    type="button"
-                    className={`btn btn-ghost btn-xs h-8 w-8 p-0 tabular-nums ${sel ? 'btn-primary' : ''}`}
-                    onClick={() => {
-                      onChange(iso);
-                      setOpen(false);
-                    }}
-                  >
-                    {d}
-                  </button>
-                );
-              })}
-          </div>
-        </div>
-      )}
-    </div>
+      {open &&
+        createPortal(
+          <div
+            ref={popRef}
+            className="fixed z-[9999] rounded-box border border-base-300 bg-base-100 p-3 shadow-popover-heavy"
+            style={{ top: pos.top, left: pos.left, width: POPOVER_WIDTH }}
+          >
+            <div className="mb-2 flex items-center justify-between">
+              <button
+                type="button"
+                className="btn btn-ghost btn-xs"
+                aria-label={t('map.prevMonth')}
+                onClick={() => setView((v) => addMonths(v.y, v.m0, -1))}
+              >
+                <ChevronLeft size={16} />
+              </button>
+              <span className="text-sm font-semibold capitalize">{monthLabel}</span>
+              <button
+                type="button"
+                className="btn btn-ghost btn-xs"
+                aria-label={t('map.nextMonth')}
+                onClick={() => setView((v) => addMonths(v.y, v.m0, 1))}
+              >
+                <ChevronRight size={16} />
+              </button>
+            </div>
+            <div className="grid grid-cols-7 gap-0.5 text-center text-[10px] font-bold text-base-content/50">
+              {dow.map((d, i) => (
+                <span key={i} className="py-1">
+                  {d}
+                </span>
+              ))}
+            </div>
+            <div className="grid grid-cols-7 gap-0.5">
+              {monthMatrix(view.y, view.m0)
+                .flat()
+                .map((d, i) => {
+                  if (d === null) return <span key={i} />;
+                  const iso = toISO(view.y, view.m0, d);
+                  const sel = iso === value;
+                  return (
+                    <button
+                      key={i}
+                      type="button"
+                      className={`btn btn-ghost btn-xs h-8 w-8 p-0 tabular-nums ${sel ? 'btn-primary' : ''}`}
+                      onClick={() => {
+                        onChange(iso);
+                        setOpen(false);
+                      }}
+                    >
+                      {d}
+                    </button>
+                  );
+                })}
+            </div>
+          </div>,
+          document.body
+        )}
+    </>
   );
 }

--- a/src/components/CampusMap/MiniCalendar.tsx
+++ b/src/components/CampusMap/MiniCalendar.tsx
@@ -1,8 +1,14 @@
-import { useEffect, useRef, useState } from 'react';
-import { Calendar, ChevronLeft, ChevronRight } from 'lucide-react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Calendar, ChevronDown, ChevronLeft, ChevronRight } from 'lucide-react';
 import { toISO, parseISO, monthMatrix, addMonths } from './calendar';
 
-const DOW = ['Po', 'Út', 'St', 'Čt', 'Pá', 'So', 'Ne'];
+// Monday-first short weekday names in the caller's locale. 2024-01-01 is a
+// Monday, so offsetting from it gives Mon…Sun in whatever language the app is in
+// (the old hardcoded Czech row ignored `locale`).
+function weekdayNames(locale: string): string[] {
+  const fmt = new Intl.DateTimeFormat(locale, { weekday: 'short' });
+  return Array.from({ length: 7 }, (_, i) => fmt.format(new Date(2024, 0, 1 + i)));
+}
 
 export function MiniCalendar({
   value,
@@ -23,6 +29,7 @@ export function MiniCalendar({
   );
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
+  const dow = useMemo(() => weekdayNames(locale), [locale]);
   const label = value
     ? new Date(`${value}T00:00:00`).toLocaleDateString(locale, {
         weekday: 'short',
@@ -57,6 +64,10 @@ export function MiniCalendar({
       >
         <Calendar size={16} className="opacity-70" />
         <span className="truncate">{label}</span>
+        <ChevronDown
+          size={16}
+          className={`ml-auto opacity-50 transition-transform ${open ? 'rotate-180' : ''}`}
+        />
       </button>
       {open && (
         <div
@@ -83,8 +94,8 @@ export function MiniCalendar({
             </button>
           </div>
           <div className="grid grid-cols-7 gap-0.5 text-center text-[10px] font-bold text-base-content/50">
-            {DOW.map((d) => (
-              <span key={d} className="py-1">
+            {dow.map((d, i) => (
+              <span key={i} className="py-1">
                 {d}
               </span>
             ))}

--- a/src/components/CampusMap/MiniCalendar.tsx
+++ b/src/components/CampusMap/MiniCalendar.tsx
@@ -55,10 +55,18 @@ export function MiniCalendar({
   }, [open]);
 
   return (
-    <div className="dropdown w-full" ref={containerRef}>
+    // dropdown-open is required: DaisyUI 5 display:none's .dropdown-content
+    // unless the container is :focus-within or .dropdown-open, and focus is
+    // unreliable inside the extension iframe — state must drive visibility.
+    <div className={`dropdown w-full ${open ? 'dropdown-open' : ''}`} ref={containerRef}>
       <button
         type="button"
-        tabIndex={0}
+        // No tabIndex: a <button> is already focusable, and marking it
+        // [tabindex] makes DaisyUI's `.dropdown:focus-within > [tabindex]:first-child`
+        // rule set pointer-events:none on it the instant mousedown focuses it —
+        // the click then lands on the parent .dropdown instead of the button, so
+        // onClick never fires and the picker never opens (only physical clicks hit
+        // this; a synthetic .click() dispatches straight to the element).
         className={`input input-bordered flex w-full items-center gap-2 ${value ? '' : 'text-base-content/50'}`}
         onClick={() => setOpen((o) => !o)}
       >

--- a/src/components/CampusMap/MyEventsPanel.tsx
+++ b/src/components/CampusMap/MyEventsPanel.tsx
@@ -1,9 +1,11 @@
-import { LogOut, Plus } from 'lucide-react';
+import { useState } from 'react';
+import { Check, LogOut, Pencil, Plus, Trash2, X } from 'lucide-react';
 import { useAppStore } from '../../store/useAppStore';
 import { useTranslation } from '../../hooks/useTranslation';
 import { sortByDate } from './eventHelpers';
 import { isPastEvent, isScheduledEvent, goLiveDate } from './eventWindow';
 import { societyById } from '../../data/societies';
+import { deletePost } from '../../api/societyPosts';
 import { EventRow } from './EventRow';
 import { EventComposer } from './EventComposer';
 import type { MapEvent } from '../../types/events';
@@ -21,11 +23,73 @@ export function MyEventsPanel() {
   const composerOpen = useAppStore((s) => s.composerOpen);
   const editEventId = useAppStore((s) => s.editEventId);
   const closeComposer = useAppStore((s) => s.closeComposer);
+  const loadSocietyPosts = useAppStore((s) => s.loadSocietyPosts);
+  const clearMapSelection = useAppStore((s) => s.clearMapSelection);
+  const selection = useAppStore((s) => s.mapSelection);
   const adminLogout = useAppStore((s) => s.adminLogout);
   const assocId = useAppStore((s) => s.adminAssociationId);
   const { t, language } = useTranslation();
   const locale = language === 'en' ? 'en-US' : 'cs-CZ';
   const soc = assocId ? societyById(assocId) : null;
+
+  // Delete is a two-step, in-row confirm so authoring never leaves this panel:
+  // the trash icon arms `confirmId`, then a check commits. `busyId` disables the
+  // row while the request is in flight.
+  const [confirmId, setConfirmId] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const selectedId = selection?.kind === 'event' ? selection.event.id : null;
+
+  const remove = async (id: string) => {
+    setBusyId(id);
+    const res = await deletePost(id);
+    setBusyId(null);
+    setConfirmId(null);
+    if (res.error) return;
+    if (selectedId === id) clearMapSelection(); // close the preview card if it was open
+    await loadSocietyPosts();
+  };
+
+  const rowActions = (e: MapEvent) =>
+    confirmId === e.id ? (
+      <>
+        <button
+          type="button"
+          className="btn btn-ghost btn-xs px-1.5 text-error"
+          aria-label={t('map.deleteConfirm')}
+          disabled={busyId === e.id}
+          onClick={() => void remove(e.id)}
+        >
+          <Check size={15} />
+        </button>
+        <button
+          type="button"
+          className="btn btn-ghost btn-xs px-1.5"
+          aria-label={t('common.cancel')}
+          onClick={() => setConfirmId(null)}
+        >
+          <X size={15} />
+        </button>
+      </>
+    ) : (
+      <>
+        <button
+          type="button"
+          className="btn btn-ghost btn-xs px-1.5 text-base-content/45 hover:text-base-content"
+          aria-label={t('map.edit')}
+          onClick={() => openComposer(e.id)}
+        >
+          <Pencil size={14} />
+        </button>
+        <button
+          type="button"
+          className="btn btn-ghost btn-xs px-1.5 text-base-content/45 hover:text-error"
+          aria-label={t('map.delete')}
+          onClick={() => setConfirmId(e.id)}
+        >
+          <Trash2 size={14} />
+        </button>
+      </>
+    );
 
   const past = sortByDate(events.filter((e) => isPastEvent(e.date))).reverse();
   const scheduled = sortByDate(events.filter((e) => isScheduledEvent(e.date)));
@@ -45,9 +109,10 @@ export function MyEventsPanel() {
             event={e}
             locale={locale}
             t={t}
-            selected={false}
+            selected={selectedId === e.id}
             subline={subline?.(e)}
             onClick={() => focusEvent(e.id, { fly: true })}
+            actions={rowActions(e)}
           />
         ))}
       </div>

--- a/src/components/CampusMap/__tests__/ComposerRoomSearch.test.tsx
+++ b/src/components/CampusMap/__tests__/ComposerRoomSearch.test.tsx
@@ -18,6 +18,15 @@ describe('ComposerRoomSearch', () => {
     expect(arg.coord).toHaveLength(2); // [lng, lat]
   });
 
+  it('ranks the bare lecture hall first: "q01" → Q01 before Q01.09', () => {
+    // Same ranking as the top-left map search — the dotted offices come first
+    // in rooms-index.json, but the hall students search for must win.
+    render(<ComposerRoomSearch selected={null} onSelect={() => {}} onClear={() => {}} t={t} />);
+    fireEvent.change(screen.getByPlaceholderText('map.searchRoom'), { target: { value: 'q01' } });
+    const names = screen.getAllByRole('button').map((b) => b.querySelector('span')?.textContent);
+    expect(names[0]).toBe('Q01');
+  });
+
   it('shows the selected room with a change button', () => {
     const onClear = vi.fn();
     render(

--- a/src/components/CampusMap/__tests__/EventComposer.test.tsx
+++ b/src/components/CampusMap/__tests__/EventComposer.test.tsx
@@ -81,4 +81,33 @@ describe('EventComposer publish', () => {
     expect(patch.room_code).toBe('BA39N6006');
     expect(patch.category).toBe('boardgames');
   });
+
+  it('shows the hall name (not the IS code) in the picked-room chip when editing', () => {
+    // Campus events save only room_code and a null location, so the chip must
+    // resolve BA39N1009 → "Q01" rather than echoing the raw code.
+    useAppStore.setState({
+      editEventId: 'c2',
+      societyMapEvents: [
+        {
+          id: 'c2',
+          title: 'Zootopia',
+          url: '',
+          date: '2026-07-14',
+          endDate: null,
+          time: null,
+          location: null,
+          imageUrl: null,
+          organizerKey: 'pef',
+          societyId: 'supef',
+          coord: [16.614, 49.209],
+          roomCode: 'BA39N1009',
+          venueKind: 'campus',
+          category: 'party',
+        },
+      ],
+    });
+    render(<EventComposer onDone={() => {}} />);
+    expect(screen.getByText('Q01')).toBeTruthy();
+    expect(screen.queryByText('BA39N1009')).toBeNull();
+  });
 });

--- a/src/components/CampusMap/__tests__/EventDetailCard.test.tsx
+++ b/src/components/CampusMap/__tests__/EventDetailCard.test.tsx
@@ -70,6 +70,15 @@ describe('EventDetailCard society controls', () => {
     expect(clearMapSelection).not.toHaveBeenCalled();
   });
 
+  it('shows the human-readable room name, not the raw IS room code', () => {
+    // Campus events persist only the IS-internal code ("BA39N1009"); the
+    // hall name ("Q01") lives in rooms-index.json. The card must resolve it.
+    const campusEvent: MapEvent = { ...ev, roomCode: 'BA39N1009', venueKind: 'campus' };
+    render(<EventDetailCard event={campusEvent} />);
+    expect(screen.getByText('Q01')).toBeTruthy();
+    expect(screen.queryByText('BA39N1009')).toBeNull();
+  });
+
   it("hides edit/delete for another society's event in society mode (cross-tenant isolation)", () => {
     useAppStore.setState({ mapMode: 'society', adminAssociationId: 'supef' });
     const otherEvent: MapEvent = { ...ev, societyId: 'esn' };

--- a/src/components/CampusMap/__tests__/EventDetailCard.test.tsx
+++ b/src/components/CampusMap/__tests__/EventDetailCard.test.tsx
@@ -1,11 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { useAppStore } from '../../../store/useAppStore';
 import { EventDetailCard } from '../EventDetailCard';
 import type { MapEvent } from '../../../types/events';
-
-vi.mock('../../../api/societyPosts', () => ({ deletePost: vi.fn().mockResolvedValue({}) }));
-import { deletePost } from '../../../api/societyPosts';
 
 const ev: MapEvent = {
   id: 'e1',
@@ -23,51 +20,24 @@ const ev: MapEvent = {
   venueKind: 'offcampus',
   category: 'party',
 };
-const mineEvent = ev;
-
-describe('EventDetailCard society controls', () => {
+describe('EventDetailCard', () => {
   beforeEach(() => {
     useAppStore.setState({
       mapMode: 'student',
       adminAssociationId: 'supef',
-      loadSocietyPosts: vi.fn() as never,
       language: 'en',
     });
     vi.clearAllMocks();
   });
 
-  it('hides edit/delete for students', () => {
+  // The card is a read-only preview: a society edits/deletes from the "Moje
+  // akce" panel, never here (management stays in one place). Guard that no
+  // authoring control leaks into the card, even for the society's own event.
+  it('never renders edit/delete controls, even for an own event in society mode', () => {
+    useAppStore.setState({ mapMode: 'society', adminAssociationId: 'supef' });
     render(<EventDetailCard event={ev} />);
-    expect(screen.queryByRole('button', { name: /delete/i })).toBeNull();
-  });
-
-  it('deletes an own event in society mode (arm then confirm)', async () => {
-    useAppStore.setState({ mapMode: 'society' });
-    render(<EventDetailCard event={ev} />);
-    // First click only arms the confirm state — label flips to "Delete for good?".
-    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
-    // Second click on the (now-relabeled) button actually deletes.
-    fireEvent.click(screen.getByRole('button', { name: 'Delete for good?' }));
-    await waitFor(() => expect(deletePost).toHaveBeenCalledWith('e1'));
-  });
-
-  it('keeps the card and does not reload when delete fails', async () => {
-    const loadSocietyPosts = vi.fn(async () => {});
-    const clearMapSelection = vi.fn();
-    vi.mocked(deletePost).mockResolvedValueOnce({ error: 'boom' } as never);
-    useAppStore.setState({
-      mapMode: 'society',
-      adminAssociationId: 'supef',
-      language: 'cz',
-      loadSocietyPosts,
-      clearMapSelection,
-    });
-    render(<EventDetailCard event={mineEvent} />);
-    fireEvent.click(screen.getByRole('button', { name: 'Smazat' })); // arm confirm (cs: map.delete)
-    fireEvent.click(screen.getByRole('button', { name: 'Opravdu smazat?' })); // confirm (cs: map.deleteConfirm)
-    await waitFor(() => expect(deletePost).toHaveBeenCalledTimes(1));
-    expect(loadSocietyPosts).not.toHaveBeenCalled();
-    expect(clearMapSelection).not.toHaveBeenCalled();
+    expect(screen.queryByRole('button', { name: /delete|smazat/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /edit|upravit/i })).toBeNull();
   });
 
   it('shows the human-readable room name, not the raw IS room code', () => {
@@ -77,13 +47,5 @@ describe('EventDetailCard society controls', () => {
     render(<EventDetailCard event={campusEvent} />);
     expect(screen.getByText('Q01')).toBeTruthy();
     expect(screen.queryByText('BA39N1009')).toBeNull();
-  });
-
-  it("hides edit/delete for another society's event in society mode (cross-tenant isolation)", () => {
-    useAppStore.setState({ mapMode: 'society', adminAssociationId: 'supef' });
-    const otherEvent: MapEvent = { ...ev, societyId: 'esn' };
-    render(<EventDetailCard event={otherEvent} />);
-    expect(screen.queryByRole('button', { name: /delete/i })).toBeNull();
-    expect(screen.queryByRole('button', { name: /edit/i })).toBeNull();
   });
 });

--- a/src/components/CampusMap/__tests__/EventLayer.test.tsx
+++ b/src/components/CampusMap/__tests__/EventLayer.test.tsx
@@ -6,7 +6,7 @@ vi.mock('../../../hooks/useEventsFacultySettings', () => {
   const subscribedFaculties = ['mendelu', 'pef'];
   return { useEventsFacultySettings: () => ({ subscribedFaculties, isLoading: false }) };
 });
-import { render, act } from '@testing-library/react';
+import { render, act, fireEvent } from '@testing-library/react';
 import { EventLayer } from '../EventLayer';
 import { setMapInstance } from '../mapInstance';
 import { useAppStore } from '../../../store/useAppStore';
@@ -154,6 +154,25 @@ describe('EventLayer', () => {
     const draft = paneEl.querySelector('[data-draft-pin="true"]') as HTMLElement;
     expect(draft).toBeTruthy();
     expect(draft.style.transform).toContain('10px'); // resting layer point (10,20)
+  });
+
+  it('re-enters placing mode when the draft pin is clicked', () => {
+    const beginPlacing = vi.fn();
+    useAppStore.setState({
+      mapMode: 'society',
+      adminAssociationId: 'supef',
+      societyMapEvents: [],
+      mapEvents: [],
+      eventFilter: 'all',
+      activeBuildingId: null,
+      composerOpen: true,
+      draftCoord: [16.61, 49.21],
+      beginPlacing,
+    });
+    render(<EventLayer />);
+    const draft = paneEl.querySelector('[data-draft-pin="true"]') as HTMLElement;
+    fireEvent.click(draft);
+    expect(beginPlacing).toHaveBeenCalledOnce();
   });
 
   it('does not render a draft pin when the composer is closed', () => {

--- a/src/components/CampusMap/__tests__/EventLayer.test.tsx
+++ b/src/components/CampusMap/__tests__/EventLayer.test.tsx
@@ -53,6 +53,11 @@ beforeEach(() => {
     activeBuildingId: null,
     mapSelection: null,
     language: 'en',
+    mapMode: 'student',
+    societyMapEvents: [],
+    composerOpen: false,
+    draftCoord: null,
+    adminAssociationId: null,
   });
   setMapInstance(fakeMap);
 });
@@ -132,6 +137,38 @@ describe('EventLayer', () => {
     render(<EventLayer />);
     const btn = paneEl.querySelector('button[title="Society Party"]') as HTMLElement;
     expect(btn).toBeTruthy();
+  });
+
+  it('renders a draft pin at draftCoord while the composer is open (no saved events needed)', () => {
+    useAppStore.setState({
+      mapMode: 'society',
+      adminAssociationId: 'supef',
+      societyMapEvents: [],
+      mapEvents: [],
+      eventFilter: 'all',
+      activeBuildingId: null,
+      composerOpen: true,
+      draftCoord: [16.61, 49.21],
+    });
+    render(<EventLayer />);
+    const draft = paneEl.querySelector('[data-draft-pin="true"]') as HTMLElement;
+    expect(draft).toBeTruthy();
+    expect(draft.style.transform).toContain('10px'); // resting layer point (10,20)
+  });
+
+  it('does not render a draft pin when the composer is closed', () => {
+    useAppStore.setState({
+      mapMode: 'society',
+      adminAssociationId: 'supef',
+      societyMapEvents: [],
+      mapEvents: [],
+      eventFilter: 'all',
+      activeBuildingId: null,
+      composerOpen: false,
+      draftCoord: [16.61, 49.21],
+    });
+    render(<EventLayer />);
+    expect(paneEl.querySelector('[data-draft-pin="true"]')).toBeNull();
   });
 
   it('marks a mixed venue group scheduled if ANY event is scheduled (society mode)', () => {

--- a/src/components/CampusMap/__tests__/MiniCalendar.test.tsx
+++ b/src/components/CampusMap/__tests__/MiniCalendar.test.tsx
@@ -38,9 +38,10 @@ describe('MiniCalendar', () => {
     expect(onChange).toHaveBeenCalledWith('2026-07-15');
   });
 
-  it('marks the container dropdown-open while open (DaisyUI hides the popover otherwise)', () => {
-    // DaisyUI 5 display:none's .dropdown-content unless the container is
-    // :focus-within or .dropdown-open — React state alone isn't enough.
+  it('portals the popover to <body> so the panel overflow can not clip it', () => {
+    // The composer lives in a side panel with overflow-hidden; an in-flow
+    // absolute popover gets clipped. The calendar renders via a body portal
+    // instead, so its grid is a descendant of <body>, not of the component root.
     const { container } = render(
       <MiniCalendar
         value={null}
@@ -50,19 +51,19 @@ describe('MiniCalendar', () => {
         locale="en-US"
       />
     );
-    const root = container.querySelector('.dropdown') as HTMLElement;
-    expect(root.classList.contains('dropdown-open')).toBe(false);
     fireEvent.click(screen.getByText('Pick a date'));
-    expect(root.classList.contains('dropdown-open')).toBe(true);
+    const day = screen.getByRole('button', { name: '15' });
+    expect(container.contains(day)).toBe(false); // portalled out of the component
+    expect(document.body.contains(day)).toBe(true);
   });
 
-  it('trigger has no tabindex (a [tabindex] trigger gets pointer-events:none on focus, so a real click never opens it)', () => {
-    // The trigger is the first child of .dropdown. If it carries [tabindex],
-    // DaisyUI's `.dropdown:focus-within > [tabindex]:first-child { pointer-events:none }`
-    // fires the moment mousedown focuses it, so the ensuing click lands on the
-    // parent .dropdown and the button's onClick never runs. happy-dom can't apply
-    // that CSS, so we guard the root cause directly: the <button> stays focusable
-    // natively and must NOT be marked [tabindex].
+  it('trigger has no tabindex (a [tabindex] dropdown trigger gets pointer-events:none on focus, so a real click never opens it)', () => {
+    // Regression guard for the original bug: as a DaisyUI `.dropdown` trigger,
+    // marking the <button> [tabindex] made
+    // `.dropdown:focus-within > [tabindex]:first-child { pointer-events:none }`
+    // fire the moment mousedown focused it, so the click landed on the parent and
+    // onClick never ran. happy-dom can't apply that CSS, so guard the cause: the
+    // <button> stays focusable natively and must NOT be marked [tabindex].
     render(
       <MiniCalendar value={null} onChange={() => {}} placeholder="Pick a date" t={t} locale="en-US" />
     );

--- a/src/components/CampusMap/__tests__/MiniCalendar.test.tsx
+++ b/src/components/CampusMap/__tests__/MiniCalendar.test.tsx
@@ -65,7 +65,13 @@ describe('MiniCalendar', () => {
     // onClick never ran. happy-dom can't apply that CSS, so guard the cause: the
     // <button> stays focusable natively and must NOT be marked [tabindex].
     render(
-      <MiniCalendar value={null} onChange={() => {}} placeholder="Pick a date" t={t} locale="en-US" />
+      <MiniCalendar
+        value={null}
+        onChange={() => {}}
+        placeholder="Pick a date"
+        t={t}
+        locale="en-US"
+      />
     );
     const trigger = screen.getByText('Pick a date').closest('button')!;
     expect(trigger.hasAttribute('tabindex')).toBe(false);

--- a/src/components/CampusMap/__tests__/MiniCalendar.test.tsx
+++ b/src/components/CampusMap/__tests__/MiniCalendar.test.tsx
@@ -38,6 +38,38 @@ describe('MiniCalendar', () => {
     expect(onChange).toHaveBeenCalledWith('2026-07-15');
   });
 
+  it('marks the container dropdown-open while open (DaisyUI hides the popover otherwise)', () => {
+    // DaisyUI 5 display:none's .dropdown-content unless the container is
+    // :focus-within or .dropdown-open — React state alone isn't enough.
+    const { container } = render(
+      <MiniCalendar
+        value={null}
+        onChange={() => {}}
+        placeholder="Pick a date"
+        t={t}
+        locale="en-US"
+      />
+    );
+    const root = container.querySelector('.dropdown') as HTMLElement;
+    expect(root.classList.contains('dropdown-open')).toBe(false);
+    fireEvent.click(screen.getByText('Pick a date'));
+    expect(root.classList.contains('dropdown-open')).toBe(true);
+  });
+
+  it('trigger has no tabindex (a [tabindex] trigger gets pointer-events:none on focus, so a real click never opens it)', () => {
+    // The trigger is the first child of .dropdown. If it carries [tabindex],
+    // DaisyUI's `.dropdown:focus-within > [tabindex]:first-child { pointer-events:none }`
+    // fires the moment mousedown focuses it, so the ensuing click lands on the
+    // parent .dropdown and the button's onClick never runs. happy-dom can't apply
+    // that CSS, so we guard the root cause directly: the <button> stays focusable
+    // natively and must NOT be marked [tabindex].
+    render(
+      <MiniCalendar value={null} onChange={() => {}} placeholder="Pick a date" t={t} locale="en-US" />
+    );
+    const trigger = screen.getByText('Pick a date').closest('button')!;
+    expect(trigger.hasAttribute('tabindex')).toBe(false);
+  });
+
   it('localizes the weekday header from the locale (English), not hardcoded Czech', () => {
     render(
       <MiniCalendar

--- a/src/components/CampusMap/__tests__/MiniCalendar.test.tsx
+++ b/src/components/CampusMap/__tests__/MiniCalendar.test.tsx
@@ -38,6 +38,22 @@ describe('MiniCalendar', () => {
     expect(onChange).toHaveBeenCalledWith('2026-07-15');
   });
 
+  it('localizes the weekday header from the locale (English), not hardcoded Czech', () => {
+    render(
+      <MiniCalendar
+        value={null}
+        onChange={() => {}}
+        placeholder="Pick a date"
+        t={t}
+        locale="en-US"
+      />
+    );
+    fireEvent.click(screen.getByText('Pick a date'));
+    // Monday-first, English short names — never the old hardcoded 'Po'/'Út'.
+    expect(screen.getByText('Mon')).toBeTruthy();
+    expect(screen.queryByText('Po')).toBeNull();
+  });
+
   it('closes the popover when clicking outside', () => {
     render(
       <MiniCalendar

--- a/src/components/CampusMap/__tests__/MiniCalendar.test.tsx
+++ b/src/components/CampusMap/__tests__/MiniCalendar.test.tsx
@@ -93,6 +93,33 @@ describe('MiniCalendar', () => {
     expect(screen.queryByText('Po')).toBeNull();
   });
 
+  it('flips the popover above the trigger when it would overflow the viewport bottom', () => {
+    // happy-dom reports offsetHeight 0, so updatePos falls back to the 340px
+    // estimate — deterministic geometry we can assert on. innerHeight 500 with a
+    // trigger whose bottom is 490 leaves no room below (490+6+340 > 492), but
+    // 114px above (460-6-340), so the card must flip above the trigger.
+    const innerHeight = Object.getOwnPropertyDescriptor(window, 'innerHeight');
+    Object.defineProperty(window, 'innerHeight', { value: 500, configurable: true });
+    render(
+      <MiniCalendar
+        value={null}
+        onChange={() => {}}
+        placeholder="Pick a date"
+        t={t}
+        locale="en-US"
+      />
+    );
+    const trigger = screen.getByText('Pick a date').closest('button')!;
+    trigger.getBoundingClientRect = () =>
+      ({ top: 460, bottom: 490, left: 12, right: 300, width: 288, height: 30 }) as DOMRect;
+    fireEvent.click(trigger);
+    const pop = Array.from(document.querySelectorAll('div')).find(
+      (d) => d.style.width === '288px'
+    )!;
+    expect(pop.style.top).toBe('114px');
+    if (innerHeight) Object.defineProperty(window, 'innerHeight', innerHeight);
+  });
+
   it('closes the popover when clicking outside', () => {
     render(
       <MiniCalendar

--- a/src/components/CampusMap/__tests__/MyEventsPanel.test.tsx
+++ b/src/components/CampusMap/__tests__/MyEventsPanel.test.tsx
@@ -1,8 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { useAppStore } from '../../../store/useAppStore';
 import { MyEventsPanel } from '../MyEventsPanel';
 import type { MapEvent } from '../../../types/events';
+
+vi.mock('../../../api/societyPosts', () => ({ deletePost: vi.fn().mockResolvedValue({}) }));
+import { deletePost } from '../../../api/societyPosts';
 
 const mk = (id: string, date: string): MapEvent => ({
   id,
@@ -83,7 +86,10 @@ describe('MyEventsPanel — EventRow rows, inline composer, logout', () => {
       ],
       openComposer: vi.fn(),
       adminLogout: vi.fn(async () => {}),
+      loadSocietyPosts: vi.fn(async () => {}),
+      clearMapSelection: vi.fn(),
     });
+    vi.clearAllMocks();
   });
 
   it('renders own events as rich rows with the thumbnail', () => {
@@ -112,5 +118,34 @@ describe('MyEventsPanel — EventRow rows, inline composer, logout', () => {
     render(<MyEventsPanel />);
     screen.getByRole('button', { name: 'Odhlásit' }).click();
     expect(adminLogout).toHaveBeenCalledOnce();
+  });
+
+  it('row Edit opens the composer for that event (authoring stays in the panel)', () => {
+    const openComposer = vi.fn();
+    useAppStore.setState({ openComposer });
+    render(<MyEventsPanel />);
+    fireEvent.click(screen.getByRole('button', { name: 'Upravit' }));
+    expect(openComposer).toHaveBeenCalledWith('e1');
+  });
+
+  it('row Delete arms an in-row confirm, then commits deletePost + reload', async () => {
+    const loadSocietyPosts = vi.fn(async () => {});
+    useAppStore.setState({ loadSocietyPosts });
+    render(<MyEventsPanel />);
+    // Arm: the trash swaps to a confirm (✓) / cancel (✗) pair, no request yet.
+    fireEvent.click(screen.getByRole('button', { name: 'Smazat' }));
+    expect(deletePost).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: 'Opravdu smazat?' }));
+    await waitFor(() => expect(deletePost).toHaveBeenCalledWith('e1'));
+    expect(loadSocietyPosts).toHaveBeenCalled();
+  });
+
+  it('Cancel disarms the delete confirm without calling deletePost', () => {
+    render(<MyEventsPanel />);
+    fireEvent.click(screen.getByRole('button', { name: 'Smazat' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Zrušit' }));
+    expect(deletePost).not.toHaveBeenCalled();
+    // Back to the resting Edit/Delete affordances.
+    expect(screen.getByRole('button', { name: 'Smazat' })).toBeInTheDocument();
   });
 });

--- a/src/components/CampusMap/__tests__/mapHelpers.test.ts
+++ b/src/components/CampusMap/__tests__/mapHelpers.test.ts
@@ -9,6 +9,7 @@ import {
   categoryStyle,
   landmarkGroupLabels,
   roomCodeToCoord,
+  roomCodeToName,
 } from '../mapHelpers';
 import type { RoomIndexEntry, BuildingsMeta, PoiFeature, Landmark } from '../../../types/campusMap';
 
@@ -31,6 +32,24 @@ describe('roomCodeToCoord', () => {
   });
   it('returns null for an unknown code', () => {
     expect(roomCodeToCoord('ZZZ', index, buildings)).toBeNull();
+  });
+});
+
+describe('roomCodeToName', () => {
+  const index = [
+    { code: 'BA39N1009', name: 'Q01', buildingId: 0, floorId: 5, floorLevel: 0, placeId: 546 },
+  ] as unknown as RoomIndexEntry[];
+  it('resolves the IS-internal code to its human-readable hall name', () => {
+    expect(roomCodeToName('BA39N1009', index)).toBe('Q01');
+  });
+  it('normalizes case and whitespace before matching', () => {
+    expect(roomCodeToName('  ba39n1009 ', index)).toBe('Q01');
+  });
+  it('passes a legacy name-valued code through unchanged', () => {
+    expect(roomCodeToName('Q01', index)).toBe('Q01');
+  });
+  it('falls back to the given string for an unknown code', () => {
+    expect(roomCodeToName('ZZZ', index)).toBe('ZZZ');
   });
 });
 

--- a/src/components/CampusMap/__tests__/mapHelpers.test.ts
+++ b/src/components/CampusMap/__tests__/mapHelpers.test.ts
@@ -4,6 +4,7 @@ import {
   lonLatToLatLng,
   ringToLatLng,
   searchPlaces,
+  searchRooms,
   polygonCentroid,
   categoryStyle,
   landmarkGroupLabels,
@@ -151,6 +152,27 @@ describe('searchPlaces', () => {
     expect(r.some((m) => m.kind === 'landmark' && m.landmark.name === 'Tauferovy koleje')).toBe(
       true
     );
+  });
+});
+
+describe('searchRooms', () => {
+  // Children listed first — mirrors the real rooms-index.json, where the
+  // dotted Q01.NN offices precede the bare "Q01" lecture hall.
+  const index: RoomIndexEntry[] = [
+    { code: 'BA39P1009', name: 'Q01.09', buildingId: 0, floorId: 5, floorLevel: 0, placeId: 10 },
+    { code: 'BA39P1014', name: 'Q01.14', buildingId: 0, floorId: 5, floorLevel: 0, placeId: 11 },
+    { code: 'BA39P1024', name: 'Q01.24', buildingId: 0, floorId: 5, floorLevel: 0, placeId: 12 },
+    { code: 'BA39N1009', name: 'Q01', buildingId: 0, floorId: 9, floorLevel: 0, placeId: 1 },
+  ];
+
+  it('ranks the exact bare-hall match first, same as the map search', () => {
+    expect(searchRooms('q01', index).map((r) => r.name)[0]).toBe('Q01');
+  });
+  it('respects the result limit after ranking', () => {
+    expect(searchRooms('q01', index, 2)).toHaveLength(2);
+  });
+  it('returns [] for an empty query', () => {
+    expect(searchRooms('   ', index)).toEqual([]);
   });
 });
 

--- a/src/components/CampusMap/mapHelpers.ts
+++ b/src/components/CampusMap/mapHelpers.ts
@@ -260,6 +260,24 @@ function matchRank(q: string, name: string, code: string): number {
   return 4;
 }
 
+// Rooms matching a normalized query, tagged with their rank. Shared by the
+// top-left map search and the composer's room picker so both order hits the
+// same way (exact "Q01" beats the dotted Q01.NN offices listed earlier).
+function rankedRooms(q: string, index: RoomIndexEntry[]) {
+  return index
+    .filter((e) => e.code.toLowerCase().includes(q) || e.name.toLowerCase().includes(q))
+    .map((entry) => ({ entry, rank: matchRank(q, entry.name, entry.code) }));
+}
+
+export function searchRooms(query: string, index: RoomIndexEntry[], limit = 6): RoomIndexEntry[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return [];
+  return rankedRooms(q, index)
+    .sort((a, b) => a.rank - b.rank)
+    .slice(0, limit)
+    .map((x) => x.entry);
+}
+
 export function searchPlaces(
   query: string,
   index: RoomIndexEntry[],
@@ -269,12 +287,10 @@ export function searchPlaces(
 ): MapSelection[] {
   const q = query.trim().toLowerCase();
   if (!q) return [];
-  const rooms = index
-    .filter((e) => e.code.toLowerCase().includes(q) || e.name.toLowerCase().includes(q))
-    .map((entry) => ({
-      sel: { kind: 'roomRef', entry } as MapSelection,
-      rank: matchRank(q, entry.name, entry.code),
-    }));
+  const rooms = rankedRooms(q, index).map(({ entry, rank }) => ({
+    sel: { kind: 'roomRef', entry } as MapSelection,
+    rank,
+  }));
   const places = pois
     .filter((f) => f.properties.name.toLowerCase().includes(q))
     .map((f) => ({

--- a/src/components/CampusMap/mapHelpers.ts
+++ b/src/components/CampusMap/mapHelpers.ts
@@ -35,6 +35,19 @@ export function roomCodeToCoord(
   return [b.center[1], b.center[0]];
 }
 
+// Events persist only the IS-internal room code (e.g. "BA39N1009"); the
+// human-readable hall name ("Q01") lives in the rooms index. Resolve code →
+// name for display. Normalizes like roomCodeToCoord and also matches on name,
+// so a legacy row that stored the name already stays a name. Falls back to the
+// given string for an unknown code so the user still sees something.
+export function roomCodeToName(code: string, index: RoomIndexEntry[]): string {
+  const needle = code.trim().toLowerCase();
+  const entry = index.find(
+    (e) => e.code.toLowerCase() === needle || e.name.toLowerCase() === needle
+  );
+  return entry?.name ?? code;
+}
+
 // Leaflet polygon styles for the map. Fixed literals (the basemap is always
 // light) kept here with categoryStyle so all map styling lives in one place.
 // SELECTED = MyMENDELU-style solid orange (brand colors are green, so orange

--- a/src/components/MobileNav/MobileProfileSheet.tsx
+++ b/src/components/MobileNav/MobileProfileSheet.tsx
@@ -172,6 +172,7 @@ export function MobileProfileSheet({
                     onToggle={() => setSpolkyOpen(!spolkyOpen)}
                     isSub={isSubscribed}
                     onToggleAssoc={toggleAssociation}
+                    onNavigate={onClose}
                   />
                   <OutlookSyncToggle enabled={isEnabled} loading={syncLoading} onToggle={tSync} />
                 </div>

--- a/src/components/Sidebar/BottomActions.tsx
+++ b/src/components/Sidebar/BottomActions.tsx
@@ -4,38 +4,97 @@ import { OUTLOOK_ICON_PATH, TEAMS_ICON_PATH, ISKAM_ICON_PATH } from '../../const
 import { ProfilePopup } from './ProfilePopup';
 import { useTranslation } from '../../hooks/useTranslation';
 
-export function BottomActions({ onOpenFeedback, isIskam }: { onOpenFeedback?: () => void; isIskam?: boolean }) {
-    const [isOpen, setIsOpen] = useState(false);
-    const ref = useRef<HTMLDivElement>(null);
-    const timeout = useRef<ReturnType<typeof setTimeout> | null>(null);
-    const { t } = useTranslation();
+export function BottomActions({
+  onOpenFeedback,
+  isIskam,
+}: {
+  onOpenFeedback?: () => void;
+  isIskam?: boolean;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const timeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const { t } = useTranslation();
 
-    const handleEnter = () => { if (timeout.current) clearTimeout(timeout.current); setIsOpen(true); };
-    const handleLeave = () => { timeout.current = setTimeout(() => setIsOpen(false), 300); };
+  const handleEnter = () => {
+    if (timeout.current) clearTimeout(timeout.current);
+    setIsOpen(true);
+  };
+  const handleLeave = () => {
+    timeout.current = setTimeout(() => setIsOpen(false), 300);
+  };
 
-    useEffect(() => {
-        const h = (e: MouseEvent) => { if (ref.current && !ref.current.contains(e.target as Node)) setIsOpen(false); };
-        document.addEventListener('mousedown', h); return () => document.removeEventListener('mousedown', h);
-    }, []);
+  useEffect(() => {
+    const h = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setIsOpen(false);
+    };
+    document.addEventListener('mousedown', h);
+    return () => document.removeEventListener('mousedown', h);
+  }, []);
 
-    return (
-        <div className="flex flex-col gap-2 mb-2 w-full px-2 items-center relative" ref={ref}>
-            {!isIskam && (
-                <a href="https://webiskam.mendelu.cz/" target="_blank" rel="noopener noreferrer" className="w-12 h-auto py-2 rounded-xl flex flex-col items-center justify-center text-base-content/50 hover:bg-base-100 hover:text-info group">
-                    <img src={ISKAM_ICON_PATH} alt="ISKAM" className="w-8 h-8 group-hover:scale-110 transition-transform" /><span className="text-[10px] mt-1 font-medium">ISKAM</span>
-                </a>
-            )}
-            <a href="https://teams.microsoft.com" target="_blank" rel="noopener noreferrer" className="w-12 h-auto py-2 rounded-xl flex flex-col items-center justify-center text-base-content/50 hover:bg-base-100 hover:text-info group">
-                <img src={TEAMS_ICON_PATH} alt="Teams" className="w-8 h-8 group-hover:scale-110 transition-transform" /><span className="text-[10px] mt-1 font-medium">Teams</span>
-            </a>
-            <a href="https://outlook.office.com" target="_blank" rel="noopener noreferrer" className="w-12 h-auto py-2 rounded-xl flex flex-col items-center justify-center text-base-content/50 hover:bg-base-100 hover:text-info group">
-                <img src={OUTLOOK_ICON_PATH} alt="Outlook" className="w-8 h-8 group-hover:scale-110 transition-transform" /><span className="text-[10px] mt-1 font-medium">Outlook</span>
-            </a>
-            <div className="h-px bg-base-300 w-full my-1" />
-            <div className="relative" onMouseEnter={handleEnter} onMouseLeave={handleLeave}>
-                <button className={`w-12 h-12 rounded-xl flex flex-col items-center justify-center transition-all ${isOpen ? 'bg-primary text-primary-content shadow-md' : 'text-base-content/50 hover:bg-base-100 hover:text-base-content'}`}><Settings className="w-5 h-5" /><span className="text-[10px] mt-1 font-medium">{t('sidebar.profile')}</span></button>
-                <div onMouseEnter={handleEnter} onMouseLeave={handleLeave}><ProfilePopup isOpen={isOpen} onOpenFeedback={() => { setIsOpen(false); onOpenFeedback?.(); }} isIskam={isIskam} /></div>
-            </div>
+  return (
+    <div className="flex flex-col gap-2 mb-2 w-full px-2 items-center relative" ref={ref}>
+      {!isIskam && (
+        <a
+          href="https://webiskam.mendelu.cz/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="w-12 h-auto py-2 rounded-xl flex flex-col items-center justify-center text-base-content/50 hover:bg-base-100 hover:text-info group"
+        >
+          <img
+            src={ISKAM_ICON_PATH}
+            alt="ISKAM"
+            className="w-8 h-8 group-hover:scale-110 transition-transform"
+          />
+          <span className="text-[10px] mt-1 font-medium">ISKAM</span>
+        </a>
+      )}
+      <a
+        href="https://teams.microsoft.com"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="w-12 h-auto py-2 rounded-xl flex flex-col items-center justify-center text-base-content/50 hover:bg-base-100 hover:text-info group"
+      >
+        <img
+          src={TEAMS_ICON_PATH}
+          alt="Teams"
+          className="w-8 h-8 group-hover:scale-110 transition-transform"
+        />
+        <span className="text-[10px] mt-1 font-medium">Teams</span>
+      </a>
+      <a
+        href="https://outlook.office.com"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="w-12 h-auto py-2 rounded-xl flex flex-col items-center justify-center text-base-content/50 hover:bg-base-100 hover:text-info group"
+      >
+        <img
+          src={OUTLOOK_ICON_PATH}
+          alt="Outlook"
+          className="w-8 h-8 group-hover:scale-110 transition-transform"
+        />
+        <span className="text-[10px] mt-1 font-medium">Outlook</span>
+      </a>
+      <div className="h-px bg-base-300 w-full my-1" />
+      <div className="relative" onMouseEnter={handleEnter} onMouseLeave={handleLeave}>
+        <button
+          className={`w-12 h-12 rounded-xl flex flex-col items-center justify-center transition-all ${isOpen ? 'bg-primary text-primary-content shadow-md' : 'text-base-content/50 hover:bg-base-100 hover:text-base-content'}`}
+        >
+          <Settings className="w-5 h-5" />
+          <span className="text-[10px] mt-1 font-medium">{t('sidebar.profile')}</span>
+        </button>
+        <div onMouseEnter={handleEnter} onMouseLeave={handleLeave}>
+          <ProfilePopup
+            isOpen={isOpen}
+            onOpenFeedback={() => {
+              setIsOpen(false);
+              onOpenFeedback?.();
+            }}
+            onClose={() => setIsOpen(false)}
+            isIskam={isIskam}
+          />
         </div>
-    );
+      </div>
+    </div>
+  );
 }

--- a/src/components/Sidebar/Profile/SpolkySection.tsx
+++ b/src/components/Sidebar/Profile/SpolkySection.tsx
@@ -9,11 +9,23 @@ interface SpolkySectionProps {
   onToggle: () => void;
   isSub: (id: string) => boolean;
   onToggleAssoc: (id: string) => void;
+  /** Close the surrounding profile popover so entering society mode is visible. */
+  onNavigate?: () => void;
 }
 
-export function SpolkySection({ expanded, onToggle, isSub, onToggleAssoc }: SpolkySectionProps) {
+export function SpolkySection({
+  expanded,
+  onToggle,
+  isSub,
+  onToggleAssoc,
+  onNavigate,
+}: SpolkySectionProps) {
   const { t } = useTranslation();
   const openSocietyAdmin = useAppStore((s) => s.openSocietyAdmin);
+  const manage = () => {
+    onNavigate?.();
+    openSocietyAdmin();
+  };
   return (
     <div>
       <button
@@ -51,7 +63,7 @@ export function SpolkySection({ expanded, onToggle, isSub, onToggleAssoc }: Spol
               ))}
             </div>
             <button
-              onClick={openSocietyAdmin}
+              onClick={manage}
               className="w-full flex items-center justify-between px-2 py-1.5 mt-1 hover:bg-base-200 rounded-md text-xs opacity-60 hover:opacity-100 transition-colors"
             >
               <span className="flex items-center gap-2">

--- a/src/components/Sidebar/Profile/__tests__/SpolkySection.test.tsx
+++ b/src/components/Sidebar/Profile/__tests__/SpolkySection.test.tsx
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SpolkySection } from '../SpolkySection';
+
+// The manage button must close its surrounding popover (onNavigate) so entering
+// society mode is visible — otherwise the click reads as "nothing happened".
+describe('SpolkySection manage button', () => {
+  it('calls onNavigate (closes the popover) when "Spravovat spolek" is clicked', () => {
+    const onNavigate = vi.fn();
+    render(
+      <SpolkySection
+        expanded
+        onToggle={() => {}}
+        isSub={() => false}
+        onToggleAssoc={() => {}}
+        onNavigate={onNavigate}
+      />
+    );
+    fireEvent.click(screen.getByText('Spravovat spolek'));
+    expect(onNavigate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/Sidebar/ProfilePopup.tsx
+++ b/src/components/Sidebar/ProfilePopup.tsx
@@ -19,10 +19,12 @@ import { useTripleClick } from '../../hooks/ui/useTripleClick';
 export function ProfilePopup({
   isOpen,
   onOpenFeedback,
+  onClose,
   isIskam,
 }: {
   isOpen: boolean;
   onOpenFeedback?: () => void;
+  onClose?: () => void;
   isIskam?: boolean;
 }) {
   const { isEnabled, isLoading: syncLoading, toggle: tSync } = useOutlookSync(),
@@ -157,6 +159,7 @@ export function ProfilePopup({
               onToggle={() => setSpolkyOpen(!spolkyOpen)}
               isSub={isSubscribed}
               onToggleAssoc={toggleAssociation}
+              onNavigate={onClose}
             />
             <OutlookSyncToggle enabled={isEnabled} loading={syncLoading} onToggle={tSync} />
             <GoogleDriveToggle />

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -1017,6 +1017,7 @@
     "changePlace": "Změnit místo",
     "publish": "Zveřejnit akci",
     "clickToPlace": "Klikněte na mapu, kde akce je",
+    "draftPinLabel": "Místo akce — klikněte pro změnu",
     "venueLabel": "Kde",
     "venueOffcampus": "Ve městě",
     "venueCampus": "Kampus",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1017,6 +1017,7 @@
     "changePlace": "Change place",
     "publish": "Publish event",
     "clickToPlace": "Click the map where your event is",
+    "draftPinLabel": "Event location — click to change",
     "venueLabel": "Where",
     "venueOffcampus": "In town",
     "venueCampus": "Campus",

--- a/src/index.css
+++ b/src/index.css
@@ -283,6 +283,21 @@ html, body, #root {
   border-color: color-mix(in oklab, var(--color-secondary) 40%, transparent);
 }
 
+/* ── Form-field focus: single ring ───────────────────────────────────────
+ * DaisyUI 5 focuses .input/.select/.textarea with a 2px outline offset 2px
+ * AROUND the field's own border — two concentric rings that read as an ugly
+ * double border. Show focus on the border itself instead. Plain rules
+ * (outside any @layer) intentionally override DaisyUI's component layer. */
+.input:focus,
+.input:focus-within,
+.select:focus,
+.select:focus-within,
+.textarea:focus,
+.textarea:focus-within {
+  outline: none;
+  border-color: color-mix(in oklab, var(--color-base-content) 45%, transparent);
+}
+
 /* ── Campus map (Leaflet) overrides ──────────────────────────────────────
  * The campus basemap is always light (CartoDB Positron) regardless of theme,
  * so these are Leaflet-library overrides, not themed component styles. */

--- a/src/index.css
+++ b/src/index.css
@@ -1,10 +1,12 @@
-@import "tailwindcss";
+@import 'tailwindcss';
 
 /* Mobile = touch device + narrow viewport. Desktop split-screen stays desktop. */
 @custom-variant touch (@media (pointer: coarse) and (max-width: 767px));
 
 /* CRITICAL: Prevent all scrolling at the page level */
-html, body, #root {
+html,
+body,
+#root {
   margin: 0;
   padding: 0;
   width: 100%;
@@ -35,7 +37,9 @@ html, body, #root {
 
 /* Enable both light and dark Mendelu themes */
 @plugin "daisyui" {
-  themes: mendelu-dark --default, mendelu;
+  themes:
+    mendelu-dark --default,
+    mendelu;
 }
 
 /* Safelist DaisyUI toggle component (not auto-detected by JIT scanner) */
@@ -44,10 +48,9 @@ html, body, #root {
 /* Safelist for calendar day highlight (dynamically constructed classes) */
 @source inline("bg-accent/5 bg-accent/10 text-accent");
 
-
 /* Custom Mendelu light theme for REIS extension */
 @plugin "daisyui/theme" {
-  name: "mendelu";
+  name: 'mendelu';
   default: false;
   color-scheme: light;
 
@@ -60,7 +63,7 @@ html, body, #root {
   /* Brand colors */
   --color-primary: #79be15;
   --color-primary-content: #ffffff;
-  --color-secondary: #8DC843;
+  --color-secondary: #8dc843;
   --color-secondary-content: #ffffff;
   --color-accent: #00548f;
   --color-accent-content: #ffffff;
@@ -96,7 +99,7 @@ html, body, #root {
 
 /* Custom Mendelu dark theme for REIS extension */
 @plugin "daisyui/theme" {
-  name: "mendelu-dark";
+  name: 'mendelu-dark';
   default: true;
   color-scheme: dark;
 
@@ -109,7 +112,7 @@ html, body, #root {
   /* Brand colors - preserved */
   --color-primary: #79be15;
   --color-primary-content: #ffffff;
-  --color-secondary: #8DC843;
+  --color-secondary: #8dc843;
   --color-secondary-content: #ffffff;
   --color-accent: #3b82f6;
   --color-accent-content: #ffffff;
@@ -147,15 +150,15 @@ html, body, #root {
 @theme {
   /* Event Type Colors */
   --color-exam-border: #dc2626;
-  --color-exam-bg: #FEF2F2;
+  --color-exam-bg: #fef2f2;
   --color-exam-text: #991b1b;
 
   --color-lecture-border: #79be15;
-  --color-lecture-bg: #F3FAEA;
+  --color-lecture-bg: #f3faea;
   --color-lecture-text: #365314;
 
   --color-seminar-border: #00548f;
-  --color-seminar-bg: #F0F7FF;
+  --color-seminar-bg: #f0f7ff;
   --color-seminar-text: #1e3a8a;
 
   /* Surface Colors */
@@ -174,7 +177,7 @@ html, body, #root {
   --shadow-drawer: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
 
   /* Typography */
-  --font-inter: "Inter", sans-serif;
+  --font-inter: 'Inter', sans-serif;
 
   /* Minimum touch hit-target (Material/Apple guideline) */
   --size-tap: 2.75rem;
@@ -205,7 +208,9 @@ html, body, #root {
 /* Clickable link styles - explicit hover effects */
 .clickable-link {
   cursor: pointer;
-  transition: color 0.2s ease, text-decoration 0.2s ease;
+  transition:
+    color 0.2s ease,
+    text-decoration 0.2s ease;
 }
 
 .clickable-link:hover {
@@ -338,7 +343,9 @@ html, body, #root {
   font-weight: 700;
   white-space: nowrap;
   pointer-events: none;
-  text-shadow: 0 0 3px rgba(255, 255, 255, 0.9), 0 0 3px rgba(255, 255, 255, 0.9);
+  text-shadow:
+    0 0 3px rgba(255, 255, 255, 0.9),
+    0 0 3px rgba(255, 255, 255, 0.9);
 }
 .leaflet-tooltip.building-label::before {
   display: none;

--- a/src/store/slices/__tests__/createAdminSlice.test.ts
+++ b/src/store/slices/__tests__/createAdminSlice.test.ts
@@ -245,4 +245,17 @@ describe('enterSocietyMode / openSocietyAdmin', () => {
     expect(useAppStore.getState().adminOverlayOpen).toBe(true);
     expect(useAppStore.getState().mapMode).toBe('student');
   });
+
+  it('openSocietyAdmin still requests map focus when already in society mode (feedback, not a no-op)', () => {
+    useAppStore.setState({
+      adminRole: 'association',
+      adminAssociationId: 'supef',
+      mapMode: 'society',
+      mapFocusRequest: 4,
+    });
+    useAppStore.getState().openSocietyAdmin();
+    // Camera re-frame / view switch fires so the click always resolves to something.
+    expect(useAppStore.getState().mapFocusRequest).toBe(5);
+    expect(useAppStore.getState().mapMode).toBe('society');
+  });
 });


### PR DESCRIPTION
## What & why

Three fixes to the campus-map **society-admin** surface where an action ran but showed nothing on screen — so the calendar, the location picker, and "Spravovat spolek" all felt dead even though the code executed. Root-caused by code trace (see the design review that accompanied this work).

### 1. Draft pin now renders (off-campus location picker)
`EventLayer` only drew pins for **saved** events, so clicking the map to place an off-campus point captured `draftCoord` but showed no marker — the only feedback was a tiny button-label flip in the panel. Now a distinct, society-coloured `DraftPin` (pulsing halo) is projected through the same layer-point pipeline as saved pins, so it stays glued on pan/zoom. Clicking the pin re-enters placing. Relaxed the zero-events guard so the pin shows before any event exists.

### 2. "Spravovat spolek" gives feedback
The manage button entered society mode but the **profile popover hosting it never closed**, covering the result — reading as "nothing happened". Now closes the popover (`onNavigate` threaded through `SpolkySection` → `ProfilePopup`/`BottomActions` and `MobileProfileSheet`). The slice already re-enters society mode and bumps `mapFocusRequest`, so the view/camera always resolves.

### 3. Calendar affordance + localized weekdays
`MiniCalendar`'s weekday header was hardcoded Czech, ignoring the `locale` it receives; the trigger looked like a text field. Now the weekday row is localized Monday-first via `Intl`, and the trigger has a chevron so it reads as a dropdown.

## Tests
Adds coverage for each: draft-pin render/hide, weekday localization, popover-close wiring, and the focus-request feedback path when already in society mode.

## Verification
- `npm run typecheck` — clean
- `eslint` on changed files (`--max-warnings=0`) — clean
- `npm run test:run` — 1162 pass incl. the new tests (pre-existing ISKAM fixture failures are unrelated: they read a `.agent/fixtures/` dir absent from CI/checkout)
- `npm run build` — succeeds

## Not included
The larger "authoring console" visual redesign of the `MyEventsPanel` (mode banner, lifecycle colour pills, create-leading empty state) — flagged as follow-up in the review, intentionally out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an interactive draft event pin that stays aligned while zooming and can be clicked to change location.
  - Localized MiniCalendar weekday labels and improved popover positioning, scrolling, and outside-click behavior.
  - Improved room search ranking, prioritizing exact room matches.

- **Bug Fixes**
  - Profile and settings popovers now close correctly when navigating.
  - Added a cleaner single-ring focus style for form fields.
  - Added localized labels for draft map pins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->