### PR TITLE
chore(deps): ignore TypeScript majors ≥ 6 in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,10 +11,12 @@ updates:
     # week. Lift the matching entry once the blocker below ships a release, then
     # let Dependabot reoffer it.
     ignore:
-      # typescript 6 — typescript-eslint peers `typescript ">=4.8.4 <6.0.0"`.
-      # Lift when typescript-eslint supports TS 6.
+      # typescript 6 & 7 — typescript-eslint@8 peers `typescript ">=4.8.4 <6.1.0"`,
+      # so anything from 6.1 up (incl. the 7.x native port) fails `npm ci` with
+      # ERESOLVE (PR #138 was TS 7.0.2). Block every major >= 6 until the toolchain
+      # widens its peer range; lift once typescript-eslint supports the target major.
       - dependency-name: "typescript"
-        versions: ["6.x"]
+        versions: [">= 6"]
       # eslint 10 / @eslint/js 10 conflict with the eslint peer range used
       # transitively by typescript-eslint. Both must move together. Lift when
       # typescript-eslint supports eslint 10.


### PR DESCRIPTION
## Why

Dependabot opened #138 (TypeScript 5.9.3 → **7.0.2**) and all CI checks failed. Root cause is an upstream peer-range block, not our code:

```
While resolving: typescript-eslint@8.63.0
Found: typescript@7.0.2
Could not resolve dependency:
peer typescript@">=4.8.4 <6.1.0" from typescript-eslint@8.63.0
```

`npm ci` dies with **ERESOLVE** before typecheck/tests/format even run — so every check fails at install. `typescript-eslint@8` caps TypeScript below `6.1.0`, so TS 7 (and 6.1+) cannot install until the toolchain widens its peer range.

## What

This is the same class of upstream-blocked major the repo already documents and ignores. The existing ignore rule only covered `6.x`, so TS 7.0.2 slipped through and reopened the failing-PR loop. Widen it to `>= 6` so these stop reoffering weekly.

Lift the entry once `typescript-eslint` supports the target major, then let Dependabot reoffer it.

Closes the loop behind #138 (that PR is closed separately — it can't merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)