### PR TITLE
chore(dev): trim launch.json, and auto-switch the dev webapp to phone layout

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -2,18 +2,6 @@
   "version": "0.0.1",
   "configurations": [
     {
-      "name": "wxt-dev-chrome",
-      "runtimeExecutable": "npm",
-      "runtimeArgs": ["run", "dev"],
-      "port": 3000
-    },
-    {
-      "name": "wxt-dev-firefox",
-      "runtimeExecutable": "npm",
-      "runtimeArgs": ["run", "dev:firefox"],
-      "port": 3000
-    },
-    {
       "name": "reis-webapp",
       "runtimeExecutable": "npm",
       "runtimeArgs": ["run", "dev:web"],
@@ -24,13 +12,6 @@
       "name": "reis-webapp-mock",
       "runtimeExecutable": "npm",
       "runtimeArgs": ["run", "dev:web:mock"],
-      "port": 3000,
-      "autoPort": true
-    },
-    {
-      "name": "reis-webapp-exams",
-      "runtimeExecutable": "npm",
-      "runtimeArgs": ["run", "dev:web:exams"],
       "port": 3000,
       "autoPort": true
     }

--- a/.claude/skills/verify-ui/SKILL.md
+++ b/.claude/skills/verify-ui/SKILL.md
@@ -38,6 +38,13 @@ npm run verify:ui -- <label> --view exams --url http://localhost:<port>
 | `--onboarding` | off | Keep the welcome modal. Off by default: it blocks the whole page. |
 | `--wait` | 600 | ms to settle after navigation. |
 
+All three widths are below the 767px phone breakpoint, so the dev webapp renders
+the **phone** shell and that is what gets measured. (Before the dev override
+followed viewport width, these runs measured the desktop tree squeezed narrow —
+`shot.ts` sets no `hasTouch`, so the strict `isTouch && isNarrow` rule never
+fired.) To measure the narrow *desktop* tree instead, append `?mobile=0` to
+`--url`.
+
 Output always lands in `.verify/` (gitignored), **wiped at the start of every
 run**, with every path printed absolute. Exit code is 1 when there are errors.
 
@@ -66,9 +73,17 @@ Occluded elements are skipped, so findings describe what is actually on screen.
   keep components thin. Every real geometry bug in this project was caught by a
   unit test or by this script — none by reading code.
 - Real exam data is seasonal and usually absent from the snapshot — a July
-  scrape leaves the Exams screen permanently empty. Start the `reis-webapp-exams`
-  preview config (`npm run dev:web:exams`) for a populated screen instead of
-  hand-editing `public/dev-real-data.json`.
+  scrape leaves the Exams screen permanently empty. Serve the exam fixture for a
+  populated screen instead of hand-editing `public/dev-real-data.json`.
+  `REIS_FIXTURE` is read from the process env at server start, so this one needs
+  a background Bash server — there is no launch config for it:
+
+  ```bash
+  npm run dev:web:exams
+  ```
+
+  This is the documented exception to "never start the dev webapp with Bash";
+  every other run uses the `reis-webapp` preview config.
 
 ## Fixtures
 

--- a/dev/phoneOverride.ts
+++ b/dev/phoneOverride.ts
@@ -27,10 +27,16 @@ if (import.meta.env.DEV) {
   // change; the equality guard is what keeps it from re-entering through
   // setDevPhoneOverride's own set().
   if (!pinned) {
-    useAppStore.subscribe((state) => {
+    const unsubscribe = useAppStore.subscribe((state) => {
       if (state.isNarrow === lastIsNarrow) return;
       lastIsNarrow = state.isNarrow;
       apply(lastIsNarrow);
     });
+
+    // A side-effect module with no accept handler normally forces a full page
+    // reload, which would drop this listener anyway — but disposing explicitly
+    // means we don't have to depend on that, and a hot re-eval can't stack a
+    // second listener holding a stale `param`.
+    import.meta.hot?.dispose(() => unsubscribe());
   }
 }

--- a/dev/phoneOverride.ts
+++ b/dev/phoneOverride.ts
@@ -1,11 +1,36 @@
 import { useAppStore } from '../src/store/useAppStore';
+import { resolveDevPhoneOverride } from '../src/utils/resolveDevPhoneOverride';
 
-// Dev-only phone override: `?mobile=1` forces the phone branch, `?mobile=0`
-// forces desktop. Guarded by import.meta.env.DEV so it cannot ship. Needed
-// because `pointer: coarse` requires touch emulation, which plain browser
-// resizing does not provide.
+// Dev-only phone override. The viewport half of the real rule (`isNarrow`)
+// flips when you resize, but the touch half (`pointer: coarse`) never does in a
+// desktop browser — resizing is not touch emulation — so the app would stay
+// desktop at phone widths. Here we follow the width alone, which is what you
+// want from a dev viewport preset.
+//
+// `?mobile=1` / `?mobile=0` still pin the layout and win over width, both as a
+// manual escape hatch and because e2e/serenity/specs/mobile-shell.spec.ts drives
+// the phone branch that way.
+//
+// Guarded by import.meta.env.DEV so it cannot ship.
 if (import.meta.env.DEV) {
   const param = new URLSearchParams(window.location.search).get('mobile');
-  if (param === '1') useAppStore.getState().setDevPhoneOverride(true);
-  if (param === '0') useAppStore.getState().setDevPhoneOverride(false);
+  const pinned = param === '1' || param === '0';
+
+  const apply = (isNarrow: boolean) => {
+    useAppStore.getState().setDevPhoneOverride(resolveDevPhoneOverride({ param, isNarrow }));
+  };
+
+  let lastIsNarrow = useAppStore.getState().isNarrow;
+  apply(lastIsNarrow);
+
+  // The store has no subscribeWithSelector middleware, so this fires on every
+  // change; the equality guard is what keeps it from re-entering through
+  // setDevPhoneOverride's own set().
+  if (!pinned) {
+    useAppStore.subscribe((state) => {
+      if (state.isNarrow === lastIsNarrow) return;
+      lastIsNarrow = state.isNarrow;
+      apply(lastIsNarrow);
+    });
+  }
 }

--- a/docs/superpowers/plans/2026-08-03-dev-phone-auto-switch.md
+++ b/docs/superpowers/plans/2026-08-03-dev-phone-auto-switch.md
@@ -29,7 +29,7 @@
 
 **Interfaces:**
 - Consumes: nothing.
-- Produces: `resolveDevPhoneOverride({ param: string | null; isNarrow: boolean }): boolean` and the exported interface `DevPhoneOverrideInput`. Task 2 imports both.
+- Produces: `resolveDevPhoneOverride({ param: string | null; isNarrow: boolean }): boolean`, plus the exported interface `DevPhoneOverrideInput` as its parameter type. Task 2 imports the function only.
 
 - [ ] **Step 1: Write the failing test**
 

--- a/docs/superpowers/plans/2026-08-03-dev-phone-auto-switch.md
+++ b/docs/superpowers/plans/2026-08-03-dev-phone-auto-switch.md
@@ -1,0 +1,242 @@
+# Dev Phone Auto-Switch Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the standalone dev webapp at `localhost:3000` switch to the phone layout automatically when the browser viewport goes narrow, instead of requiring a manual `?mobile=1`.
+
+**Architecture:** A pure resolver in `src/utils/` decides the dev override from the `?mobile=` query param and the current `isNarrow` flag; `dev/phoneOverride.ts` wires it to the store, applying it once at load and re-applying it on every `isNarrow` change. The production `resolvePhoneViewport` rule (`isTouch && isNarrow`) is untouched.
+
+**Tech Stack:** TypeScript, Zustand, Vitest, Vite (dev webapp entry).
+
+**Spec:** `docs/superpowers/specs/2026-08-03-dev-phone-auto-switch-design.md`
+
+## Global Constraints
+
+- Scope is the dev webapp only. Do **not** modify `src/utils/resolvePhoneViewport.ts` — its `isTouch && isNarrow` rule is production behavior and stays as-is.
+- `dev/phoneOverride.ts` must stay wrapped in `if (import.meta.env.DEV)` so it cannot ship.
+- An explicit `?mobile=1` / `?mobile=0` must keep pinning the layout and must win over viewport width. `e2e/serenity/specs/mobile-shell.spec.ts:122` depends on `?mobile=1` reaching the phone branch.
+- Do **not** add another `matchMedia('(max-width: 767px)')` call. The 767px threshold already exists in three places (`src/store/slices/createViewportSlice.ts:17`, `src/hooks/ui/useIsMobile.ts:3`, `src/components/AppShell.tsx:23`); read `isNarrow` from the store instead of adding a fourth.
+- Tests must live under `src/**` — vitest's `include` is `['src/**/*.{test,spec}.{js,ts,jsx,tsx}', 'scripts/**/*.{test,spec}.{js,ts,jsx,tsx}']`, so a test file placed in `dev/` would silently never run.
+- Max 200 lines per file (project convention).
+
+---
+
+### Task 1: Pure dev-override resolver
+
+**Files:**
+- Create: `src/utils/resolveDevPhoneOverride.ts`
+- Test: `src/utils/__tests__/resolveDevPhoneOverride.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `resolveDevPhoneOverride({ param: string | null; isNarrow: boolean }): boolean` and the exported interface `DevPhoneOverrideInput`. Task 2 imports both.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/utils/__tests__/resolveDevPhoneOverride.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { resolveDevPhoneOverride } from '../resolveDevPhoneOverride';
+
+describe('resolveDevPhoneOverride', () => {
+  it('param "1" pins the phone branch regardless of width', () => {
+    expect(resolveDevPhoneOverride({ param: '1', isNarrow: false })).toBe(true);
+    expect(resolveDevPhoneOverride({ param: '1', isNarrow: true })).toBe(true);
+  });
+
+  it('param "0" pins the desktop branch regardless of width', () => {
+    expect(resolveDevPhoneOverride({ param: '0', isNarrow: true })).toBe(false);
+    expect(resolveDevPhoneOverride({ param: '0', isNarrow: false })).toBe(false);
+  });
+
+  it('follows the viewport when no param is given', () => {
+    expect(resolveDevPhoneOverride({ param: null, isNarrow: true })).toBe(true);
+    expect(resolveDevPhoneOverride({ param: null, isNarrow: false })).toBe(false);
+  });
+
+  it('ignores an unrecognised param value and follows the viewport', () => {
+    expect(resolveDevPhoneOverride({ param: 'yes', isNarrow: true })).toBe(true);
+    expect(resolveDevPhoneOverride({ param: '', isNarrow: false })).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+npx vitest run src/utils/__tests__/resolveDevPhoneOverride.test.ts
+```
+
+Expected: FAIL — `Failed to resolve import "../resolveDevPhoneOverride"`.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Create `src/utils/resolveDevPhoneOverride.ts`:
+
+```ts
+export interface DevPhoneOverrideInput {
+  /** The `?mobile=` query param value, or null when absent. */
+  param: string | null;
+  isNarrow: boolean;
+}
+
+/**
+ * Decides the dev-webapp phone override.
+ *
+ * An explicit `?mobile=1` / `?mobile=0` pins the layout; anything else follows
+ * the viewport width. Returns a plain boolean rather than the tri-state the
+ * store accepts: `false` at a wide width is what `isTouch && isNarrow` would
+ * have produced anyway, so pinning it costs nothing and keeps the caller simple.
+ */
+export function resolveDevPhoneOverride({ param, isNarrow }: DevPhoneOverrideInput): boolean {
+  if (param === '1') return true;
+  if (param === '0') return false;
+  return isNarrow;
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+npx vitest run src/utils/__tests__/resolveDevPhoneOverride.test.ts
+```
+
+Expected: PASS — 4 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/resolveDevPhoneOverride.ts src/utils/__tests__/resolveDevPhoneOverride.test.ts
+git commit -m "feat(dev): add resolveDevPhoneOverride, a pure dev phone-override resolver"
+```
+
+---
+
+### Task 2: Wire the resolver to the store in the dev entry
+
+**Files:**
+- Modify: `dev/phoneOverride.ts` (entire file, currently 11 lines)
+
+**Interfaces:**
+- Consumes: `resolveDevPhoneOverride` from Task 1; `useAppStore` from `src/store/useAppStore`, using `getState()`, `subscribe()`, and the `setDevPhoneOverride(value: boolean | null)` action defined in `src/store/slices/createMobileUiSlice.ts:31`.
+- Produces: nothing importable — side-effect module.
+
+**Critical detail:** `useAppStore` is created with a plain `create<AppState>()(...)` and does **not** use the `subscribeWithSelector` middleware. The selector form `subscribe(selector, listener)` is therefore unavailable — `subscribe(listener)` fires on *every* store change. The listener must compare `isNarrow` against the last applied value and bail when unchanged. Without that guard, every unrelated store write calls `setDevPhoneOverride`, which is itself a `set()`, re-notifying subscribers in a loop.
+
+- [ ] **Step 1: Replace the file contents**
+
+Replace all of `dev/phoneOverride.ts` with:
+
+```ts
+import { useAppStore } from '../src/store/useAppStore';
+import { resolveDevPhoneOverride } from '../src/utils/resolveDevPhoneOverride';
+
+// Dev-only phone override. The viewport half of the real rule (`isNarrow`)
+// flips when you resize, but the touch half (`pointer: coarse`) never does in a
+// desktop browser — resizing is not touch emulation — so the app would stay
+// desktop at phone widths. Here we follow the width alone, which is what you
+// want from a dev viewport preset.
+//
+// `?mobile=1` / `?mobile=0` still pin the layout and win over width, both as a
+// manual escape hatch and because e2e/serenity/specs/mobile-shell.spec.ts drives
+// the phone branch that way.
+//
+// Guarded by import.meta.env.DEV so it cannot ship.
+if (import.meta.env.DEV) {
+  const param = new URLSearchParams(window.location.search).get('mobile');
+  const pinned = param === '1' || param === '0';
+
+  const apply = (isNarrow: boolean) => {
+    useAppStore.getState().setDevPhoneOverride(resolveDevPhoneOverride({ param, isNarrow }));
+  };
+
+  let lastIsNarrow = useAppStore.getState().isNarrow;
+  apply(lastIsNarrow);
+
+  // The store has no subscribeWithSelector middleware, so this fires on every
+  // change; the equality guard is what keeps it from re-entering through
+  // setDevPhoneOverride's own set().
+  if (!pinned) {
+    useAppStore.subscribe((state) => {
+      if (state.isNarrow === lastIsNarrow) return;
+      lastIsNarrow = state.isNarrow;
+      apply(lastIsNarrow);
+    });
+  }
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+npm run typecheck
+```
+
+Expected: PASS, no errors.
+
+- [ ] **Step 3: Lint the changed files**
+
+```bash
+npx eslint dev/phoneOverride.ts src/utils/resolveDevPhoneOverride.ts src/utils/__tests__/resolveDevPhoneOverride.test.ts --max-warnings=0
+```
+
+Expected: no output (clean). CI's lint gate is `--max-warnings=0`, so warnings fail the build.
+
+- [ ] **Step 4: Run the full unit suite for regressions**
+
+```bash
+npm run test:run
+```
+
+Expected: PASS. Pay attention to `src/utils/__tests__/resolvePhoneViewport.test.ts` — it must still pass untouched.
+
+Use `test:run`, not `test` — `npm run test` is bare `vitest`, which stays in watch mode and never exits.
+
+- [ ] **Step 5: Verify manually in the dev webapp**
+
+Start the webapp with the `reis-webapp` launch config (`preview_start`), not a
+foreground `npm run dev:web` — the dev server does not exit and will block.
+
+Then, in the browser pane at `http://localhost:3000` with **no query param**:
+
+| Viewport | Expected |
+|---|---|
+| Mobile preset (375×812) | Phone shell — bottom tab bar reading Kalendář / Zkoušky / Předměty / Mapa / Profil |
+| Tablet preset (768×1024) | Desktop shell — left icon sidebar, week grid |
+| Responsive / wide | Desktop shell |
+
+Resize between presets without reloading and confirm the layout switches live.
+
+Then confirm the pins still win:
+- `http://localhost:3000/?mobile=1` at a **wide** viewport → phone shell.
+- `http://localhost:3000/?mobile=0` at the **Mobile** preset → desktop shell.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add dev/phoneOverride.ts
+git commit -m "feat(dev): follow viewport width for the dev phone override
+
+The browser viewport preset resizes but never sets pointer: coarse, so the
+strict isTouch && isNarrow rule kept the desktop layout at phone widths.
+The dev override now follows isNarrow, with ?mobile=1/0 still pinning."
+```
+
+---
+
+## Verification
+
+After both tasks, the whole change is:
+
+- `src/utils/resolveDevPhoneOverride.ts` — new, pure, 4 tests.
+- `src/utils/__tests__/resolveDevPhoneOverride.test.ts` — new.
+- `dev/phoneOverride.ts` — rewritten.
+
+`src/utils/resolvePhoneViewport.ts` must show **no diff**. Confirm with:
+
+```bash
+git diff main --stat -- src/utils/resolvePhoneViewport.ts
+```
+
+Expected: empty output.

--- a/docs/superpowers/plans/2026-08-03-dev-phone-auto-switch.md
+++ b/docs/superpowers/plans/2026-08-03-dev-phone-auto-switch.md
@@ -10,6 +10,12 @@
 
 **Spec:** `docs/superpowers/specs/2026-08-03-dev-phone-auto-switch-design.md`
 
+**Status:** Executed. All steps below are done — `fd8e4331` (Task 1), `d65fd306`
+(Task 2). Two changes landed afterwards from PR review, so the code blocks below
+are the plan as written, not the final state: the resolver returns `null` rather
+than `false` for the unpinned-wide case, and the subscription registers an
+`import.meta.hot?.dispose` teardown. Read the source files for current code.
+
 ## Global Constraints
 
 - Scope is the dev webapp only. Do **not** modify `src/utils/resolvePhoneViewport.ts` — its `isTouch && isNarrow` rule is production behavior and stays as-is.
@@ -31,7 +37,7 @@
 - Consumes: nothing.
 - Produces: `resolveDevPhoneOverride({ param: string | null; isNarrow: boolean }): boolean`, plus the exported interface `DevPhoneOverrideInput` as its parameter type. Task 2 imports the function only.
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 Create `src/utils/__tests__/resolveDevPhoneOverride.test.ts`:
 
@@ -62,7 +68,7 @@ describe('resolveDevPhoneOverride', () => {
 });
 ```
 
-- [ ] **Step 2: Run the test to verify it fails**
+- [x] **Step 2: Run the test to verify it fails**
 
 ```bash
 npx vitest run src/utils/__tests__/resolveDevPhoneOverride.test.ts
@@ -70,7 +76,7 @@ npx vitest run src/utils/__tests__/resolveDevPhoneOverride.test.ts
 
 Expected: FAIL — `Failed to resolve import "../resolveDevPhoneOverride"`.
 
-- [ ] **Step 3: Write the minimal implementation**
+- [x] **Step 3: Write the minimal implementation**
 
 Create `src/utils/resolveDevPhoneOverride.ts`:
 
@@ -96,7 +102,7 @@ export function resolveDevPhoneOverride({ param, isNarrow }: DevPhoneOverrideInp
 }
 ```
 
-- [ ] **Step 4: Run the test to verify it passes**
+- [x] **Step 4: Run the test to verify it passes**
 
 ```bash
 npx vitest run src/utils/__tests__/resolveDevPhoneOverride.test.ts
@@ -104,7 +110,7 @@ npx vitest run src/utils/__tests__/resolveDevPhoneOverride.test.ts
 
 Expected: PASS — 4 tests.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add src/utils/resolveDevPhoneOverride.ts src/utils/__tests__/resolveDevPhoneOverride.test.ts
@@ -124,7 +130,7 @@ git commit -m "feat(dev): add resolveDevPhoneOverride, a pure dev phone-override
 
 **Critical detail:** `useAppStore` is created with a plain `create<AppState>()(...)` and does **not** use the `subscribeWithSelector` middleware. The selector form `subscribe(selector, listener)` is therefore unavailable — `subscribe(listener)` fires on *every* store change. The listener must compare `isNarrow` against the last applied value and bail when unchanged. Without that guard, every unrelated store write calls `setDevPhoneOverride`, which is itself a `set()`, re-notifying subscribers in a loop.
 
-- [ ] **Step 1: Replace the file contents**
+- [x] **Step 1: Replace the file contents**
 
 Replace all of `dev/phoneOverride.ts` with:
 
@@ -167,7 +173,7 @@ if (import.meta.env.DEV) {
 }
 ```
 
-- [ ] **Step 2: Typecheck**
+- [x] **Step 2: Typecheck**
 
 ```bash
 npm run typecheck
@@ -175,7 +181,7 @@ npm run typecheck
 
 Expected: PASS, no errors.
 
-- [ ] **Step 3: Lint the changed files**
+- [x] **Step 3: Lint the changed files**
 
 ```bash
 npx eslint dev/phoneOverride.ts src/utils/resolveDevPhoneOverride.ts src/utils/__tests__/resolveDevPhoneOverride.test.ts --max-warnings=0
@@ -183,7 +189,7 @@ npx eslint dev/phoneOverride.ts src/utils/resolveDevPhoneOverride.ts src/utils/_
 
 Expected: no output (clean). CI's lint gate is `--max-warnings=0`, so warnings fail the build.
 
-- [ ] **Step 4: Run the full unit suite for regressions**
+- [x] **Step 4: Run the full unit suite for regressions**
 
 ```bash
 npm run test:run
@@ -193,7 +199,7 @@ Expected: PASS. Pay attention to `src/utils/__tests__/resolvePhoneViewport.test.
 
 Use `test:run`, not `test` — `npm run test` is bare `vitest`, which stays in watch mode and never exits.
 
-- [ ] **Step 5: Verify manually in the dev webapp**
+- [x] **Step 5: Verify manually in the dev webapp**
 
 Start the webapp with the `reis-webapp` launch config (`preview_start`), not a
 foreground `npm run dev:web` — the dev server does not exit and will block.
@@ -212,7 +218,7 @@ Then confirm the pins still win:
 - `http://localhost:3000/?mobile=1` at a **wide** viewport → phone shell.
 - `http://localhost:3000/?mobile=0` at the **Mobile** preset → desktop shell.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add dev/phoneOverride.ts

--- a/docs/superpowers/specs/2026-08-03-dev-phone-auto-switch-design.md
+++ b/docs/superpowers/specs/2026-08-03-dev-phone-auto-switch-design.md
@@ -29,6 +29,15 @@ developer-facing affordance changes.
 Dev webapp only. The shipped extension keeps the strict `isTouch && isNarrow` rule
 and its behavior is unchanged.
 
+"Dev webapp only" is not the same as "nothing else is affected" — `npm run
+verify:ui` drives the dev webapp, so it is downstream of this change. `shot.ts`
+builds its Playwright context with no `hasTouch`, and its three widths
+(320/390/430) are all below the 767px breakpoint, so its runs previously measured
+the desktop tree squeezed narrow and now measure the phone shell. That is the more
+useful measurement for a mobile-width check, but it does invalidate baselines from
+earlier runs. Documented in `.claude/skills/verify-ui/SKILL.md`, along with
+`?mobile=0` as the way to measure the narrow desktop tree.
+
 ## Design
 
 ### Pure decision function

--- a/docs/superpowers/specs/2026-08-03-dev-phone-auto-switch-design.md
+++ b/docs/superpowers/specs/2026-08-03-dev-phone-auto-switch-design.md
@@ -1,0 +1,114 @@
+# Dev webapp: auto-switch to phone layout on narrow viewport
+
+**Date:** 2026-08-03
+**Status:** Approved, not yet implemented
+
+## Problem
+
+Setting the browser pane's Mobile preset (375×812) on `localhost:3000` resizes the
+viewport but leaves the app in the desktop layout — squeezed sidebar, week grid cut
+off at Friday. Reaching the phone UI requires manually appending `?mobile=1`.
+
+The cause is deliberate. `resolvePhoneViewport` decides phone-ness as:
+
+```ts
+return isTouch && isNarrow;
+```
+
+`isNarrow` tracks width and updates on resize. `isTouch` comes from
+`matchMedia('(pointer: coarse)')`, which a resized desktop browser never satisfies —
+that needs touch emulation, which the viewport preset does not provide. So the
+narrow-width half flips and the touch half never does, and the app stays desktop.
+
+The strictness is intentional and stays: a narrow desktop window should keep the
+desktop UI, and a tablet should keep the desktop UI. Only the dev webapp's
+developer-facing affordance changes.
+
+## Scope
+
+Dev webapp only. The shipped extension keeps the strict `isTouch && isNarrow` rule
+and its behavior is unchanged.
+
+## Design
+
+### Pure decision function
+
+New `src/utils/resolveDevPhoneOverride.ts`, alongside the existing
+`resolvePhoneViewport.ts` and following the same pattern — pure, DOM-free, testable:
+
+```ts
+export interface DevPhoneOverrideInput {
+  /** The `?mobile=` query param value, or null when absent. */
+  param: string | null;
+  isNarrow: boolean;
+}
+
+export function resolveDevPhoneOverride({ param, isNarrow }: DevPhoneOverrideInput): boolean {
+  if (param === '1') return true;
+  if (param === '0') return false;
+  return isNarrow;
+}
+```
+
+An explicit `?mobile=1` / `?mobile=0` pins the layout and wins over width. This is
+load-bearing in two ways:
+
+- `e2e/serenity/specs/mobile-shell.spec.ts:122` drives the phone branch with
+  `?mobile=1`. Pinning keeps that spec passing.
+- It preserves the manual escape hatch for forcing desktop at a narrow width.
+
+The function returns a boolean rather than the tri-state `boolean | null` that
+`devPhoneOverride` accepts. Returning `false` when wide, instead of `null`, is safe:
+`resolvePhoneViewport` short-circuits on `override === false` and returns false,
+which is what `isTouch && isNarrow` would have produced anyway at a wide width — on
+a real tablet (touch, not narrow) both paths give desktop.
+
+### Wiring
+
+`dev/phoneOverride.ts` changes from a one-shot param read to:
+
+1. Read the `?mobile=` param once at module load.
+2. Set `devPhoneOverride` from `resolveDevPhoneOverride({ param, isNarrow })`, taking
+   `isNarrow` from the store's current state.
+3. When no param pins the value, `useAppStore.subscribe` to `isNarrow` and re-apply
+   the resolver on every change.
+
+Subscribing to the store rather than adding a fourth
+`matchMedia('(max-width: 767px)')` call is deliberate: `isNarrow` is already seeded
+synchronously at store creation (`createViewportSlice.ts:17`) and kept live by
+`AppShell.tsx:23`. This introduces no new media query and no new copy of the 767px
+threshold to drift from the other three.
+
+The file stays `import.meta.env.DEV`-guarded and stays imported only by
+`dev/main.web.tsx`, the standalone-webapp entry.
+
+### Resulting behavior
+
+| Viewport preset | Layout |
+|---|---|
+| Mobile (375×812) | Phone |
+| Tablet (768×1024) | Desktop — consistent with the existing "a tablet stays desktop" intent |
+| Responsive / wide | Desktop |
+
+Switching between presets updates live; no reload needed.
+
+## Production safety
+
+The only new file that could reach the extension bundle is the pure resolver, which
+the extension entry never imports and which tree-shakes out. `resolvePhoneViewport`
+is untouched.
+
+## Testing
+
+Unit tests for the resolver, written first, covering its three branches:
+
+- `param: '1'` returns true regardless of `isNarrow`
+- `param: '0'` returns false regardless of `isNarrow`
+- `param: null` falls through to `isNarrow` in both directions
+
+Tests live in `src/utils/__tests__/` — vitest's `include` covers `src/**` and
+`scripts/**` only, so a test placed in `dev/` would silently never run. This is the
+reason the resolver lives in `src/utils/` rather than beside its wiring in `dev/`.
+
+Manual verification: load `localhost:3000` at the Mobile preset with no query param
+and confirm the phone shell (bottom tab bar) renders.

--- a/docs/superpowers/specs/2026-08-03-dev-phone-auto-switch-design.md
+++ b/docs/superpowers/specs/2026-08-03-dev-phone-auto-switch-design.md
@@ -1,7 +1,7 @@
 # Dev webapp: auto-switch to phone layout on narrow viewport
 
 **Date:** 2026-08-03
-**Status:** Approved, not yet implemented
+**Status:** Implemented — `fd8e4331` (resolver + tests), `d65fd306` (wiring)
 
 ## Problem
 
@@ -66,11 +66,11 @@ load-bearing in two ways:
   `?mobile=1`. Pinning keeps that spec passing.
 - It preserves the manual escape hatch for forcing desktop at a narrow width.
 
-The function returns a boolean rather than the tri-state `boolean | null` that
-`devPhoneOverride` accepts. Returning `false` when wide, instead of `null`, is safe:
-`resolvePhoneViewport` short-circuits on `override === false` and returns false,
-which is what `isTouch && isNarrow` would have produced anyway at a wide width — on
-a real tablet (touch, not narrow) both paths give desktop.
+Unpinned and wide returns `null`, the store's "defer to the viewport" value, not
+`false`. The two are behaviourally identical — the wide case implies
+`isNarrow === false`, so the `isTouch && isNarrow` fallback is false regardless —
+but `null` states what is meant. `false` would assert a desktop override nobody
+asked for, which is a latent trap if a future reader ever distinguishes the two.
 
 ### Wiring
 

--- a/src/utils/__tests__/resolveDevPhoneOverride.test.ts
+++ b/src/utils/__tests__/resolveDevPhoneOverride.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { resolveDevPhoneOverride } from '../resolveDevPhoneOverride';
+
+describe('resolveDevPhoneOverride', () => {
+  it('param "1" pins the phone branch regardless of width', () => {
+    expect(resolveDevPhoneOverride({ param: '1', isNarrow: false })).toBe(true);
+    expect(resolveDevPhoneOverride({ param: '1', isNarrow: true })).toBe(true);
+  });
+
+  it('param "0" pins the desktop branch regardless of width', () => {
+    expect(resolveDevPhoneOverride({ param: '0', isNarrow: true })).toBe(false);
+    expect(resolveDevPhoneOverride({ param: '0', isNarrow: false })).toBe(false);
+  });
+
+  it('follows the viewport when no param is given', () => {
+    expect(resolveDevPhoneOverride({ param: null, isNarrow: true })).toBe(true);
+    expect(resolveDevPhoneOverride({ param: null, isNarrow: false })).toBe(false);
+  });
+
+  it('ignores an unrecognised param value and follows the viewport', () => {
+    expect(resolveDevPhoneOverride({ param: 'yes', isNarrow: true })).toBe(true);
+    expect(resolveDevPhoneOverride({ param: '', isNarrow: false })).toBe(false);
+  });
+});

--- a/src/utils/__tests__/resolveDevPhoneOverride.test.ts
+++ b/src/utils/__tests__/resolveDevPhoneOverride.test.ts
@@ -12,13 +12,16 @@ describe('resolveDevPhoneOverride', () => {
     expect(resolveDevPhoneOverride({ param: '0', isNarrow: false })).toBe(false);
   });
 
-  it('follows the viewport when no param is given', () => {
+  it('forces the phone branch on a narrow viewport when no param is given', () => {
     expect(resolveDevPhoneOverride({ param: null, isNarrow: true })).toBe(true);
-    expect(resolveDevPhoneOverride({ param: null, isNarrow: false })).toBe(false);
+  });
+
+  it('defers to the viewport (null) when unpinned and wide', () => {
+    expect(resolveDevPhoneOverride({ param: null, isNarrow: false })).toBeNull();
   });
 
   it('ignores an unrecognised param value and follows the viewport', () => {
     expect(resolveDevPhoneOverride({ param: 'yes', isNarrow: true })).toBe(true);
-    expect(resolveDevPhoneOverride({ param: '', isNarrow: false })).toBe(false);
+    expect(resolveDevPhoneOverride({ param: '', isNarrow: false })).toBeNull();
   });
 });

--- a/src/utils/resolveDevPhoneOverride.ts
+++ b/src/utils/resolveDevPhoneOverride.ts
@@ -7,13 +7,19 @@ export interface DevPhoneOverrideInput {
 /**
  * Decides the dev-webapp phone override.
  *
- * An explicit `?mobile=1` / `?mobile=0` pins the layout; anything else follows
- * the viewport width. Returns a plain boolean rather than the tri-state the
- * store accepts: `false` at a wide width is what `isTouch && isNarrow` would
- * have produced anyway, so pinning it costs nothing and keeps the caller simple.
+ * An explicit `?mobile=1` / `?mobile=0` pins the layout and wins over width.
+ * Unpinned, a narrow viewport forces the phone branch, and a wide one returns
+ * `null` — the store's "no opinion, defer to the viewport" value. Returning
+ * `null` rather than `false` there is behaviourally identical today (the wide
+ * case implies `isNarrow === false`, so `isTouch && isNarrow` is false either
+ * way) but it states what we actually mean, instead of asserting a desktop
+ * override we were never asked for.
  */
-export function resolveDevPhoneOverride({ param, isNarrow }: DevPhoneOverrideInput): boolean {
+export function resolveDevPhoneOverride({
+  param,
+  isNarrow,
+}: DevPhoneOverrideInput): boolean | null {
   if (param === '1') return true;
   if (param === '0') return false;
-  return isNarrow;
+  return isNarrow ? true : null;
 }

--- a/src/utils/resolveDevPhoneOverride.ts
+++ b/src/utils/resolveDevPhoneOverride.ts
@@ -1,0 +1,19 @@
+export interface DevPhoneOverrideInput {
+  /** The `?mobile=` query param value, or null when absent. */
+  param: string | null;
+  isNarrow: boolean;
+}
+
+/**
+ * Decides the dev-webapp phone override.
+ *
+ * An explicit `?mobile=1` / `?mobile=0` pins the layout; anything else follows
+ * the viewport width. Returns a plain boolean rather than the tri-state the
+ * store accepts: `false` at a wide width is what `isTouch && isNarrow` would
+ * have produced anyway, so pinning it costs nothing and keeps the caller simple.
+ */
+export function resolveDevPhoneOverride({ param, isNarrow }: DevPhoneOverrideInput): boolean {
+  if (param === '1') return true;
+  if (param === '0') return false;
+  return isNarrow;
+}


### PR DESCRIPTION
Two related dev-environment changes.

## 1. Trim `.claude/launch.json`

It listed five dev-server configs, all declaring port 3000, which reads as five competing servers when only one can hold the port. Now two: `reis-webapp` and `reis-webapp-mock`.

Removed: `wxt-dev-chrome` and `wxt-dev-firefox` (these build the **extension** — they never serve a browsable app at localhost:3000, so they were actively misleading) and `reis-webapp-exams`.

All three npm scripts still exist and work — this only removes them from the launch picker.

`reis-webapp-exams` was the one real cost: `.claude/skills/verify-ui/SKILL.md` told you to start it as a preview config for a populated Exams screen, and `preview_start` resolves configs by name from this file. `REIS_FIXTURE` is read from `process.env` at server start, so there's no runtime way to select the fixture. The skill now documents `npm run dev:web:exams` as a background Bash server — the one explicit exception to its own "never start the dev webapp with Bash" rule.

## 2. Dev webapp auto-switches to the phone layout on a narrow viewport

Setting a browser Mobile preset on localhost:3000 resized the viewport but left the desktop layout — squeezed sidebar, week grid cut off at Friday. Reaching the phone UI meant appending `?mobile=1` by hand.

The cause is deliberate. `resolvePhoneViewport` is `isTouch && isNarrow`. `isNarrow` tracks width; `isTouch` comes from `pointer: coarse`, which a resized desktop browser never satisfies. Half the rule flips, half never does.

**That production rule is untouched** — `src/utils/resolvePhoneViewport.ts` shows no diff. Only the dev-webapp override changes:

- New `src/utils/resolveDevPhoneOverride.ts` — pure, 4 unit tests. `?mobile=1`/`?mobile=0` pin the layout; anything else follows width.
- `dev/phoneOverride.ts` applies it at load and subscribes to `isNarrow`.

`?mobile=1` still pins, which `e2e/serenity/specs/mobile-shell.spec.ts:129` depends on.

Two details worth knowing:

- `useAppStore` is a plain zustand `create()` with no `subscribeWithSelector`, so `subscribe` fires on *every* store change — and `setDevPhoneOverride` is itself a `set()`. The `lastIsNarrow` equality guard is what stops it re-entering.
- No fourth copy of the 767px threshold: the resolver takes `isNarrow` as a parameter and the wiring reads it from the store.

### Ripple into `verify:ui`

`scripts/shot.ts` builds its Playwright context with no `hasTouch`, and its widths (320/390/430) are all below 767px. So `npm run verify:ui` previously measured the desktop tree squeezed narrow and now measures the phone shell. That's the more useful measurement for a mobile-width check, but it invalidates baselines from earlier runs. Documented in the verify-ui skill, with `?mobile=0` as the way back to the narrow desktop tree.

## Verification

Unit suite: 1731 passed, 4 skipped, 0 failures. (5 test *files* fail to collect on missing `.agent/fixtures` — that directory is gitignored and absent in every checkout; unrelated and pre-existing.) Typecheck and eslint clean.

Manual, in the browser:

| Case | Result |
|---|---|
| No param, 375×812 | phone shell |
| No param, 768×1024 | desktop — switches **live**, no reload |
| `?mobile=0`, 375×812 | desktop |
| `?mobile=1`, 1280×800 | phone shell |

Spec and implementation plan are in `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Development phone layouts now automatically follow the current viewport width.
  * Added options to force phone or desktop layouts with `?mobile=1` or `?mobile=0`.

* **Documentation**
  * Updated UI verification guidance for responsive layouts and Exams fixtures.

* **Bug Fixes**
  * Improved consistency when switching between narrow and wide development views.

* **Chores**
  * Removed obsolete Chrome, Firefox, and Exams launch options while retaining standard and mock launch options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->