### PR TITLE
fix(dev): isolate mock data + reset omitted real-data sections

### DIFF
--- a/src/services/__tests__/loadRealDataSnapshot.test.ts
+++ b/src/services/__tests__/loadRealDataSnapshot.test.ts
@@ -55,7 +55,9 @@ describe('resetRealDataStores', () => {
   it('clears the crawl-data stores when a snapshot exists', async () => {
     vi.stubGlobal(
       'fetch',
-      vi.fn(async () => new Response(JSON.stringify({ subjects: {}, lastSync: 1 }), { status: 200 }))
+      vi.fn(
+        async () => new Response(JSON.stringify({ subjects: {}, lastSync: 1 }), { status: 200 })
+      )
     );
     const { IndexedDBService } = await import('../storage');
     const didClear = await resetRealDataStores();
@@ -63,9 +65,7 @@ describe('resetRealDataStores', () => {
     const cleared = vi.mocked(IndexedDBService.clear).mock.calls.map((c) => c[0]);
     // Exams must be among them — that is the stale-mock store that leaked.
     expect(cleared).toContain('exams');
-    expect(cleared).toEqual(
-      expect.arrayContaining(['schedule', 'subjects', 'exams', 'zaznamnik'])
-    );
+    expect(cleared).toEqual(expect.arrayContaining(['schedule', 'subjects', 'exams', 'zaznamnik']));
     // Must NOT wipe meta (holds user_params/theme the snapshot load depends on).
     expect(cleared).not.toContain('meta');
   });

--- a/src/services/__tests__/loadRealDataSnapshot.test.ts
+++ b/src/services/__tests__/loadRealDataSnapshot.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { loadRealDataSnapshot } from '../loadRealDataSnapshot';
+import { loadRealDataSnapshot, resetRealDataStores } from '../loadRealDataSnapshot';
+
+vi.mock('../storage', () => ({
+  IndexedDBService: { clear: vi.fn(async () => {}) },
+}));
 
 describe('loadRealDataSnapshot', () => {
   beforeEach(() => vi.restoreAllMocks());
@@ -41,5 +45,40 @@ describe('loadRealDataSnapshot', () => {
     const { isContentMessage, Messages } = await import('../../types/messages');
     const msg = Messages.syncUpdate({ lastSync: 1, isSyncing: false });
     expect(isContentMessage(msg)).toBe(true);
+  });
+});
+
+describe('resetRealDataStores', () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('clears the crawl-data stores when a snapshot exists', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify({ subjects: {}, lastSync: 1 }), { status: 200 }))
+    );
+    const { IndexedDBService } = await import('../storage');
+    const didClear = await resetRealDataStores();
+    expect(didClear).toBe(true);
+    const cleared = vi.mocked(IndexedDBService.clear).mock.calls.map((c) => c[0]);
+    // Exams must be among them — that is the stale-mock store that leaked.
+    expect(cleared).toContain('exams');
+    expect(cleared).toEqual(
+      expect.arrayContaining(['schedule', 'subjects', 'exams', 'zaznamnik'])
+    );
+    // Must NOT wipe meta (holds user_params/theme the snapshot load depends on).
+    expect(cleared).not.toContain('meta');
+  });
+
+  it('does NOT clear anything when the snapshot is absent (404 → HTML fallback)', async () => {
+    // Missing file: dev server returns index.html, so res.json() throws.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('<!DOCTYPE html><html></html>', { status: 200 }))
+    );
+    const { IndexedDBService } = await import('../storage');
+    const didClear = await resetRealDataStores();
+    expect(didClear).toBe(false);
+    expect(IndexedDBService.clear).not.toHaveBeenCalled();
   });
 });

--- a/src/services/loadRealDataSnapshot.ts
+++ b/src/services/loadRealDataSnapshot.ts
@@ -1,11 +1,50 @@
 import { Messages } from '../types/messages';
 import type { SyncedData } from '../types/messages';
 import { isInIframe } from '../api/proxyClient';
+import { IndexedDBService } from '../services/storage';
+import type { StoreName } from '../types/storage';
 
 // Non-dotfile so WXT packs it into the dev build; the extension page fetches it
 // from its own origin (chrome-extension://<id>/dev-real-data.json). Gitignored,
 // and DEV-gated below so it is inert in production.
 const SNAPSHOT_URL = '/dev-real-data.json';
+
+// The IDB stores the real-data snapshot is the authoritative source for. In dev
+// real-data mode these are wiped at boot (resetRealDataStores) so a section the
+// snapshot OMITS — e.g. an account with no exam terms, where collectRealData
+// drops `exams` entirely — shows empty instead of inheriting stale data from an
+// earlier VITE_USE_MOCK_DATA session. Without this, boot hydration (fetchExams)
+// reads the old ESN mock ("Czech Language for Foreigners") and the empty-list
+// guard in setExams keeps it on screen even though the snapshot has no exams.
+// Excludes `meta` (holds user_params/theme the snapshot load itself depends on)
+// and CDN-fed stores like success_rates (not part of the snapshot).
+const SNAPSHOT_STORES: StoreName[] = [
+  'schedule', 'exams', 'subjects', 'study_plan', 'cvicne_tests',
+  'odevzdavarny', 'syllabuses', 'classmates', 'zaznamnik', 'files',
+];
+
+/** Dev-only, standalone-only: clear the crawl-data stores so the real-data
+ *  snapshot is the single source of truth for the session. No-op in production,
+ *  inside the extension iframe, AND — critically — when no snapshot is available
+ *  to repopulate from, so a missing snapshot never wipes persisted data with
+ *  nothing to restore it. Returns whether it cleared. */
+export async function resetRealDataStores(): Promise<boolean> {
+  if (!import.meta.env.DEV) return false;
+  if (isInIframe()) return false;
+  if (import.meta.env.VITE_USE_MOCK_DATA === 'true') return false;
+  // Guard: only wipe when a real snapshot actually exists. A missing file makes
+  // the dev server serve the SPA index.html, so res.json() throws — treat that
+  // as "no snapshot" and leave IDB untouched.
+  try {
+    const res = await fetch(SNAPSHOT_URL);
+    if (!res.ok) return false;
+    await res.json();
+  } catch {
+    return false;
+  }
+  await Promise.all(SNAPSHOT_STORES.map((s) => IndexedDBService.clear(s).catch(() => {})));
+  return true;
+}
 
 /** Dev-only, standalone-only: load the scraped real-data snapshot and feed it
  *  through the production REIS_SYNC_UPDATE handler. No-op if unavailable. */

--- a/src/services/loadRealDataSnapshot.ts
+++ b/src/services/loadRealDataSnapshot.ts
@@ -19,8 +19,16 @@ const SNAPSHOT_URL = '/dev-real-data.json';
 // Excludes `meta` (holds user_params/theme the snapshot load itself depends on)
 // and CDN-fed stores like success_rates (not part of the snapshot).
 const SNAPSHOT_STORES: StoreName[] = [
-  'schedule', 'exams', 'subjects', 'study_plan', 'cvicne_tests',
-  'odevzdavarny', 'syllabuses', 'classmates', 'zaznamnik', 'files',
+  'schedule',
+  'exams',
+  'subjects',
+  'study_plan',
+  'cvicne_tests',
+  'odevzdavarny',
+  'syllabuses',
+  'classmates',
+  'zaznamnik',
+  'files',
 ];
 
 /** Dev-only, standalone-only: clear the crawl-data stores so the real-data

--- a/src/services/storage/IndexedDBService.ts
+++ b/src/services/storage/IndexedDBService.ts
@@ -103,7 +103,15 @@ interface ReisDB extends DBSchema {
     };
 }
 
-const DB_NAME = 'reis_db';
+// Mock/demo mode (VITE_USE_MOCK_DATA=true) uses a SEPARATE database so its
+// seeded society data can never bleed into the real one. IndexedDB is
+// origin-scoped and the standalone dev webapp serves every mode from the same
+// origin (localhost), so without this split a demo/screenshot run and a
+// real-data run would share `reis_db` — and flipping the flag off does not clean
+// up, so leftover mock (e.g. the ESN "Czech Language for Foreigners" exam) would
+// hydrate on the next real-data boot. The production extension never sets the
+// flag, so it always uses `reis_db`.
+const DB_NAME = import.meta.env.VITE_USE_MOCK_DATA === 'true' ? 'reis_db_mock' : 'reis_db';
 const DB_VERSION = 21;
 
 // True for the "database connection is closing" / InvalidStateError family that

--- a/src/services/storage/IndexedDBService.ts
+++ b/src/services/storage/IndexedDBService.ts
@@ -1,5 +1,12 @@
 import { openDB, type DBSchema, type IDBPDatabase } from 'idb';
-import type { SubjectsData, SyllabusRequirements, ParsedFile, GradeHistory, DocumentNote, NoteImage } from '../../types/documents';
+import type {
+  SubjectsData,
+  SyllabusRequirements,
+  ParsedFile,
+  GradeHistory,
+  DocumentNote,
+  NoteImage,
+} from '../../types/documents';
 import type { BlockLesson } from '../../types/calendarTypes';
 import type { ExamSubject } from '../../types/exams';
 import type { ClassmatesData } from '../../types/classmates';
@@ -13,94 +20,94 @@ import type { SubjectZaznamnik } from '../../types/zaznamnik';
 import { StoreSchemas, type StoreName } from '../../types/storage';
 
 interface ReisDB extends DBSchema {
-    files: {
-        key: string;
-        value: ParsedFile[] | { cz: ParsedFile[], en: ParsedFile[] }; // Key is courseCode
-    };
-    assessments: {
-        key: string;
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        value: any; // Legacy store — kept for backward compatibility
-    };
-    syllabuses: {
-        key: string;
-        value: SyllabusRequirements | { cz: SyllabusRequirements, en: SyllabusRequirements }; // Key is courseCode
-    };
-    classmates: {
-        key: string;
-        // Keys are either `${courseCode}` (course classmates) or `exam:${terminId}` (per-exam-term classmates)
-        value: ClassmatesData;
-    };
-    exams: {
-        key: string;
-        value: ExamSubject[];
-    };
-    schedule: {
-        key: string;
-        value: BlockLesson[];
-    };
-    subjects: {
-        key: string;
-        value: SubjectsData;
-    };
-    success_rates: {
-        key: string;
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        value: any;
-    };
-    meta: {
-        key: string;
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        value: any;
-    };
-    grade_history: {
-        key: string;
-        value: GradeHistory;
-    };
-    study_plan: {
-        key: string;
-        value: StudyPlan | DualLanguageStudyPlan;
-    };
-    cvicne_tests: {
-        key: string;
-        value: CvicnyTest[];
-    };
-    odevzdavarny: {
-        key: string;
-        value: Odevzdavarna[];
-    };
-    erasmus: {
-        key: string;
-        value: ErasmusCountryData;
-    };
-    document_notes: {
-        key: string;
-        value: DocumentNote;
-    };
-    note_images: {
-        key: string;
-        value: NoteImage;
-    };
-    hidden_items: {
-        key: string;
-        value: HiddenItems;
-    };
-    custom_events: {
-        key: string;
-        value: CalendarCustomEvent;
-    };
-    iskam: {
-        key: string;
-        value: IskamData;
-    };
-    zaznamnik: {
-        key: string;
-        value: SubjectZaznamnik | null; // Key is courseCode
-    };
-    map_rooms: {
-        key: string;        // String(buildingId), e.g. "0" for Q
-        value: import('../../types/campusMap').RoomsCollection;
-    };
+  files: {
+    key: string;
+    value: ParsedFile[] | { cz: ParsedFile[]; en: ParsedFile[] }; // Key is courseCode
+  };
+  assessments: {
+    key: string;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    value: any; // Legacy store — kept for backward compatibility
+  };
+  syllabuses: {
+    key: string;
+    value: SyllabusRequirements | { cz: SyllabusRequirements; en: SyllabusRequirements }; // Key is courseCode
+  };
+  classmates: {
+    key: string;
+    // Keys are either `${courseCode}` (course classmates) or `exam:${terminId}` (per-exam-term classmates)
+    value: ClassmatesData;
+  };
+  exams: {
+    key: string;
+    value: ExamSubject[];
+  };
+  schedule: {
+    key: string;
+    value: BlockLesson[];
+  };
+  subjects: {
+    key: string;
+    value: SubjectsData;
+  };
+  success_rates: {
+    key: string;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    value: any;
+  };
+  meta: {
+    key: string;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    value: any;
+  };
+  grade_history: {
+    key: string;
+    value: GradeHistory;
+  };
+  study_plan: {
+    key: string;
+    value: StudyPlan | DualLanguageStudyPlan;
+  };
+  cvicne_tests: {
+    key: string;
+    value: CvicnyTest[];
+  };
+  odevzdavarny: {
+    key: string;
+    value: Odevzdavarna[];
+  };
+  erasmus: {
+    key: string;
+    value: ErasmusCountryData;
+  };
+  document_notes: {
+    key: string;
+    value: DocumentNote;
+  };
+  note_images: {
+    key: string;
+    value: NoteImage;
+  };
+  hidden_items: {
+    key: string;
+    value: HiddenItems;
+  };
+  custom_events: {
+    key: string;
+    value: CalendarCustomEvent;
+  };
+  iskam: {
+    key: string;
+    value: IskamData;
+  };
+  zaznamnik: {
+    key: string;
+    value: SubjectZaznamnik | null; // Key is courseCode
+  };
+  map_rooms: {
+    key: string; // String(buildingId), e.g. "0" for Q
+    value: import('../../types/campusMap').RoomsCollection;
+  };
 }
 
 // Mock/demo mode (VITE_USE_MOCK_DATA=true) uses a SEPARATE database so its
@@ -117,157 +124,190 @@ const DB_VERSION = 21;
 // True for the "database connection is closing" / InvalidStateError family that
 // a stale handle throws after the underlying connection was closed.
 function isConnectionClosing(e: unknown): boolean {
-    if (e instanceof DOMException && e.name === 'InvalidStateError') return true;
-    const msg = e instanceof Error ? e.message : String(e);
-    return /connection is closing|InvalidStateError/i.test(msg);
+  if (e instanceof DOMException && e.name === 'InvalidStateError') return true;
+  const msg = e instanceof Error ? e.message : String(e);
+  return /connection is closing|InvalidStateError/i.test(msg);
 }
 
 class IndexedDBServiceImpl {
-    // Null when no live connection is held. Self-healing: any close (another tab
-    // upgrading the DB, the extension context being invalidated, or the browser
-    // reaping an idle connection) resets this so the next call reopens, instead
-    // of forever awaiting a dead handle that throws "connection is closing".
-    private dbPromise: Promise<IDBPDatabase<ReisDB>> | null = null;
+  // Null when no live connection is held. Self-healing: any close (another tab
+  // upgrading the DB, the extension context being invalidated, or the browser
+  // reaping an idle connection) resets this so the next call reopens, instead
+  // of forever awaiting a dead handle that throws "connection is closing".
+  private dbPromise: Promise<IDBPDatabase<ReisDB>> | null = null;
 
-    private getDB(): Promise<IDBPDatabase<ReisDB>> {
-        if (!this.dbPromise) {
-            this.dbPromise = openDB<ReisDB>(DB_NAME, DB_VERSION, {
-                upgrade(db) {
-                    const requiredStores: (keyof ReisDB)[] = [
-                        'files', 'assessments', 'syllabuses', 'classmates',
-                        'exams', 'schedule', 'subjects', 'success_rates', 'meta',
-                        'grade_history', 'study_plan', 'cvicne_tests', 'odevzdavarny',
-                        'erasmus', 'document_notes', 'note_images', 'hidden_items', 'custom_events',
-                        'iskam', 'zaznamnik', 'map_rooms'
-                    ];
+  private getDB(): Promise<IDBPDatabase<ReisDB>> {
+    if (!this.dbPromise) {
+      this.dbPromise = openDB<ReisDB>(DB_NAME, DB_VERSION, {
+        upgrade(db) {
+          const requiredStores: (keyof ReisDB)[] = [
+            'files',
+            'assessments',
+            'syllabuses',
+            'classmates',
+            'exams',
+            'schedule',
+            'subjects',
+            'success_rates',
+            'meta',
+            'grade_history',
+            'study_plan',
+            'cvicne_tests',
+            'odevzdavarny',
+            'erasmus',
+            'document_notes',
+            'note_images',
+            'hidden_items',
+            'custom_events',
+            'iskam',
+            'zaznamnik',
+            'map_rooms',
+          ];
 
-                    requiredStores.forEach(store => {
-                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                        if (!db.objectStoreNames.contains(store as any)) {
-                            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                            db.createObjectStore(store as any);
-                        }
-                    });
-                },
-                // A newer DB version (e.g. after an extension update) wants to
-                // open: step aside by closing our connection and dropping the
-                // handle, so the next call reopens at the new version.
-                blocking: () => {
-                    const closing = this.dbPromise;
-                    this.dbPromise = null;
-                    void closing?.then(db => db.close()).catch(() => {});
-                },
-                // Browser closed the connection unexpectedly. Force a reopen.
-                terminated: () => { this.dbPromise = null; },
-            }).catch(err => {
-                this.dbPromise = null;
-                throw err;
-            });
-        }
-        return this.dbPromise;
-    }
-
-    // Runs a DB operation, transparently reopening and retrying once if it fails
-    // because the connection was closing. Single funnel so the self-heal lives
-    // in one place rather than a try/catch at every call site.
-    private async run<T>(op: (db: IDBPDatabase<ReisDB>) => Promise<T>): Promise<T> {
-        try {
-            return await op(await this.getDB());
-        } catch (e) {
-            if (!isConnectionClosing(e)) throw e;
-            this.dbPromise = null;
-            return await op(await this.getDB());
-        }
-    }
-
-
-    private validate<K extends StoreName>(storeName: K, value: unknown): ReisDB[K]['value'] | undefined {
-        const schema = StoreSchemas[storeName];
-        const result = schema.safeParse(value);
-        if (!result.success) return undefined;
-        return result.data as ReisDB[K]['value'];
-    }
-
-    async get<K extends StoreName>(storeName: K, key: string): Promise<ReisDB[K]['value'] | undefined> {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const value = await this.run(db => db.get(storeName as any, key));
-        return value ? this.validate(storeName, value) : undefined;
-    }
-
-
-
-    async set<K extends StoreName>(storeName: K, key: string, value: ReisDB[K]['value']): Promise<void> {
-        // Validate before saving to prevent corrupt data ingress
-        const validated = this.validate(storeName, value);
-        if (!validated) return; // Drop invalid data rather than saving it
-
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        await this.run(db => db.put(storeName as any, validated, key));
-    }
-
-    async setMany<K extends StoreName>(
-        storeName: K,
-        entries: Array<readonly [string, ReisDB[K]['value']]>
-    ): Promise<void> {
-        if (entries.length === 0) return;
-        const validated = entries
-            .map(([key, value]) => [key, this.validate(storeName, value)] as const)
-            .filter((e): e is readonly [string, ReisDB[K]['value']] => e[1] !== undefined);
-        if (validated.length === 0) return;
-
-        await this.run(async db => {
+          requiredStores.forEach((store) => {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const tx = db.transaction(storeName as any, 'readwrite');
-            const store = tx.store;
-            for (const [key, value] of validated) {
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                store.put(value as any, key);
+            if (!db.objectStoreNames.contains(store as any)) {
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              db.createObjectStore(store as any);
             }
-            await tx.done;
-        });
+          });
+        },
+        // A newer DB version (e.g. after an extension update) wants to
+        // open: step aside by closing our connection and dropping the
+        // handle, so the next call reopens at the new version.
+        blocking: () => {
+          const closing = this.dbPromise;
+          this.dbPromise = null;
+          void closing?.then((db) => db.close()).catch(() => {});
+        },
+        // Browser closed the connection unexpectedly. Force a reopen.
+        terminated: () => {
+          this.dbPromise = null;
+        },
+      }).catch((err) => {
+        this.dbPromise = null;
+        throw err;
+      });
     }
+    return this.dbPromise;
+  }
 
-    async delete<K extends keyof ReisDB>(storeName: K, key: string): Promise<void> {
+  // Runs a DB operation, transparently reopening and retrying once if it fails
+  // because the connection was closing. Single funnel so the self-heal lives
+  // in one place rather than a try/catch at every call site.
+  private async run<T>(op: (db: IDBPDatabase<ReisDB>) => Promise<T>): Promise<T> {
+    try {
+      return await op(await this.getDB());
+    } catch (e) {
+      if (!isConnectionClosing(e)) throw e;
+      this.dbPromise = null;
+      return await op(await this.getDB());
+    }
+  }
+
+  private validate<K extends StoreName>(
+    storeName: K,
+    value: unknown
+  ): ReisDB[K]['value'] | undefined {
+    const schema = StoreSchemas[storeName];
+    const result = schema.safeParse(value);
+    if (!result.success) return undefined;
+    return result.data as ReisDB[K]['value'];
+  }
+
+  async get<K extends StoreName>(
+    storeName: K,
+    key: string
+  ): Promise<ReisDB[K]['value'] | undefined> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const value = await this.run((db) => db.get(storeName as any, key));
+    return value ? this.validate(storeName, value) : undefined;
+  }
+
+  async set<K extends StoreName>(
+    storeName: K,
+    key: string,
+    value: ReisDB[K]['value']
+  ): Promise<void> {
+    // Validate before saving to prevent corrupt data ingress
+    const validated = this.validate(storeName, value);
+    if (!validated) return; // Drop invalid data rather than saving it
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await this.run((db) => db.put(storeName as any, validated, key));
+  }
+
+  async setMany<K extends StoreName>(
+    storeName: K,
+    entries: Array<readonly [string, ReisDB[K]['value']]>
+  ): Promise<void> {
+    if (entries.length === 0) return;
+    const validated = entries
+      .map(([key, value]) => [key, this.validate(storeName, value)] as const)
+      .filter((e): e is readonly [string, ReisDB[K]['value']] => e[1] !== undefined);
+    if (validated.length === 0) return;
+
+    await this.run(async (db) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const tx = db.transaction(storeName as any, 'readwrite');
+      const store = tx.store;
+      for (const [key, value] of validated) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        await this.run(db => db.delete(storeName as any, key));
-    }
+        store.put(value as any, key);
+      }
+      await tx.done;
+    });
+  }
 
-    async clear<K extends keyof ReisDB>(storeName: K): Promise<void> {
+  async delete<K extends keyof ReisDB>(storeName: K, key: string): Promise<void> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await this.run((db) => db.delete(storeName as any, key));
+  }
+
+  async clear<K extends keyof ReisDB>(storeName: K): Promise<void> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await this.run((db) => db.clear(storeName as any));
+  }
+
+  async clearAll(): Promise<void> {
+    await this.run(async (db) => {
+      const stores = Array.from(db.objectStoreNames);
+      if (stores.length === 0) return;
+      const tx = db.transaction(stores, 'readwrite');
+      for (const store of stores) {
+        tx.objectStore(store).clear();
+      }
+      await tx.done;
+    });
+  }
+
+  async getAll<K extends StoreName>(storeName: K): Promise<ReisDB[K]['value'][]> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const values = await this.run((db) => db.getAll(storeName as any));
+    return values
+      .map((v) => this.validate(storeName, v))
+      .filter((v): v is ReisDB[K]['value'] => v !== undefined);
+  }
+
+  async getAllWithKeys<K extends StoreName>(
+    storeName: K
+  ): Promise<{ key: string; value: ReisDB[K]['value'] }[]> {
+    const [keys, values] = await this.run((db) =>
+      Promise.all([
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        await this.run(db => db.clear(storeName as any));
-    }
-
-    async clearAll(): Promise<void> {
-        await this.run(async db => {
-            const stores = Array.from(db.objectStoreNames);
-            if (stores.length === 0) return;
-            const tx = db.transaction(stores, 'readwrite');
-            for (const store of stores) {
-                tx.objectStore(store).clear();
-            }
-            await tx.done;
-        });
-    }
-
-    async getAll<K extends StoreName>(storeName: K): Promise<ReisDB[K]['value'][]> {
+        db.getAllKeys(storeName as any),
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const values = await this.run(db => db.getAll(storeName as any));
-        return values.map(v => this.validate(storeName, v)).filter((v): v is ReisDB[K]['value'] => v !== undefined);
-    }
+        db.getAll(storeName as any),
+      ])
+    );
 
-    async getAllWithKeys<K extends StoreName>(storeName: K): Promise<{ key: string, value: ReisDB[K]['value'] }[]> {
-        const [keys, values] = await this.run(db => Promise.all([
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            db.getAllKeys(storeName as any),
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            db.getAll(storeName as any),
-        ]));
-        
-        return (keys as string[]).map((key, i) => {
-            const value = this.validate(storeName, values[i]);
-            return value !== undefined ? { key, value } : null;
-        }).filter((item): item is { key: string, value: ReisDB[K]['value'] } => item !== null);
-    }
+    return (keys as string[])
+      .map((key, i) => {
+        const value = this.validate(storeName, values[i]);
+        return value !== undefined ? { key, value } : null;
+      })
+      .filter((item): item is { key: string; value: ReisDB[K]['value'] } => item !== null);
+  }
 }
 
 export const IndexedDBService = new IndexedDBServiceImpl();

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -37,6 +37,7 @@ import { createRsvpSlice } from './slices/createRsvpSlice';
 import { createAdminSlice } from './slices/createAdminSlice';
 import { syncService } from '../services/sync';
 import { initMockData } from '../utils/initMockData';
+import { resetRealDataStores } from '../services/loadRealDataSnapshot';
 import { FILES_SYNC_CHANNEL, type FilesSyncMessage } from './slices/files/broadcastFilesSync';
 
 export const useAppStore = create<AppState>()((...a) => ({
@@ -83,6 +84,11 @@ export const initializeStore = async () => {
   // Set USE_MOCK_DATA=true in your .env file to enable
   if (import.meta.env.VITE_USE_MOCK_DATA === 'true') {
     await initMockData();
+  } else {
+    // Dev standalone real-data mode: wipe crawl data left in IDB by a previous
+    // mock session BEFORE the tier-1 hydration below reads it, so the snapshot
+    // is the sole source of truth. No-op in production / inside the iframe.
+    await resetRealDataStores();
   }
 
   const s = useAppStore.getState();


### PR DESCRIPTION
## Why

While testing the standalone dev webapp with real data, the **Exams** view showed a mock exam ("Czech Language for Foreigners") while **Subjects** showed real data. Two independent root causes:

1. **Mock and real data shared one IndexedDB.** `reis_db` is origin-scoped, and `dev:web` serves every mode from the same origin. A prior demo/screenshot run with `VITE_USE_MOCK_DATA=true` seeded ESN society data into `reis_db`; flipping the flag off doesn't clean up, so the mock exam persisted into the next real-data session.
2. **Omitted snapshot sections inherited stale data.** The sync handler applies each section only `if (r.section)`. The scraped account has no exam terms, so `collectRealData` drops `exams` entirely — nothing overwrote the leftover mock exam, and the empty-list guard in `setExams` would have preserved it anyway.

## Changes

- **`fix(storage)`** — `DB_NAME` is now `reis_db_mock` when `VITE_USE_MOCK_DATA=true`, else `reis_db`. Mock and real can no longer cross-contaminate. The production extension never sets the flag, so it always uses `reis_db`.
- **`fix(dev)`** — `resetRealDataStores()` clears the crawl-data stores at boot in dev real-data mode so the snapshot is the single source of truth, and a section the snapshot omits shows empty instead of stale data. **Guarded** to only clear when a valid snapshot actually exists, so a missing snapshot never wipes persisted data with nothing to restore it. No-op in production and inside the extension iframe.

Both are **dev/local-only** paths; production extension behavior is unchanged.

## Verification

- Verified live in the standalone webapp: Subjects render real data, Exams correctly show the empty state (account has no exams) — no mock bleed. Real-data session opens only `reis_db`.
- `npm run typecheck` clean, `npm run lint` clean on changed files, 152 unit tests pass (incl. new tests: reset clears when a snapshot exists, no-op when absent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic cleanup of stale local data before loading real data in development mode.
  * Added safeguards to prevent cleanup when snapshot data is unavailable or invalid.

* **Bug Fixes**
  * Mock data now uses a separate local database, preventing it from mixing with real data.

* **Tests**
  * Added coverage for successful cleanup, invalid snapshot responses, and protected metadata storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->