### PR TITLE
Library study rooms: fix blank availability, modern calendar picker, 60-day advance booking, commitment checkbox

### DIFF
--- a/src/components/CampusMap/LibraryBookingDialog.tsx
+++ b/src/components/CampusMap/LibraryBookingDialog.tsx
@@ -105,10 +105,10 @@ export function LibraryBookingDialog({
               {t('map.libraryBookRealNote')}
             </p>
 
-            <label className="flex cursor-pointer items-start gap-2 text-xs text-base-content/80">
+            <label className="flex cursor-pointer items-center gap-2 text-sm text-base-content/80">
               <input
                 type="checkbox"
-                className="checkbox checkbox-primary checkbox-sm mt-0.5 shrink-0"
+                className="checkbox checkbox-primary checkbox-xs shrink-0"
                 checked={committed}
                 onChange={(e) => setCommitted(e.target.checked)}
               />

--- a/src/components/CampusMap/LibraryBookingDialog.tsx
+++ b/src/components/CampusMap/LibraryBookingDialog.tsx
@@ -36,6 +36,7 @@ export function LibraryBookingDialog({
   const [email, setEmail] = useState(useAppStore.getState().userEmail ?? '');
   const [sid, setSid] = useState(useAppStore.getState().studentId ?? '');
   const [showMissing, setShowMissing] = useState(false);
+  const [committed, setCommitted] = useState(false);
 
   const identity = { name, email, studentId: sid };
   const missing = missingIdentityFields(identity);
@@ -104,6 +105,16 @@ export function LibraryBookingDialog({
               {t('map.libraryBookRealNote')}
             </p>
 
+            <label className="flex cursor-pointer items-start gap-2 text-xs text-base-content/80">
+              <input
+                type="checkbox"
+                className="checkbox checkbox-primary checkbox-sm mt-0.5 shrink-0"
+                checked={committed}
+                onChange={(e) => setCommitted(e.target.checked)}
+              />
+              <span>{t('map.libraryBookCommit')}</span>
+            </label>
+
             <div className="flex justify-end gap-2">
               <button type="button" className="btn btn-ghost btn-sm" onClick={onClose}>
                 {t('common.cancel')}
@@ -111,7 +122,7 @@ export function LibraryBookingDialog({
               <button
                 type="button"
                 className="btn btn-primary btn-sm"
-                disabled={status === 'submitting'}
+                disabled={status === 'submitting' || !committed}
                 onClick={submit}
               >
                 {status === 'submitting' && <span className="loading loading-spinner loading-xs" />}

--- a/src/components/CampusMap/LibraryOverviewPanel.tsx
+++ b/src/components/CampusMap/LibraryOverviewPanel.tsx
@@ -167,7 +167,6 @@ export function LibraryOverviewPanel() {
             hours={hours}
             hour={activeHour}
             onHour={setHour}
-            now={now}
             loc={loc}
           />
         )}

--- a/src/components/CampusMap/LibrarySlotPicker.tsx
+++ b/src/components/CampusMap/LibrarySlotPicker.tsx
@@ -42,6 +42,8 @@ export function LibrarySlotPicker({
           if (i !== undefined) onDay(i);
         }}
         isDisabled={(iso) => !indexByISO.has(iso)}
+        minDate={dayISO(days[0]!)}
+        maxDate={dayISO(days[days.length - 1]!)}
         placeholder={t('map.libraryPickDay')}
         t={t}
         locale={loc}

--- a/src/components/CampusMap/LibrarySlotPicker.tsx
+++ b/src/components/CampusMap/LibrarySlotPicker.tsx
@@ -1,19 +1,15 @@
 import { useTranslation } from '@/hooks/useTranslation';
+import { MiniCalendar } from './MiniCalendar';
+import { toISO } from './calendar';
 
-function isSameDay(a: Date, b: Date): boolean {
-  return a.toDateString() === b.toDateString();
+function dayISO(d: Date): string {
+  return toISO(d.getFullYear(), d.getMonth(), d.getDate());
 }
 
-function dayLabel(d: Date, now: Date, loc: string, t: (k: string) => string): string {
-  if (isSameDay(d, now)) return t('map.libraryDayToday');
-  const tomorrow = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1);
-  if (isSameDay(d, tomorrow)) return t('map.libraryDayTomorrow');
-  return d.toLocaleDateString(loc, { weekday: 'short', day: 'numeric', month: 'numeric' });
-}
-
-// A two-row control: pick a day, then optionally an exact hour. "Any time"
-// (hour = null) is the default and shows each room's open windows; picking an
-// hour switches the rooms to a free/busy answer for that precise slot.
+// Pick a day from the shared MiniCalendar (only bookable days are selectable),
+// then optionally an exact hour. "Any time" (hour = null) is the default and
+// shows each room's open windows; picking an hour switches the rooms to a
+// precise free/busy answer for that slot. Hours stay a compact pill row.
 export function LibrarySlotPicker({
   days,
   dayIdx,
@@ -21,7 +17,6 @@ export function LibrarySlotPicker({
   hours,
   hour,
   onHour,
-  now,
   loc,
 }: {
   days: Date[];
@@ -30,27 +25,27 @@ export function LibrarySlotPicker({
   hours: number[];
   hour: number | null;
   onHour: (h: number | null) => void;
-  now: Date;
   loc: string;
 }) {
   const { t } = useTranslation();
   const pill = 'btn btn-xs shrink-0 rounded-full font-medium';
 
+  const selected = days[Math.min(dayIdx, days.length - 1)]!;
+  const indexByISO = new Map(days.map((d, i) => [dayISO(d), i]));
+
   return (
     <div className="space-y-1.5">
-      <div className="flex gap-1 overflow-x-auto pb-0.5">
-        {days.map((d, i) => (
-          <button
-            key={d.toDateString()}
-            type="button"
-            aria-pressed={i === dayIdx}
-            className={`${pill} ${i === dayIdx ? 'btn-primary' : 'btn-ghost'}`}
-            onClick={() => onDay(i)}
-          >
-            {dayLabel(d, now, loc, t)}
-          </button>
-        ))}
-      </div>
+      <MiniCalendar
+        value={dayISO(selected)}
+        onChange={(iso) => {
+          const i = indexByISO.get(iso);
+          if (i !== undefined) onDay(i);
+        }}
+        isDisabled={(iso) => !indexByISO.has(iso)}
+        placeholder={t('map.libraryPickDay')}
+        t={t}
+        locale={loc}
+      />
       <div className="flex gap-1 overflow-x-auto pb-0.5">
         <button
           type="button"

--- a/src/components/CampusMap/MiniCalendar.tsx
+++ b/src/components/CampusMap/MiniCalendar.tsx
@@ -26,6 +26,8 @@ export function MiniCalendar({
   t,
   locale,
   isDisabled,
+  minDate,
+  maxDate,
 }: {
   value: string | null;
   onChange: (iso: string) => void;
@@ -35,6 +37,11 @@ export function MiniCalendar({
   // Optional gate: return true for a day that can't be picked (greyed, inert).
   // Omitted → every day is selectable (the original behaviour).
   isDisabled?: (iso: string) => boolean;
+  // Optional ISO bounds that stop month paging past the selectable range, so a
+  // user can't wander into all-greyed months with no explanation. Omitted → the
+  // chevrons page freely (the original behaviour).
+  minDate?: string;
+  maxDate?: string;
 }) {
   const parsed = value ? parseISO(value) : null;
   const [view, setView] = useState(
@@ -58,6 +65,15 @@ export function MiniCalendar({
       })
     : placeholder;
   const monthName = new Date(view.y, view.m0, 1).toLocaleDateString(locale, { month: 'long' });
+
+  // Bound month paging to the min/max range (compared by year*12+month), so the
+  // chevrons stop at the edge of the selectable window instead of paging into
+  // empty months.
+  const viewMonth = view.y * 12 + view.m0;
+  const minP = minDate ? parseISO(minDate) : null;
+  const maxP = maxDate ? parseISO(maxDate) : null;
+  const prevDisabled = minP ? viewMonth <= minP.y * 12 + minP.m0 : false;
+  const nextDisabled = maxP ? viewMonth >= maxP.y * 12 + maxP.m0 : false;
 
   // Anchor the popover to the trigger in viewport coords. It's portalled to
   // <body> so the side-panel's overflow-hidden can't clip it. Right-align it to
@@ -137,9 +153,10 @@ export function MiniCalendar({
             <div className="mb-3 flex items-center justify-between">
               <button
                 type="button"
-                className="flex h-7 w-7 items-center justify-center rounded-full text-base-content/70 transition-colors hover:bg-base-content/10"
+                disabled={prevDisabled}
+                className={`flex h-7 w-7 items-center justify-center rounded-full text-base-content/70 transition-colors ${prevDisabled ? 'opacity-30' : 'hover:bg-base-content/10'}`}
                 aria-label={t('map.prevMonth')}
-                onClick={() => setView((v) => addMonths(v.y, v.m0, -1))}
+                onClick={() => !prevDisabled && setView((v) => addMonths(v.y, v.m0, -1))}
               >
                 <ChevronLeft size={16} />
               </button>
@@ -149,9 +166,10 @@ export function MiniCalendar({
               </span>
               <button
                 type="button"
-                className="flex h-7 w-7 items-center justify-center rounded-full text-base-content/70 transition-colors hover:bg-base-content/10"
+                disabled={nextDisabled}
+                className={`flex h-7 w-7 items-center justify-center rounded-full text-base-content/70 transition-colors ${nextDisabled ? 'opacity-30' : 'hover:bg-base-content/10'}`}
                 aria-label={t('map.nextMonth')}
-                onClick={() => setView((v) => addMonths(v.y, v.m0, 1))}
+                onClick={() => !nextDisabled && setView((v) => addMonths(v.y, v.m0, 1))}
               >
                 <ChevronRight size={16} />
               </button>

--- a/src/components/CampusMap/MiniCalendar.tsx
+++ b/src/components/CampusMap/MiniCalendar.tsx
@@ -25,12 +25,16 @@ export function MiniCalendar({
   placeholder,
   t,
   locale,
+  isDisabled,
 }: {
   value: string | null;
   onChange: (iso: string) => void;
   placeholder: string;
   t: (k: string) => string;
   locale: string;
+  // Optional gate: return true for a day that can't be picked (greyed, inert).
+  // Omitted → every day is selectable (the original behaviour).
+  isDisabled?: (iso: string) => boolean;
 }) {
   const parsed = value ? parseISO(value) : null;
   const [view, setView] = useState(
@@ -169,24 +173,32 @@ export function MiniCalendar({
                   const iso = toISO(view.y, view.m0, d);
                   const sel = iso === value;
                   const isToday = iso === todayISO;
+                  const disabled = isDisabled?.(iso) ?? false;
                   return (
                     <button
                       key={i}
                       type="button"
+                      disabled={disabled}
                       aria-pressed={sel}
                       aria-current={isToday ? 'date' : undefined}
                       className={[
                         'flex h-8 w-8 items-center justify-center rounded-full text-sm tabular-nums transition-colors',
-                        sel
-                          ? 'bg-primary font-semibold text-primary-content hover:bg-primary/90'
-                          : isToday
-                            ? 'font-semibold text-primary ring-1 ring-inset ring-primary/50 hover:bg-primary/10'
-                            : 'text-base-content hover:bg-base-content/10',
+                        disabled
+                          ? 'cursor-not-allowed text-base-content/20'
+                          : sel
+                            ? 'bg-primary font-semibold text-primary-content hover:bg-primary/90'
+                            : isToday
+                              ? 'font-semibold text-primary ring-1 ring-inset ring-primary/50 hover:bg-primary/10'
+                              : 'text-base-content hover:bg-base-content/10',
                       ].join(' ')}
-                      onClick={() => {
-                        onChange(iso);
-                        setOpen(false);
-                      }}
+                      onClick={
+                        disabled
+                          ? undefined
+                          : () => {
+                              onChange(iso);
+                              setOpen(false);
+                            }
+                      }
                     >
                       {d}
                     </button>

--- a/src/components/CampusMap/__tests__/LibraryBookingDialog.test.tsx
+++ b/src/components/CampusMap/__tests__/LibraryBookingDialog.test.tsx
@@ -1,0 +1,27 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { LibraryBookingDialog } from '../LibraryBookingDialog';
+import { useAppStore } from '@/store/useAppStore';
+import { LIBRARY_ROOMS } from '@/data/map/libraryRooms';
+
+const room = LIBRARY_ROOMS[0]!;
+
+beforeEach(() => {
+  useAppStore.setState({ language: 'en', bookingStatus: {}, bookingError: {} });
+});
+
+describe('LibraryBookingDialog commitment', () => {
+  it('keeps Confirm disabled until the show-up commitment is checked', () => {
+    render(
+      <LibraryBookingDialog room={room} slotIso="2026-07-22T11:00:00" onClose={() => {}} />
+    );
+    const confirm = screen.getByRole('button', { name: 'Confirm booking' });
+    expect(confirm).toBeDisabled();
+
+    fireEvent.click(screen.getByRole('checkbox'));
+    expect(confirm).toBeEnabled();
+
+    fireEvent.click(screen.getByRole('checkbox')); // untick → gated again
+    expect(confirm).toBeDisabled();
+  });
+});

--- a/src/components/CampusMap/__tests__/LibraryBookingDialog.test.tsx
+++ b/src/components/CampusMap/__tests__/LibraryBookingDialog.test.tsx
@@ -12,9 +12,7 @@ beforeEach(() => {
 
 describe('LibraryBookingDialog commitment', () => {
   it('keeps Confirm disabled until the show-up commitment is checked', () => {
-    render(
-      <LibraryBookingDialog room={room} slotIso="2026-07-22T11:00:00" onClose={() => {}} />
-    );
+    render(<LibraryBookingDialog room={room} slotIso="2026-07-22T11:00:00" onClose={() => {}} />);
     const confirm = screen.getByRole('button', { name: 'Confirm booking' });
     expect(confirm).toBeDisabled();
 

--- a/src/components/CampusMap/__tests__/LibrarySlotPicker.test.tsx
+++ b/src/components/CampusMap/__tests__/LibrarySlotPicker.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { LibrarySlotPicker } from '../LibrarySlotPicker';
+import { useAppStore } from '@/store/useAppStore';
+
+// The picker reads strings through useTranslation (store-backed). Pin the
+// language so the hour labels ("Any time") are stable.
+beforeEach(() => useAppStore.setState({ language: 'en' }));
+
+const baseProps = {
+  days: [new Date(2026, 7, 3), new Date(2026, 7, 4), new Date(2026, 7, 5)],
+  dayIdx: 1,
+  hours: [8, 9, 10],
+  hour: null as number | null,
+  loc: 'en-US',
+};
+
+// The day field is the MiniCalendar trigger — its label carries the year.
+const openCalendar = () => fireEvent.click(screen.getByText(/2026/).closest('button')!);
+
+describe('LibrarySlotPicker', () => {
+  it('opens a calendar and picks a bookable day → onDay with its index', () => {
+    const onDay = vi.fn();
+    render(<LibrarySlotPicker {...baseProps} onDay={onDay} onHour={() => {}} />);
+    openCalendar();
+    fireEvent.click(screen.getByRole('button', { name: '3' })); // Aug 3 = index 0
+    expect(onDay).toHaveBeenCalledWith(0);
+  });
+
+  it('greys out and blocks days that are not on offer', () => {
+    const onDay = vi.fn();
+    render(<LibrarySlotPicker {...baseProps} onDay={onDay} onHour={() => {}} />);
+    openCalendar();
+    const closed = screen.getByRole('button', { name: '10' }); // not in `days`
+    expect(closed).toBeDisabled();
+    fireEvent.click(closed);
+    expect(onDay).not.toHaveBeenCalled();
+  });
+
+  it('renders an Any-time toggle plus one pill per open hour', () => {
+    render(<LibrarySlotPicker {...baseProps} onDay={() => {}} onHour={() => {}} />);
+    expect(screen.getByRole('button', { name: 'Any time' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+    for (const h of baseProps.hours) {
+      expect(screen.getByRole('button', { name: `${h}:00` })).toBeInTheDocument();
+    }
+  });
+
+  it('calls onHour with the picked hour, and null for Any time', () => {
+    const onHour = vi.fn();
+    render(<LibrarySlotPicker {...baseProps} hour={9} onDay={() => {}} onHour={onHour} />);
+    fireEvent.click(screen.getByRole('button', { name: '10:00' }));
+    expect(onHour).toHaveBeenCalledWith(10);
+    fireEvent.click(screen.getByRole('button', { name: 'Any time' }));
+    expect(onHour).toHaveBeenCalledWith(null);
+  });
+});

--- a/src/components/CampusMap/__tests__/MiniCalendar.test.tsx
+++ b/src/components/CampusMap/__tests__/MiniCalendar.test.tsx
@@ -120,6 +120,25 @@ describe('MiniCalendar', () => {
     if (innerHeight) Object.defineProperty(window, 'innerHeight', innerHeight);
   });
 
+  it('disables days rejected by isDisabled and never emits them', () => {
+    const onChange = vi.fn();
+    render(
+      <MiniCalendar
+        value="2026-07-15"
+        onChange={onChange}
+        placeholder="Pick a date"
+        t={t}
+        locale="en-US"
+        isDisabled={(iso) => iso !== '2026-07-15'}
+      />
+    );
+    fireEvent.click(screen.getByText(/2026/).closest('button')!);
+    const other = screen.getByRole('button', { name: '16' });
+    expect(other).toBeDisabled();
+    fireEvent.click(other);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
   it('closes the popover when clicking outside', () => {
     render(
       <MiniCalendar

--- a/src/components/CampusMap/__tests__/MiniCalendar.test.tsx
+++ b/src/components/CampusMap/__tests__/MiniCalendar.test.tsx
@@ -139,6 +139,24 @@ describe('MiniCalendar', () => {
     expect(onChange).not.toHaveBeenCalled();
   });
 
+  it('bounds month paging to the min/max range', () => {
+    render(
+      <MiniCalendar
+        value="2026-07-20"
+        onChange={() => {}}
+        placeholder="Pick a date"
+        t={t}
+        locale="en-US"
+        minDate="2026-07-20"
+        maxDate="2026-09-16"
+      />
+    );
+    fireEvent.click(screen.getByText(/2026/).closest('button')!);
+    // Viewing July (the min month): can't page back, can page forward toward Sept.
+    expect(screen.getByRole('button', { name: 'map.prevMonth' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'map.nextMonth' })).toBeEnabled();
+  });
+
   it('closes the popover when clicking outside', () => {
     render(
       <MiniCalendar

--- a/src/data/map/__tests__/libraryRooms.test.ts
+++ b/src/data/map/__tests__/libraryRooms.test.ts
@@ -66,6 +66,8 @@ describe('indexAvailabilityByRoom', () => {
     expect(Object.keys(map)).toHaveLength(7);
     for (const room of LIBRARY_ROOMS) {
       expect(map[room.staffGuid]?.serviceId).toBe(room.serviceId);
+      // the stored object's own guid is rewritten to match its key, not the shared API guid
+      expect(map[room.staffGuid]?.staffGuid).toBe(room.staffGuid);
     }
     // The shared API guid must NOT survive as a key — that was the bug: all 7
     // rooms collapsed to a single entry and every per-room lookup missed.

--- a/src/data/map/__tests__/libraryRooms.test.ts
+++ b/src/data/map/__tests__/libraryRooms.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import roomsIndex from '@/data/map/rooms-index.json';
-import { LIBRARY_ROOMS, LIBRARY_PLACE_IDS, libraryRoomsByPlaceId } from '@/data/map/libraryRooms';
+import {
+  LIBRARY_ROOMS,
+  LIBRARY_PLACE_IDS,
+  libraryRoomsByPlaceId,
+  indexAvailabilityByRoom,
+} from '@/data/map/libraryRooms';
+import type { RoomAvailability } from '@/types/library';
 
 const INDEX = roomsIndex as Array<{ placeId: number; buildingId: number; floorId: number }>;
 
@@ -38,5 +44,38 @@ describe('libraryRooms', () => {
   it('groups the two IC rooms under the shared placeId 57640', () => {
     expect(libraryRoomsByPlaceId(57640)).toHaveLength(2);
     expect(LIBRARY_PLACE_IDS.has(57640)).toBe(true);
+  });
+});
+
+describe('indexAvailabilityByRoom', () => {
+  // The Bookings availability API returns every study room under ONE shared
+  // staff GUID (a single scheduling mailbox), distinguished only by serviceId.
+  // The app identifies rooms by their own per-room staffGuid, so indexing must
+  // fan the shared-guid rows back out to each room's staffGuid via serviceId.
+  const SHARED = '8a0cb634-8abc-4ee1-ba84-f9ba54cd6d7d';
+  const apiRooms: RoomAvailability[] = LIBRARY_ROOMS.map((r) => ({
+    staffGuid: SHARED,
+    serviceId: r.serviceId,
+    webUrl: `https://example/${r.serviceId}`,
+    leadMinutes: r.leadMinutes,
+    blocks: [{ status: 'AVAILABLE', start: '2026-07-20T08:00:00', end: '2026-07-20T16:00:00' }],
+  }));
+
+  it("keys availability by each room's own staffGuid, not the shared API guid", () => {
+    const map = indexAvailabilityByRoom(apiRooms);
+    expect(Object.keys(map)).toHaveLength(7);
+    for (const room of LIBRARY_ROOMS) {
+      expect(map[room.staffGuid]?.serviceId).toBe(room.serviceId);
+    }
+    // The shared API guid must NOT survive as a key — that was the bug: all 7
+    // rooms collapsed to a single entry and every per-room lookup missed.
+    expect(map[SHARED]).toBeUndefined();
+  });
+
+  it('drops availability rows whose serviceId is not a known room', () => {
+    const map = indexAvailabilityByRoom([
+      { staffGuid: SHARED, serviceId: 'unknown-service', webUrl: '', leadMinutes: 60, blocks: [] },
+    ]);
+    expect(Object.keys(map)).toHaveLength(0);
   });
 });

--- a/src/data/map/libraryRooms.ts
+++ b/src/data/map/libraryRooms.ts
@@ -124,7 +124,9 @@ export function indexAvailabilityByRoom(
   const out: Record<string, RoomAvailability> = {};
   for (const room of LIBRARY_ROOMS) {
     const a = byServiceId.get(room.serviceId);
-    if (a) out[room.staffGuid] = a;
+    // Overwrite the row's `staffGuid` (the shared API mailbox guid) with the
+    // room's own guid so the object is self-consistent with its map key.
+    if (a) out[room.staffGuid] = { ...a, staffGuid: room.staffGuid };
   }
   return out;
 }

--- a/src/data/map/libraryRooms.ts
+++ b/src/data/map/libraryRooms.ts
@@ -1,4 +1,4 @@
-import type { LibraryRoom } from '@/types/library';
+import type { LibraryRoom, RoomAvailability } from '@/types/library';
 
 const BOOKING_BASE =
   'https://outlook.office.com/book/RezervacestudovenMENDELU@mendelu.onmicrosoft.com/s';
@@ -106,4 +106,25 @@ export const LIBRARY_PLACE_IDS: Set<number> = new Set(LIBRARY_ROOMS.map((r) => r
 
 export function libraryRoomsByPlaceId(placeId: number): LibraryRoom[] {
   return LIBRARY_ROOMS.filter((r) => r.placeId === placeId);
+}
+
+// Reconcile the Bookings availability API's identity with the app's. The API
+// returns every study room under ONE shared staff GUID (a single scheduling
+// mailbox), telling rooms apart only by `serviceId`. The rest of the app keys a
+// room by its own per-room `staffGuid` (the id the booking-create path sends and
+// the edge's allow-list validates). So index availability by that per-room
+// staffGuid, matching each API row to a room on the unique serviceId. Rows whose
+// serviceId isn't a known room are dropped. Keying the API rows directly by their
+// `staffGuid` would collapse all rooms into one entry — the shared guid — and
+// leave every per-room lookup missing.
+export function indexAvailabilityByRoom(
+  rooms: RoomAvailability[]
+): Record<string, RoomAvailability> {
+  const byServiceId = new Map(rooms.map((r) => [r.serviceId, r]));
+  const out: Record<string, RoomAvailability> = {};
+  for (const room of LIBRARY_ROOMS) {
+    const a = byServiceId.get(room.serviceId);
+    if (a) out[room.staffGuid] = a;
+  }
+  return out;
 }

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -1069,6 +1069,7 @@
     "libraryBook": "Rezervovat studovnu",
     "libraryFullShort": "plno",
     "libraryAnyTime": "Kdykoliv",
+    "libraryPickDay": "Vyberte den",
     "libraryDayToday": "Dnes",
     "libraryDayTomorrow": "Zítra",
     "libraryFreeAt": "Volno",

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -1082,6 +1082,7 @@
     "libraryBookStudentId": "Studentské / zaměstnanecké číslo",
     "libraryBookConfirmCta": "Potvrdit rezervaci",
     "libraryBookRealNote": "Vytvoří skutečnou rezervaci a odešle potvrzení do knihovny.",
+    "libraryBookCommit": "Zavazuji se, že na rezervaci přijdu.",
     "libraryBookSuccess": "Rezervováno!",
     "libraryBookConflict": "Tento termín byl právě obsazen — zkuste jiný.",
     "libraryBookRateLimited": "Nedávno jste rezervovali několik místností — zkuste to později.",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1082,6 +1082,7 @@
     "libraryBookStudentId": "Student / employee ID",
     "libraryBookConfirmCta": "Confirm booking",
     "libraryBookRealNote": "Creates a real reservation and emails the library.",
+    "libraryBookCommit": "I commit to showing up for my reservation.",
     "libraryBookSuccess": "Booked!",
     "libraryBookConflict": "That time was just taken — pick another.",
     "libraryBookRateLimited": "You've booked several rooms recently — try again later.",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1069,6 +1069,7 @@
     "libraryBook": "Book a study room",
     "libraryFullShort": "full",
     "libraryAnyTime": "Any time",
+    "libraryPickDay": "Pick a day",
     "libraryDayToday": "Today",
     "libraryDayTomorrow": "Tomorrow",
     "libraryFreeAt": "Free",

--- a/src/services/library/__tests__/availabilityView.test.ts
+++ b/src/services/library/__tests__/availabilityView.test.ts
@@ -28,6 +28,21 @@ describe('pickableDays', () => {
     const now = new Date('2026-07-20T23:00:00'); // Monday, after hours
     expect(pickableDays(blocks, now).map(ymd)).toEqual(['2026-07-20']);
   });
+
+  it('offers well beyond a week when availability reaches further (advance booking)', () => {
+    // Three weeks of open weekdays from a Monday → 15 bookable days. The old
+    // 7-day horizon clipped this to a single week; advance booking needs the
+    // full run, bounded only by the fetched window / MS maximumAdvance.
+    const now = new Date('2026-07-20T07:00:00'); // Monday
+    const many: AvailabilityBlock[] = [];
+    for (let i = 0; i < 21; i++) {
+      const d = new Date(2026, 6, 20 + i);
+      if (d.getDay() === 0 || d.getDay() === 6) continue; // skip weekends
+      const iso = ymd(d);
+      many.push({ status: 'AVAILABLE', start: `${iso}T08:00:00`, end: `${iso}T16:00:00` });
+    }
+    expect(pickableDays(many, now)).toHaveLength(15);
+  });
 });
 
 describe('openStartHours', () => {

--- a/src/services/library/availabilityView.ts
+++ b/src/services/library/availabilityView.ts
@@ -11,8 +11,10 @@ function startOfDay(d: Date): Date {
 // plus every later open day that still has an AVAILABLE window ending in the
 // future, capped at `horizon` days and sorted ascending. Weekends are dropped —
 // the library is closed then (see isOpenDay). Fed the union of all rooms' blocks
-// so the picker covers any day any room is open.
-export function pickableDays(blocks: AvailabilityBlock[], now: Date, horizon = 7): Date[] {
+// so the picker covers any day any room is open. The default matches MS Bookings'
+// `maximumAdvance` (P60D) so the horizon never clips before the real ceiling —
+// the fetched availability window (edge fn) and MS's own policy bound it instead.
+export function pickableDays(blocks: AvailabilityBlock[], now: Date, horizon = 60): Date[] {
   const today = startOfDay(now);
   const days = new Map<string, Date>();
   if (isOpenDay(today)) days.set(today.toDateString(), today);

--- a/src/store/slices/__tests__/libraryAvailability.test.ts
+++ b/src/store/slices/__tests__/libraryAvailability.test.ts
@@ -1,23 +1,39 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('@/api/libraryAvailability', () => ({
-  fetchLibraryAvailability: vi.fn(async () => [
-    { staffGuid: 'g1', serviceId: 's1', webUrl: 'u', leadMinutes: 60, blocks: [] },
-  ]),
+  fetchLibraryAvailability: vi.fn(),
 }));
 
 import { useAppStore } from '@/store/useAppStore';
 import { fetchLibraryAvailability } from '@/api/libraryAvailability';
+import { LIBRARY_ROOMS } from '@/data/map/libraryRooms';
+
+const room = LIBRARY_ROOMS[0]!;
+const SHARED = 'shared-scheduling-mailbox-guid';
 
 describe('loadLibraryAvailability', () => {
   beforeEach(() => {
     useAppStore.setState({ libraryAvailability: {}, libraryAvailabilityLoaded: false });
     vi.clearAllMocks();
+    // The Bookings API returns every room under ONE shared staff GUID, keyed
+    // apart only by serviceId (see indexAvailabilityByRoom).
+    vi.mocked(fetchLibraryAvailability).mockResolvedValue([
+      {
+        staffGuid: SHARED,
+        serviceId: room.serviceId,
+        webUrl: 'u',
+        leadMinutes: room.leadMinutes,
+        blocks: [],
+      },
+    ]);
   });
 
-  it('populates libraryAvailability keyed by staffGuid', async () => {
+  it("keys availability by each room's own staffGuid, matched on serviceId", async () => {
     await useAppStore.getState().loadLibraryAvailability();
-    expect(useAppStore.getState().libraryAvailability.g1!.webUrl).toBe('u'); // safe: populated above
+    const map = useAppStore.getState().libraryAvailability;
+    expect(map[room.staffGuid]?.webUrl).toBe('u');
+    // The shared API guid must NOT survive as a key (that was the display bug).
+    expect(map[SHARED]).toBeUndefined();
     expect(useAppStore.getState().libraryAvailabilityLoaded).toBe(true);
   });
 

--- a/src/store/slices/__tests__/libraryAvailability.test.ts
+++ b/src/store/slices/__tests__/libraryAvailability.test.ts
@@ -32,6 +32,8 @@ describe('loadLibraryAvailability', () => {
     await useAppStore.getState().loadLibraryAvailability();
     const map = useAppStore.getState().libraryAvailability;
     expect(map[room.staffGuid]?.webUrl).toBe('u');
+    // Stored object's guid is rewritten to its key, not the shared API mailbox guid.
+    expect(map[room.staffGuid]?.staffGuid).toBe(room.staffGuid);
     // The shared API guid must NOT survive as a key (that was the display bug).
     expect(map[SHARED]).toBeUndefined();
     expect(useAppStore.getState().libraryAvailabilityLoaded).toBe(true);

--- a/src/store/slices/createMapSlice.ts
+++ b/src/store/slices/createMapSlice.ts
@@ -22,6 +22,7 @@ import {
 import { fetchBuildingRooms } from '../../api/campusMap';
 import { fetchMapEvents, toMapEvent } from '../../api/mapEvents';
 import { fetchLibraryAvailability } from '@/api/libraryAvailability';
+import { indexAvailabilityByRoom } from '@/data/map/libraryRooms';
 import { createLibraryBooking } from '@/api/libraryBooking';
 import { buildBookingRequest } from '@/services/library/bookingRequest';
 import { logError } from '../../utils/reportError';
@@ -259,9 +260,10 @@ export const createMapSlice: AppSlice<MapSlice> = (set, get) => ({
     if (get().libraryAvailabilityLoaded) return;
     // fetchLibraryAvailability never throws — it logs and returns [] on failure.
     const rooms = await fetchLibraryAvailability();
-    const byGuid: Record<string, (typeof rooms)[number]> = {};
-    for (const r of rooms) byGuid[r.staffGuid] = r;
-    set({ libraryAvailability: byGuid, libraryAvailabilityLoaded: true });
+    // The API returns all rooms under one shared staff GUID; index by each room's
+    // own per-room staffGuid (matched on serviceId) so every reader's
+    // `availability[room.staffGuid]` lookup resolves. See indexAvailabilityByRoom.
+    set({ libraryAvailability: indexAvailabilityByRoom(rooms), libraryAvailabilityLoaded: true });
   },
 
   bookRoom: async (room, slotIso, identity) => {

--- a/supabase/functions/bookings-availability/index.ts
+++ b/supabase/functions/bookings-availability/index.ts
@@ -69,7 +69,11 @@ serve(async (req: Request) => {
 
     const now = new Date();
     const start = new Date(now.getTime() - 24 * 3600_000);
-    const end = new Date(now.getTime() + 5 * 24 * 3600_000);
+    // 60 days ahead — MENDELU's Bookings business allows booking up to its
+    // maximumAdvance (P60D). MS only reports AVAILABLE within its own policy, so
+    // a wider window never over-offers; it just stops throttling advance booking
+    // to a few days. Payload stays small (one block-run per open day per room).
+    const end = new Date(now.getTime() + 60 * 24 * 3600_000);
 
     const rooms = (
       await Promise.all(

--- a/supabase/functions/bookings-availability/index.ts
+++ b/supabase/functions/bookings-availability/index.ts
@@ -81,7 +81,11 @@ serve(async (req: Request) => {
     // ~4-concurrent throttle and, over a 60-day window (MS latency is variable,
     // seen up to ~8.5s), blow the fetch timeout and drop every room. A generous
     // 15s timeout absorbs a slow-but-valid response instead of aborting it.
-    const uniqueGuids = [...new Set<string>(services.map((s: any) => s.staffMemberIds[0]))];
+    // staffMemberIds is non-empty here (services was filtered above), but drop any
+    // falsy GUID defensively so a malformed entry never becomes a wasted lookup.
+    const uniqueGuids = [
+      ...new Set<string>(services.map((s: any) => s.staffMemberIds?.[0]).filter(Boolean)),
+    ];
     const availByGuid = new Map<string, unknown[]>();
     await Promise.all(
       uniqueGuids.map(async (guid) => {

--- a/supabase/functions/bookings-availability/index.ts
+++ b/supabase/functions/bookings-availability/index.ts
@@ -75,17 +75,20 @@ serve(async (req: Request) => {
     // to a few days. Payload stays small (one block-run per open day per room).
     const end = new Date(now.getTime() + 60 * 24 * 3600_000);
 
-    const rooms = (
-      await Promise.all(
-        services.map(async (s: any) => {
-          // Isolate per-room failures: without this try/catch a single room's
-          // timeout (fetchWithTimeout aborts → throws) would reject Promise.all
-          // and drop ALL rooms to the outer catch. Omit only the failing room so
-          // the client renders "unknown" for it, not "fully booked" for all.
-          try {
-            const guid = s.staffMemberIds[0];
-            const lead = s.bookingsSchedulingPolicy?.minimumLeadTime === 'P2D' ? 2880 : 60;
-            const availRes = await fetchWithTimeout(`${BASE}GetStaffAvailability`, {
+    // Every service maps to a staff member (currently a single shared scheduling
+    // mailbox), so many services share one GUID. Fetch availability ONCE per
+    // unique GUID, not once per service: N identical calls would trip MS's
+    // ~4-concurrent throttle and, over a 60-day window (MS latency is variable,
+    // seen up to ~8.5s), blow the fetch timeout and drop every room. A generous
+    // 15s timeout absorbs a slow-but-valid response instead of aborting it.
+    const uniqueGuids = [...new Set<string>(services.map((s: any) => s.staffMemberIds[0]))];
+    const availByGuid = new Map<string, unknown[]>();
+    await Promise.all(
+      uniqueGuids.map(async (guid) => {
+        try {
+          const availRes = await fetchWithTimeout(
+            `${BASE}GetStaffAvailability`,
+            {
               method: 'POST',
               headers: { 'content-type': 'application/json' },
               body: JSON.stringify({
@@ -93,23 +96,28 @@ serve(async (req: Request) => {
                 startDateTime: { dateTime: dateOnly(start), timeZone: TZ },
                 endDateTime: { dateTime: dateOnly(end), timeZone: TZ },
               }),
-            });
-            if (!availRes.ok) return null;
-            const availJson = await availRes.json();
-            const items = availJson.staffAvailabilityResponse?.[0]?.availabilityItems || [];
-            return {
-              staffGuid: guid,
-              serviceId: s.serviceId,
-              webUrl: s.webUrl,
-              leadMinutes: lead,
-              items,
-            };
-          } catch {
-            return null;
-          }
-        })
-      )
-    ).filter((r) => r !== null);
+            },
+            15000
+          );
+          if (!availRes.ok) return; // leave GUID unset → its rooms omitted, not fabricated
+          const availJson = await availRes.json();
+          availByGuid.set(guid, availJson.staffAvailabilityResponse?.[0]?.availabilityItems || []);
+        } catch {
+          // Timeout/network: omit this GUID's rooms so the client shows "unknown"
+          // for them rather than "fully booked" for all.
+        }
+      })
+    );
+
+    const rooms = services
+      .map((s: any) => {
+        const guid = s.staffMemberIds[0];
+        const items = availByGuid.get(guid);
+        if (!items) return null;
+        const lead = s.bookingsSchedulingPolicy?.minimumLeadTime === 'P2D' ? 2880 : 60;
+        return { staffGuid: guid, serviceId: s.serviceId, webUrl: s.webUrl, leadMinutes: lead, items };
+      })
+      .filter((r: unknown) => r !== null);
 
     const payload = { rooms };
     cache = { at: Date.now(), payload };

--- a/supabase/functions/bookings-availability/index.ts
+++ b/supabase/functions/bookings-availability/index.ts
@@ -115,7 +115,13 @@ serve(async (req: Request) => {
         const items = availByGuid.get(guid);
         if (!items) return null;
         const lead = s.bookingsSchedulingPolicy?.minimumLeadTime === 'P2D' ? 2880 : 60;
-        return { staffGuid: guid, serviceId: s.serviceId, webUrl: s.webUrl, leadMinutes: lead, items };
+        return {
+          staffGuid: guid,
+          serviceId: s.serviceId,
+          webUrl: s.webUrl,
+          leadMinutes: lead,
+          items,
+        };
       })
       .filter((r: unknown) => r !== null);
 


### PR DESCRIPTION
Fixes the library study-room panel end to end, starting from a user report that every room showed a blank `—` and the rooms "should be bookable", then a series of follow-on improvements to the picker and booking flow.

## What changed

### 1. Fix: blank availability (`—` on every room)
The Bookings API returns all 7 rooms under **one shared staff GUID** (a single scheduling mailbox), keyed apart only by `serviceId`. `loadLibraryAvailability` indexed the store map by that shared `staffGuid`, collapsing every room into one entry, so each reader's `availability[room.staffGuid]` lookup missed → blank `—`, no slot picker. Reconcile API identity (`serviceId`) → the app's per-room `staffGuid` in `indexAvailabilityByRoom()`; readers and the booking path are unchanged.

### 2. Modern calendar picker
The day picker was a scrolling pill row (and briefly a native `<input type="date">`). It now reuses the app's own **`MiniCalendar`** (the event composer's calendar) for a consistent, modern popover. Added an optional `isDisabled(iso)` predicate so closed / out-of-range days are greyed and inert (existing callers unaffected).

### 3. Advance booking: 5 days → 60 days
Booking was self-throttled to ~4 days: the `bookings-availability` edge function fetched only `now + 5 days`, and `pickableDays` capped the horizon at 7. MENDELU's Bookings policy actually allows `maximumAdvance: P60D`. Raised the edge window and the client horizon to 60 days.

### 4. Fix: edge returned no rooms at 60 days
The wider window exposed two problems — MS `GetStaffAvailability` latency is variable (seen ~8.5s), blowing the 8s fetch timeout, and the function fired one identical call per service (all 7 share one staff GUID), tripping MS's ~4-concurrent throttle. Now it **fetches once per unique staff GUID** (7 → 1 call) with a **15s timeout**. This also resolves the long-standing "cold load ~19s" caveat.

### 5. Booking commitment checkbox
A required pledge — *"Zavazuji se, že na rezervaci přijdu." / "I commit to showing up for my reservation."* — disables **Potvrdit rezervaci** until ticked, to cut no-shows that block a free room for others.

## Deployment
The `bookings-availability` edge function is **already deployed live (v7)** on the Supabase project. No further deploy needed for this PR to work in production.

## Testing
- New/updated unit tests: `libraryRooms`, `libraryAvailability`, `availabilityView` (advance horizon), `MiniCalendar` (disabled days), `LibrarySlotPicker`, `LibraryBookingDialog` (commitment gate). `typecheck` + changed-file `eslint --max-warnings=0` clean.
- Verified end to end in the dev webapp: rooms show live availability, the calendar opens the full 60-day range (weekdays through August/September enabled, weekends greyed), and the commitment checkbox gates Confirm.
- Note: 5 pre-existing `iskam` parser test files fail in this worktree due to missing untracked `.agent/fixtures/webiskam/*.html` — unrelated to these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Library bookings now support reservations up to 60 days in advance.
  * Added a calendar for selecting available booking days; unavailable days are disabled.
  * Added “Any time” and specific-hour booking options.
  * Users must confirm their commitment before submitting a booking.
  * Improved availability handling for rooms with shared scheduling information.

* **Localization**
  * Added Czech and English translations for new booking prompts.

* **Bug Fixes**
  * Corrected room availability mapping and ignored unknown services.

* **Tests**
  * Added coverage for calendar selection, booking confirmation, availability mapping, and extended booking windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->