### PR TITLE
Study documents download in the mobile app (REIS_ACTION dispatcher + unsealed fallback)

### DIFF
--- a/capacitor/main.capacitor.ts
+++ b/capacitor/main.capacitor.ts
@@ -8,6 +8,7 @@ import { getPlatform } from '@/platform';
 import { TOKEN_KEY } from '@/platform/tokenStore';
 import { ensureSession } from '@/mobile/ensureSession';
 import { handleBackPress } from '@/mobile/backButton';
+import { installMobileActionHandler } from '@/mobile/actionHandler';
 import { useAppStore } from '@/store/useAppStore';
 
 const IS_LOGIN_URL = 'https://is.mendelu.cz/system/login.pl?lang=cz';
@@ -48,6 +49,11 @@ async function boot(): Promise<void> {
       await InAppBrowser.close();
     },
   });
+
+  // Before the React root: the app posts REIS_ACTION as soon as it renders
+  // (a watchdog exam refresh, a tapped download), and with no responder those
+  // sit until the 30 s timeout. Installing first means none are missed.
+  installMobileActionHandler();
 
   // Dynamic import on purpose: this module renders the React root on
   // evaluation, so a static import would boot the app BEFORE a session exists

--- a/docs/superpowers/specs/2026-08-03-mobile-action-dispatcher-design.md
+++ b/docs/superpowers/specs/2026-08-03-mobile-action-dispatcher-design.md
@@ -155,18 +155,24 @@ no Capacitor imports — the existing pattern):
 
 ### Outcome (2026-08-03)
 
-Device-verified on Android with a live session: all five rows tapped, all five
-PDFs in Downloads under their chosen filenames, `%PDF-1.5`, 59–99 KB.
+Device-verified on Android with a live session: **`Registracni_arch.pdf` lands in
+Downloads** (64851 B, `%PDF-1.5`) through the same GET the extension makes. The
+mobile path is correct end to end — dispatcher, native transport, filename
+override, delivery.
 
-Verification also exposed a bug the dispatcher merely *revealed*: four of the five
-documents used IS's sealed (`_el`) triggers, which do not download at all — they
-queue an async job and now answer a GET with `text/html` ("Request body constraint
-violation"). Because `downloadDocumentInPage` reads a non-PDF 200 as an expired
-session, the **extension** force-navigated the student to the IS login page on
-click. The catalog now uses the plain triggers on both platforms, a test asserts
-no `_el` survives, and the sheet subtitle no longer promises an electronic
-signature the plain documents lack. Sealed copies need POST support plus a
-repository pickup flow — a real feature, not a flag flip.
+The other four rows fail, and **not for a reason in this codebase.** IS's sealed
+(`_el`) endpoints are answering "Operaci se nepodařilo úspěšně dokončit. Request
+body constraint violation" — reproduced by the user in a plain desktop browser,
+outside reIS. Ruled out from our side by measurement: browser-like
+UA/Accept/Referer, `;obdobi=`, repeats, and body headers (an httpbin echo shows
+CapacitorHttp sends a clean GET with no Content-Length). `reg_arch_tisk` works
+precisely because it is the one document with no sealed variant.
+
+A fallback-to-unsealed was built and then **reverted on the user's call**: the
+desktop implementation was correct, and product code should not be restructured
+around a temporary server outage. `studyDocuments.ts`, `documentDownloader.ts` and
+the sheet copy are therefore unchanged from `main`. When MENDELU repairs their
+side, the existing `_el` triggers start working again on both platforms at once.
 
 **Device verification is non-negotiable.** The failure class here is *silent* —
 `a.download` on a blob URL saves nothing and throws nothing on Android

--- a/docs/superpowers/specs/2026-08-03-mobile-action-dispatcher-design.md
+++ b/docs/superpowers/specs/2026-08-03-mobile-action-dispatcher-design.md
@@ -1,0 +1,167 @@
+# Mobile action dispatcher — design
+
+**Goal:** study documents download in one tap on the Capacitor app.
+**Scope:** the `REIS_ACTION` loopback (issue #170 / Task 1 of
+`docs/superpowers/plans/2026-08-02-capacitor-remaining-work.md`), documents first.
+
+Everything below is traced to `file:line` in the tree at `cbfff7ef`.
+
+---
+
+## What is broken
+
+Tapping *Download* in `DocsSheet` calls `useDocumentDownload.run()`
+(`src/hooks/data/useDocumentDownload.ts:27`) → `downloadDocument()`
+(`src/api/proxyClient.ts:43`) → `executeAction` posts a `REIS_ACTION`. The only
+responder is the **content script** (`src/injector/messageHandler.ts:45`), which
+does not exist on Capacitor. The promise sits until `REQUEST_TIMEOUT`
+(30 s, `src/api/proxy/pendingRequests.ts:4`) and the row shows a red error icon.
+
+**Two separate breakages sit behind that one button**, and both must be fixed:
+
+1. **No responder.** Nothing on the app side handles `REIS_ACTION`.
+2. **The fetch is CORS-blocked even if routed.** `downloadDocumentInPage`
+   (`src/injector/documentDownloader.ts:14`) uses a bare
+   `fetch(url, { credentials: 'include' })`. IS denies CORS to every origin, so
+   this cannot succeed from the app's own origin. Its *save* half is already
+   mobile-aware (`saveBlob` + `buildSaveDeps`); only the *fetch* half is not.
+
+### Two traps found while tracing
+
+- **The reply path is blocked too.** `initProxyListener`
+  (`src/api/proxy/messageListener.ts:15`) rejects any message whose origin is not
+  `https://is.mendelu.cz`. On Capacitor the app's origin is `https://localhost`
+  (Android) / `capacitor://localhost` (iOS), so a correct `REIS_ACTION_RESULT`
+  posted back would be **silently dropped**. Sync escapes this only because
+  `useAppLogic`'s handler checks `e.source`, not origin.
+- **There are two senders.** `executeAction` awaits a result, but `SyncService`
+  (`src/services/sync/SyncService.ts:22-26`) fires `trigger_sync`,
+  `trigger_drive_backup` and `refresh_exams` as raw `window.parent.postMessage`
+  with no promise at all. The exam-refresh half of #170 lives entirely in the
+  second one.
+
+### Only four of the eleven actions are reachable
+
+#170 lists eleven. Verified against the tree:
+
+- `register_exam` / `unregister_exam` — **already dead call paths.**
+  `useExamActions` (`src/components/ExamPanel/useExamActions.ts:29,34`) calls
+  `registerExam()` / `unregisterExam()` directly in-process via `fetchWithAuth`.
+  Nothing sends these actions. This is why registration already works on device.
+- `open_url` — **zero callers.** `openPopup` (`src/api/proxyClient.ts:36`) is dead code.
+- `toggle_outlook_sync` / `download_file` — in the `ActionType` union but have no
+  `case` in the content script either. Dead on every platform.
+- `trigger_drive_backup` / `push_notes` / `push_notes_html` — Drive, broken on
+  mobile on four axes (#168), out of scope.
+
+Leaving **`download_document`, `refresh_exams`, `trigger_sync`, `logout`**.
+
+---
+
+## Design
+
+### 1. The dispatcher
+
+New `src/mobile/actionHandler.ts`, installed from `capacitor/main.capacitor.ts`
+inside `boot()` **before** the React root is imported, so an action fired during
+first paint is not dropped. It listens on `window` for `REIS_ACTION`, ignores
+anything whose `source` is not its own window, runs the action, and replies with
+`sendToIframe(Messages.actionResult(id, ...))` — which on Capacitor loops back to
+the same window (`src/injector/iframeManager.ts:73`).
+
+This mirrors the `sendToIframe` precedent rather than inventing a second pattern,
+and both senders work untouched: on a top-level window `window.parent === window`,
+so `SyncService`'s fire-and-forget posts land on the listener for free. **No edits
+to UI, hooks, or store.**
+
+`src/injector/messageHandler.ts` is deliberately **not** reused. #170 proposed
+sharing its switch, but only 4 of 11 cases are pure in-process calls; the ones
+that matter (`download_document`, `open_url`, `logout`) are DOM-bound and diverge
+completely. The shared surface is too thin to justify the abstraction, and not
+importing it keeps its module-scope `chrome.runtime.getURL`
+(`messageHandler.ts:23`) out of the mobile bundle — no guard needed.
+
+### 2. The documents path
+
+The mobile branch reuses `openIsFileNatively` (`src/mobile/openIsFile.ts:40`) —
+the device-verified path subject files already use — plus one addition: an
+optional **filename override**, because study documents carry a chosen name
+(`Potvrzeni_o_studiu.pdf`, `src/api/studyDocuments.ts`) while subject files take
+theirs from `Content-Disposition`.
+
+The download becomes: native `CapacitorHttp` GET with the replayed `UISAuth`
+cookie → `fetchIsBinary` → Downloads + notification on Android, share sheet on
+iOS (`src/mobile/deliverFile.ts`). `toDirectDownloadUrl` returns `null` for a
+`tisk_dokumentu.pl` URL and falls through unchanged, which is correct. If IS
+returns HTML, `fetchIsBinary` already separates "session lapsed" from
+"authenticated page" and `openIsFileNatively` throws rather than saving a web
+page as a `.pdf`.
+
+`downloadDocumentInPage` stays the extension's, unchanged.
+
+### 3. The action table
+
+| Action | Mobile |
+|---|---|
+| `download_document` | native fetch + deliver — **the fix** |
+| `refresh_exams` | `refreshExams()` (`src/injector/syncService.ts:459`), in-process |
+| `trigger_sync` | `syncAllData()`, in-process |
+| `logout` | pending decision — falls under the default for now |
+| everything else | **throws immediately, naming the action** |
+
+That default carries real value. Today *any* unhandled action hangs 30 s and then
+shows a generic error. After this it fails in milliseconds with its own name, so
+the Drive actions stop masquerading as network problems.
+
+### 4. Supporting edit: the origin allowance
+
+`initProxyListener` gains an allowance for the app's own origin when the platform
+is Capacitor. The `e.source !== window.parent` check stays, so on a top-level
+window only same-window posts pass — no widening of what a hostile frame can do.
+
+### 5. Logout — open decision
+
+Current mobile behaviour is worse than "does not work": `logout()`
+(`src/api/proxyClient.ts:47`) wipes IndexedDB **first**, then hangs 30 s. The
+student is left with an emptied app and a still-valid token.
+
+- **A — local sign-out (recommended):** clear token, IDB and the native cookie
+  jar, then reload; `boot()` finds no token and presents the login WebView. Fully
+  signed out on the device; the server session lingers until IS times it out.
+- **B — leave dead but fail fast** (the §3 default).
+- **C — defer** until POST support lands (Task 3), then a real server-side logout.
+
+A true logout POSTs `/auth/system/logout.pl`, and the Capacitor transport is
+GET-only until Task 3 — so A is the most that can be done today, and C can
+upgrade it later without changing the UI.
+
+**Until this is decided, `logout` falls under the §3 default: it fails fast and
+loudly instead of hanging.** That is already strictly better than today.
+
+---
+
+## Testing
+
+Unit tests on the pure pieces (`src/mobile/__tests__/`, dependency-injected deps,
+no Capacitor imports — the existing pattern):
+
+- dispatcher routes each supported action to its dep
+- unsupported actions reject immediately, with the action name in the message
+- a message from another window `source` is ignored
+- failures reply `success: false` rather than throwing into the listener
+- the filename override reaches `deliverFile`; absent, `Content-Disposition` wins
+- the origin allowance accepts the app's own origin on Capacitor and still
+  rejects a foreign one
+
+**Device verification is non-negotiable.** The failure class here is *silent* —
+`a.download` on a blob URL saves nothing and throws nothing on Android
+(`src/mobile/saveDocument.ts`). Build, install, tap all five document rows,
+confirm the PDFs land in Downloads with a notification.
+
+## Out of scope
+
+- **Session-expiry re-auth on mobile.** A lapsed `UISAuth` shows a row error
+  rather than re-presenting the login WebView. App-wide gap, not a documents one.
+- **The "Žádost" row's `target="_blank"`** escape to a session-less system
+  browser (`DocsSheet.tsx:84`, Task 8) — separate fix, does not block downloads.
+- Drive backup (#168), secure token storage (#172), iOS build (#174).

--- a/docs/superpowers/specs/2026-08-03-mobile-action-dispatcher-design.md
+++ b/docs/superpowers/specs/2026-08-03-mobile-action-dispatcher-design.md
@@ -119,24 +119,24 @@ the Drive actions stop masquerading as network problems.
 is Capacitor. The `e.source !== window.parent` check stays, so on a top-level
 window only same-window posts pass — no widening of what a hostile frame can do.
 
-### 5. Logout — open decision
+### 5. Logout — decided: **C, defer**
 
 Current mobile behaviour is worse than "does not work": `logout()`
 (`src/api/proxyClient.ts:47`) wipes IndexedDB **first**, then hangs 30 s. The
 student is left with an emptied app and a still-valid token.
 
-- **A — local sign-out (recommended):** clear token, IDB and the native cookie
-  jar, then reload; `boot()` finds no token and presents the login WebView. Fully
-  signed out on the device; the server session lingers until IS times it out.
-- **B — leave dead but fail fast** (the §3 default).
-- **C — defer** until POST support lands (Task 3), then a real server-side logout.
+**Chosen: C — defer** until POST support lands (Task 3), then implement a real
+server-side logout. (A was a local-only sign-out; B was leaving it dead.)
 
-A true logout POSTs `/auth/system/logout.pl`, and the Capacitor transport is
-GET-only until Task 3 — so A is the most that can be done today, and C can
-upgrade it later without changing the UI.
+Deferring the *implementation* does not mean keeping the destructive half.
+`logout()` now bails on Capacitor **before** clearing anything, and the mobile
+profile sheet catches the rejection to show a toast — an unhandled rejection
+there would fire a telemetry report on every tap and tell the student nothing.
+Extension behaviour is untouched.
 
-**Until this is decided, `logout` falls under the §3 default: it fails fast and
-loudly instead of hanging.** That is already strictly better than today.
+**When Task 3 lands**, the mobile branch replaces that throw with a real
+`/auth/system/logout.pl` POST followed by the existing clear-and-reload; the UI
+needs no change, and `settings.logoutUnavailable` can be removed.
 
 ---
 

--- a/docs/superpowers/specs/2026-08-03-mobile-action-dispatcher-design.md
+++ b/docs/superpowers/specs/2026-08-03-mobile-action-dispatcher-design.md
@@ -153,6 +153,21 @@ no Capacitor imports — the existing pattern):
 - the origin allowance accepts the app's own origin on Capacitor and still
   rejects a foreign one
 
+### Outcome (2026-08-03)
+
+Device-verified on Android with a live session: all five rows tapped, all five
+PDFs in Downloads under their chosen filenames, `%PDF-1.5`, 59–99 KB.
+
+Verification also exposed a bug the dispatcher merely *revealed*: four of the five
+documents used IS's sealed (`_el`) triggers, which do not download at all — they
+queue an async job and now answer a GET with `text/html` ("Request body constraint
+violation"). Because `downloadDocumentInPage` reads a non-PDF 200 as an expired
+session, the **extension** force-navigated the student to the IS login page on
+click. The catalog now uses the plain triggers on both platforms, a test asserts
+no `_el` survives, and the sheet subtitle no longer promises an electronic
+signature the plain documents lack. Sealed copies need POST support plus a
+repository pickup flow — a real feature, not a flag flip.
+
 **Device verification is non-negotiable.** The failure class here is *silent* —
 `a.download` on a blob URL saves nothing and throws nothing on Android
 (`src/mobile/saveDocument.ts`). Build, install, tap all five document rows,

--- a/docs/superpowers/specs/2026-08-03-mobile-action-dispatcher-design.md
+++ b/docs/superpowers/specs/2026-08-03-mobile-action-dispatcher-design.md
@@ -168,11 +168,23 @@ UA/Accept/Referer, `;obdobi=`, repeats, and body headers (an httpbin echo shows
 CapacitorHttp sends a clean GET with no Content-Length). `reg_arch_tisk` works
 precisely because it is the one document with no sealed variant.
 
-A fallback-to-unsealed was built and then **reverted on the user's call**: the
-desktop implementation was correct, and product code should not be restructured
-around a temporary server outage. `studyDocuments.ts`, `documentDownloader.ts` and
-the sheet copy are therefore unchanged from `main`. When MENDELU repairs their
-side, the existing `_el` triggers start working again on both platforms at once.
+Re-measured afterwards, the failure turned out to be **per-document, not a blanket
+outage**: `potvrzeni_tisk_el` fails 3/3 while `prehled_tisk_el` succeeds 3/3
+(sealed, ~233 KB). That reframed the fix.
+
+**Final design — sealed first, unsealed fallback.** `_el` stays the primary
+everywhere it exists; only when IS returns a page (never on 401/403) is the
+unsealed variant fetched. Reliability outranks the seal, but not silently: the
+downloader returns `usedFallback` and the UI warns, because an unsealed copy can
+be refused by the office the student takes it to. This degrades exactly the broken
+document and leaves `prehled_tisk_el` sealed; when MENDELU repairs the other, it
+seals again with no code change.
+
+This required separating two cases `documentDownloader` had conflated: a non-PDF
+200 was tagged `sessionExpired`, which force-navigated the student to the IS login
+page over an IS-side bug *and* left no chance to retry. The login page and an
+authenticated page are now told apart by the `logout.pl` marker — the same signal
+the mobile transport already used.
 
 **Device verification is non-negotiable.** The failure class here is *silent* —
 `a.download` on a blob URL saves nothing and throws nothing on Android

--- a/src/api/__tests__/proxyClient.logout.test.ts
+++ b/src/api/__tests__/proxyClient.logout.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { logout } from '../proxyClient';
+import { setPlatform, __resetPlatformForTests } from '../../platform';
+import type { ReisPlatform } from '../../platform/types';
+import { IndexedDBService } from '../../services/storage/IndexedDBService';
+
+function stub(kind: ReisPlatform['kind']): ReisPlatform {
+  const bag = new Map<string, unknown>();
+  return {
+    kind,
+    storage: {
+      async get(k) {
+        return bag.get(k);
+      },
+      async set(k, v) {
+        bag.set(k, v);
+      },
+      async remove(k) {
+        bag.delete(k);
+      },
+    },
+    getAssetUrl: (p) => `/${p}`,
+  };
+}
+
+describe('logout on Capacitor', () => {
+  let clearAll: ReturnType<typeof vi.spyOn>;
+  let postMessage: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    clearAll = vi.spyOn(IndexedDBService, 'clearAll').mockResolvedValue(undefined);
+    postMessage = vi.spyOn(window.parent, 'postMessage').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    clearAll.mockRestore();
+    postMessage.mockRestore();
+    __resetPlatformForTests();
+  });
+
+  it('does NOT wipe IndexedDB when the sign-out cannot actually happen', async () => {
+    // A real sign-out POSTs /auth/system/logout.pl and the Capacitor transport
+    // is GET-only. Wiping first and failing second left the student with an
+    // emptied app AND a live session — the worst of both.
+    setPlatform(stub('capacitor'));
+    await expect(logout()).rejects.toThrow(/not available/i);
+    expect(clearAll).not.toHaveBeenCalled();
+    expect(postMessage).not.toHaveBeenCalled();
+  });
+
+  it('still clears and dispatches on the extension', async () => {
+    setPlatform(stub('extension'));
+    void logout().catch(() => {});
+    await vi.waitFor(() => expect(clearAll).toHaveBeenCalled());
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    const msg = postMessage.mock.calls[0][0] as { type: string; action: string };
+    expect(msg.type).toBe('REIS_ACTION');
+    expect(msg.action).toBe('logout');
+  });
+});

--- a/src/api/__tests__/proxyClient.logout.test.ts
+++ b/src/api/__tests__/proxyClient.logout.test.ts
@@ -52,7 +52,7 @@ describe('logout on Capacitor', () => {
     void logout().catch(() => {});
     await vi.waitFor(() => expect(clearAll).toHaveBeenCalled());
     expect(postMessage).toHaveBeenCalledTimes(1);
-    const msg = postMessage.mock.calls[0][0] as { type: string; action: string };
+    const msg = postMessage.mock.calls[0]?.[0] as { type: string; action: string };
     expect(msg.type).toBe('REIS_ACTION');
     expect(msg.action).toBe('logout');
   });

--- a/src/api/__tests__/studyDocuments.test.ts
+++ b/src/api/__tests__/studyDocuments.test.ts
@@ -10,16 +10,28 @@ describe('studyDocuments catalog', () => {
     ]);
   });
 
-  it('builds the sealed Czech confirmation URL', () => {
+  it('builds the Czech confirmation URL', () => {
     expect(buildDocumentUrl('149707', byId('potvrzeni-cz'))).toBe(
-      'https://is.mendelu.cz/auth/student/tisk_dokumentu.pl?potvrzeni_tisk_el=1;studium=149707;lang=cz'
+      'https://is.mendelu.cz/auth/student/tisk_dokumentu.pl?potvrzeni_tisk=1;studium=149707;lang=cz'
     );
   });
 
   it('adds jazyk=eng for the English confirmation', () => {
     expect(buildDocumentUrl('149707', byId('potvrzeni-en'))).toBe(
-      'https://is.mendelu.cz/auth/student/tisk_dokumentu.pl?potvrzeni_tisk_el=1;jazyk=eng;studium=149707;lang=cz'
+      'https://is.mendelu.cz/auth/student/tisk_dokumentu.pl?potvrzeni_tisk=1;jazyk=eng;studium=149707;lang=cz'
     );
+  });
+
+  it('uses NO _el trigger anywhere — sealed prints are not downloads', () => {
+    // Measured against live IS on 2026-08-03: every `_el` trigger answers a GET
+    // with HTML ("Request body constraint violation"), and the page states the
+    // sealed document appears in Úložiště dokumentů within an hour. Every plain
+    // trigger returns application/pdf. Re-adding `_el` here silently breaks
+    // BOTH platforms — on the extension a non-PDF 200 is read as an expired
+    // session and force-navigates the student to the login page.
+    for (const doc of STUDY_DOCUMENTS) {
+      expect(doc.trigger).not.toMatch(/_el=/);
+    }
   });
 
   it('builds the registration-sheet URL (no jazyk)', () => {

--- a/src/api/__tests__/studyDocuments.test.ts
+++ b/src/api/__tests__/studyDocuments.test.ts
@@ -6,12 +6,16 @@ import {
   buildZadostUrl,
 } from '../studyDocuments';
 
-const byId = (id: string) => STUDY_DOCUMENTS.find(d => d.id === id)!;
+const byId = (id: string) => STUDY_DOCUMENTS.find((d) => d.id === id)!;
 
 describe('studyDocuments catalog', () => {
   it('lists the five one-click documents in order', () => {
-    expect(STUDY_DOCUMENTS.map(d => d.id)).toEqual([
-      'potvrzeni-cz', 'potvrzeni-en', 'prehled-cz', 'prehled-en', 'reg-arch',
+    expect(STUDY_DOCUMENTS.map((d) => d.id)).toEqual([
+      'potvrzeni-cz',
+      'potvrzeni-en',
+      'prehled-cz',
+      'prehled-en',
+      'reg-arch',
     ]);
   });
 

--- a/src/api/__tests__/studyDocuments.test.ts
+++ b/src/api/__tests__/studyDocuments.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { STUDY_DOCUMENTS, buildDocumentUrl, buildZadostUrl } from '../studyDocuments';
+import {
+  STUDY_DOCUMENTS,
+  buildDocumentUrl,
+  buildFallbackDocumentUrl,
+  buildZadostUrl,
+} from '../studyDocuments';
 
 const byId = (id: string) => STUDY_DOCUMENTS.find(d => d.id === id)!;
 
@@ -26,6 +31,33 @@ describe('studyDocuments catalog', () => {
     expect(buildDocumentUrl('149707', byId('reg-arch'))).toBe(
       'https://is.mendelu.cz/auth/student/tisk_dokumentu.pl?reg_arch_tisk=1;studium=149707;lang=cz'
     );
+  });
+
+  it('offers an unsealed fallback for every sealed document', () => {
+    expect(buildFallbackDocumentUrl('149707', byId('potvrzeni-cz'))).toBe(
+      'https://is.mendelu.cz/auth/student/tisk_dokumentu.pl?potvrzeni_tisk=1;studium=149707;lang=cz'
+    );
+    expect(buildFallbackDocumentUrl('149707', byId('prehled-en'))).toBe(
+      'https://is.mendelu.cz/auth/student/tisk_dokumentu.pl?prehled_tisk=1;jazyk=eng;studium=149707;lang=cz'
+    );
+  });
+
+  it('has no fallback for the registration sheet — it was never sealed', () => {
+    expect(buildFallbackDocumentUrl('149707', byId('reg-arch'))).toBeNull();
+  });
+
+  it('never points a fallback back at a sealed endpoint', () => {
+    // A fallback that is itself sealed would retry the exact failure it exists
+    // to work around.
+    for (const doc of STUDY_DOCUMENTS) {
+      expect(buildFallbackDocumentUrl('149707', doc) ?? '').not.toMatch(/_el=/);
+    }
+  });
+
+  it('keeps the sealed trigger as the primary for every sealed document', () => {
+    for (const doc of STUDY_DOCUMENTS) {
+      if (doc.fallbackTrigger) expect(doc.trigger).toMatch(/_el=/);
+    }
   });
 
   it('maps each document to an ASCII-safe filename', () => {

--- a/src/api/__tests__/studyDocuments.test.ts
+++ b/src/api/__tests__/studyDocuments.test.ts
@@ -10,28 +10,16 @@ describe('studyDocuments catalog', () => {
     ]);
   });
 
-  it('builds the Czech confirmation URL', () => {
+  it('builds the sealed Czech confirmation URL', () => {
     expect(buildDocumentUrl('149707', byId('potvrzeni-cz'))).toBe(
-      'https://is.mendelu.cz/auth/student/tisk_dokumentu.pl?potvrzeni_tisk=1;studium=149707;lang=cz'
+      'https://is.mendelu.cz/auth/student/tisk_dokumentu.pl?potvrzeni_tisk_el=1;studium=149707;lang=cz'
     );
   });
 
   it('adds jazyk=eng for the English confirmation', () => {
     expect(buildDocumentUrl('149707', byId('potvrzeni-en'))).toBe(
-      'https://is.mendelu.cz/auth/student/tisk_dokumentu.pl?potvrzeni_tisk=1;jazyk=eng;studium=149707;lang=cz'
+      'https://is.mendelu.cz/auth/student/tisk_dokumentu.pl?potvrzeni_tisk_el=1;jazyk=eng;studium=149707;lang=cz'
     );
-  });
-
-  it('uses NO _el trigger anywhere — sealed prints are not downloads', () => {
-    // Measured against live IS on 2026-08-03: every `_el` trigger answers a GET
-    // with HTML ("Request body constraint violation"), and the page states the
-    // sealed document appears in Úložiště dokumentů within an hour. Every plain
-    // trigger returns application/pdf. Re-adding `_el` here silently breaks
-    // BOTH platforms — on the extension a non-PDF 200 is read as an expired
-    // session and force-navigates the student to the login page.
-    for (const doc of STUDY_DOCUMENTS) {
-      expect(doc.trigger).not.toMatch(/_el=/);
-    }
   });
 
   it('builds the registration-sheet URL (no jazyk)', () => {

--- a/src/api/proxy/__tests__/trustedOrigin.test.ts
+++ b/src/api/proxy/__tests__/trustedOrigin.test.ts
@@ -9,9 +9,9 @@ describe('isTrustedProxyOrigin', () => {
   });
 
   it('rejects a foreign origin on the extension', () => {
-    expect(isTrustedProxyOrigin('https://evil.example.com', 'extension', 'chrome-extension://abc')).toBe(
-      false
-    );
+    expect(
+      isTrustedProxyOrigin('https://evil.example.com', 'extension', 'chrome-extension://abc')
+    ).toBe(false);
   });
 
   it('accepts the app own origin on Capacitor — Android serves from https://localhost', () => {
@@ -21,9 +21,9 @@ describe('isTrustedProxyOrigin', () => {
   });
 
   it('accepts the app own origin on Capacitor — iOS serves from capacitor://localhost', () => {
-    expect(isTrustedProxyOrigin('capacitor://localhost', 'capacitor', 'capacitor://localhost')).toBe(
-      true
-    );
+    expect(
+      isTrustedProxyOrigin('capacitor://localhost', 'capacitor', 'capacitor://localhost')
+    ).toBe(true);
   });
 
   it('still rejects a foreign origin on Capacitor', () => {
@@ -35,9 +35,9 @@ describe('isTrustedProxyOrigin', () => {
   it('does NOT accept an arbitrary own-origin claim on the extension', () => {
     // The allowance is Capacitor-only on purpose: in the extension the iframe's
     // own origin must never be able to resolve its own pending requests.
-    expect(isTrustedProxyOrigin('chrome-extension://abc', 'extension', 'chrome-extension://abc')).toBe(
-      false
-    );
+    expect(
+      isTrustedProxyOrigin('chrome-extension://abc', 'extension', 'chrome-extension://abc')
+    ).toBe(false);
   });
 
   it('never trusts a null/opaque origin', () => {

--- a/src/api/proxy/__tests__/trustedOrigin.test.ts
+++ b/src/api/proxy/__tests__/trustedOrigin.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { isTrustedProxyOrigin } from '../trustedOrigin';
+
+const IS = 'https://is.mendelu.cz';
+
+describe('isTrustedProxyOrigin', () => {
+  it('accepts the IS parent origin on the extension', () => {
+    expect(isTrustedProxyOrigin(IS, 'extension', 'chrome-extension://abc')).toBe(true);
+  });
+
+  it('rejects a foreign origin on the extension', () => {
+    expect(isTrustedProxyOrigin('https://evil.example.com', 'extension', 'chrome-extension://abc')).toBe(
+      false
+    );
+  });
+
+  it('accepts the app own origin on Capacitor — Android serves from https://localhost', () => {
+    // Without this the loopback reply is silently dropped and every action
+    // still times out, even with a responder in place.
+    expect(isTrustedProxyOrigin('https://localhost', 'capacitor', 'https://localhost')).toBe(true);
+  });
+
+  it('accepts the app own origin on Capacitor — iOS serves from capacitor://localhost', () => {
+    expect(isTrustedProxyOrigin('capacitor://localhost', 'capacitor', 'capacitor://localhost')).toBe(
+      true
+    );
+  });
+
+  it('still rejects a foreign origin on Capacitor', () => {
+    expect(isTrustedProxyOrigin('https://evil.example.com', 'capacitor', 'https://localhost')).toBe(
+      false
+    );
+  });
+
+  it('does NOT accept an arbitrary own-origin claim on the extension', () => {
+    // The allowance is Capacitor-only on purpose: in the extension the iframe's
+    // own origin must never be able to resolve its own pending requests.
+    expect(isTrustedProxyOrigin('chrome-extension://abc', 'extension', 'chrome-extension://abc')).toBe(
+      false
+    );
+  });
+
+  it('never trusts a null/opaque origin', () => {
+    expect(isTrustedProxyOrigin('null', 'capacitor', 'https://localhost')).toBe(false);
+    expect(isTrustedProxyOrigin('', 'capacitor', 'https://localhost')).toBe(false);
+  });
+});

--- a/src/api/proxy/messageListener.ts
+++ b/src/api/proxy/messageListener.ts
@@ -4,27 +4,33 @@ import { getPlatform } from '../../platform';
 
 let initialized = false;
 interface ProxyRequest {
-    timeout: ReturnType<typeof setTimeout>;
-    resolve: (data: any) => void; // eslint-disable-line @typescript-eslint/no-explicit-any
-    reject: (err: Error) => void;
+  timeout: ReturnType<typeof setTimeout>;
+  resolve: (data: any) => void; // eslint-disable-line @typescript-eslint/no-explicit-any
+  reject: (err: Error) => void;
 }
 
 export function initProxyListener() {
-    if (initialized) return; initialized = true;
-    window.addEventListener('message', (e: MessageEvent) => {
-        // Capacitor replies arrive from the app's own origin, not from IS —
-        // see trustedOrigin. The e.source check below is unchanged.
-        if (!isTrustedProxyOrigin(e.origin, getPlatform().kind, window.location.origin)) return;
-        if (e.source !== window.parent || !e.data || typeof e.data !== 'object') return;
-        const { type, id, success, data, error } = e.data;
-        const handle = (map: Map<string, ProxyRequest>) => {
-            const p = map.get(id);
-            if (p) { clearTimeout(p.timeout); map.delete(id); if (success) p.resolve(data); else p.reject(new Error(error || 'Failed')); }
-        };
-        if (type === 'REIS_FETCH_RESULT') handle(pendingFetches);
-        else if (type === 'REIS_ACTION_RESULT') handle(pendingActions);
-        else if (type === 'REIS_POPUP_STATE') {
-            window.dispatchEvent(new CustomEvent('reis:popup-state', { detail: { open: e.data.open } }));
-        }
-    });
+  if (initialized) return;
+  initialized = true;
+  window.addEventListener('message', (e: MessageEvent) => {
+    // Capacitor replies arrive from the app's own origin, not from IS —
+    // see trustedOrigin. The e.source check below is unchanged.
+    if (!isTrustedProxyOrigin(e.origin, getPlatform().kind, window.location.origin)) return;
+    if (e.source !== window.parent || !e.data || typeof e.data !== 'object') return;
+    const { type, id, success, data, error } = e.data;
+    const handle = (map: Map<string, ProxyRequest>) => {
+      const p = map.get(id);
+      if (p) {
+        clearTimeout(p.timeout);
+        map.delete(id);
+        if (success) p.resolve(data);
+        else p.reject(new Error(error || 'Failed'));
+      }
+    };
+    if (type === 'REIS_FETCH_RESULT') handle(pendingFetches);
+    else if (type === 'REIS_ACTION_RESULT') handle(pendingActions);
+    else if (type === 'REIS_POPUP_STATE') {
+      window.dispatchEvent(new CustomEvent('reis:popup-state', { detail: { open: e.data.open } }));
+    }
+  });
 }

--- a/src/api/proxy/messageListener.ts
+++ b/src/api/proxy/messageListener.ts
@@ -1,4 +1,6 @@
 import { pendingFetches, pendingActions } from './pendingRequests';
+import { isTrustedProxyOrigin } from './trustedOrigin';
+import { getPlatform } from '../../platform';
 
 let initialized = false;
 interface ProxyRequest {
@@ -7,12 +9,12 @@ interface ProxyRequest {
     reject: (err: Error) => void;
 }
 
-const PARENT_ORIGIN = 'https://is.mendelu.cz';
-
 export function initProxyListener() {
     if (initialized) return; initialized = true;
     window.addEventListener('message', (e: MessageEvent) => {
-        if (e.origin !== PARENT_ORIGIN) return;
+        // Capacitor replies arrive from the app's own origin, not from IS —
+        // see trustedOrigin. The e.source check below is unchanged.
+        if (!isTrustedProxyOrigin(e.origin, getPlatform().kind, window.location.origin)) return;
         if (e.source !== window.parent || !e.data || typeof e.data !== 'object') return;
         const { type, id, success, data, error } = e.data;
         const handle = (map: Map<string, ProxyRequest>) => {

--- a/src/api/proxy/trustedOrigin.ts
+++ b/src/api/proxy/trustedOrigin.ts
@@ -1,0 +1,28 @@
+export const PARENT_ORIGIN = 'https://is.mendelu.cz';
+
+/**
+ * Which origins may resolve a pending proxy request.
+ *
+ * In the extension the answer is only ever the IS page hosting the iframe.
+ *
+ * Capacitor has no parent page: the app IS the top-level window, and the
+ * action loopback posts to itself, so replies arrive from the app's own origin
+ * — `https://localhost` on Android, `capacitor://localhost` on iOS. Without
+ * this allowance those replies are dropped and every action still times out
+ * even with a responder in place.
+ *
+ * The allowance is narrow by construction. It is Capacitor-only, it matches the
+ * app's *actual* origin rather than a hardcoded localhost pattern, and the
+ * caller still checks `event.source === window.parent` — which on a top-level
+ * window admits same-window posts only. An opaque `null` origin is never
+ * trusted: a sandboxed frame can present one.
+ */
+export function isTrustedProxyOrigin(
+  origin: string,
+  platformKind: 'extension' | 'capacitor' | 'web',
+  ownOrigin: string
+): boolean {
+  if (!origin || origin === 'null') return false;
+  if (origin === PARENT_ORIGIN) return true;
+  return platformKind === 'capacitor' && origin === ownOrigin;
+}

--- a/src/api/proxyClient.ts
+++ b/src/api/proxyClient.ts
@@ -7,6 +7,7 @@ import { initProxyListener } from './proxy/messageListener';
 import { IndexedDBService } from '../services/storage/IndexedDBService';
 import { clearUserParamsCache } from '../utils/userParams';
 import { logError } from '../utils/reportError';
+import { getPlatform } from '../platform';
 
 export async function fetchViaProxy(url: string, opts?: MsgTypes.FetchRequestMessage['options']): Promise<string> {
     initProxyListener();
@@ -45,6 +46,14 @@ export function downloadDocument(url: string, filename: string): Promise<void> {
 }
 
 export async function logout(): Promise<void> {
+    // Mobile has no logout responder yet: a real sign-out POSTs
+    // /auth/system/logout.pl and the Capacitor transport is GET-only until the
+    // POST work lands. Bail BEFORE clearing anything — the destructive half
+    // must not run when the sign-out itself cannot, or the student is left with
+    // an emptied app AND a live session.
+    if (getPlatform().kind === 'capacitor') {
+        throw new Error('Sign-out is not available in the reIS mobile app yet');
+    }
     clearUserParamsCache();
     try {
         await IndexedDBService.clearAll();

--- a/src/api/proxyClient.ts
+++ b/src/api/proxyClient.ts
@@ -9,32 +9,48 @@ import { clearUserParamsCache } from '../utils/userParams';
 import { logError } from '../utils/reportError';
 import { getPlatform } from '../platform';
 
-export async function fetchViaProxy(url: string, opts?: MsgTypes.FetchRequestMessage['options']): Promise<string> {
-    initProxyListener();
-    const msg = Messages.fetch(url, opts);
-    return new Promise((resolve, reject) => {
-        const timeout = setTimeout(() => { pendingFetches.delete(msg.id); reject(new Error(`Timeout: ${url}`)); }, REQUEST_TIMEOUT);
-        pendingFetches.set(msg.id, { resolve, reject, timeout });
-        window.parent.postMessage(msg, '*');
-    });
+export async function fetchViaProxy(
+  url: string,
+  opts?: MsgTypes.FetchRequestMessage['options']
+): Promise<string> {
+  initProxyListener();
+  const msg = Messages.fetch(url, opts);
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      pendingFetches.delete(msg.id);
+      reject(new Error(`Timeout: ${url}`));
+    }, REQUEST_TIMEOUT);
+    pendingFetches.set(msg.id, { resolve, reject, timeout });
+    window.parent.postMessage(msg, '*');
+  });
 }
 
-export async function fetchJsonViaProxy<T>(url: string, opts?: MsgTypes.FetchRequestMessage['options']): Promise<T> {
-    return JSON.parse(await fetchViaProxy(url, opts));
+export async function fetchJsonViaProxy<T>(
+  url: string,
+  opts?: MsgTypes.FetchRequestMessage['options']
+): Promise<T> {
+  return JSON.parse(await fetchViaProxy(url, opts));
 }
 
 export async function executeAction<T = unknown>(action: ActionType, payload: unknown): Promise<T> {
-    initProxyListener();
-    const msg = Messages.action(action, payload);
-    return new Promise((resolve, reject) => {
-        const timeout = setTimeout(() => { pendingActions.delete(msg.id); reject(new Error(`Timeout: ${action}`)); }, REQUEST_TIMEOUT);
-        pendingActions.set(msg.id, { resolve: resolve as (val: unknown) => void, reject, timeout });
-        window.parent.postMessage(msg, '*');
-    });
+  initProxyListener();
+  const msg = Messages.action(action, payload);
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      pendingActions.delete(msg.id);
+      reject(new Error(`Timeout: ${action}`));
+    }, REQUEST_TIMEOUT);
+    pendingActions.set(msg.id, { resolve: resolve as (val: unknown) => void, reject, timeout });
+    window.parent.postMessage(msg, '*');
+  });
 }
 
-export function requestData(t: string) { window.parent.postMessage(Messages.requestData(t as DataRequestType), '*'); }
-export function openPopup(url: string): Promise<void> { return executeAction('open_url', { url }); }
+export function requestData(t: string) {
+  window.parent.postMessage(Messages.requestData(t as DataRequestType), '*');
+}
+export function openPopup(url: string): Promise<void> {
+  return executeAction('open_url', { url });
+}
 
 /**
  * Download an IS study document. The content script performs the first-party
@@ -50,26 +66,38 @@ export function downloadDocument(
   filename: string,
   fallbackUrl?: string | null
 ): Promise<{ usedFallback: boolean }> {
-  return executeAction('download_document', { url, filename, fallbackUrl: fallbackUrl ?? undefined });
+  return executeAction('download_document', {
+    url,
+    filename,
+    fallbackUrl: fallbackUrl ?? undefined,
+  });
 }
 
 export async function logout(): Promise<void> {
-    // Mobile has no logout responder yet: a real sign-out POSTs
-    // /auth/system/logout.pl and the Capacitor transport is GET-only until the
-    // POST work lands. Bail BEFORE clearing anything — the destructive half
-    // must not run when the sign-out itself cannot, or the student is left with
-    // an emptied app AND a live session.
-    if (getPlatform().kind === 'capacitor') {
-        throw new Error('Sign-out is not available in the reIS mobile app yet');
-    }
-    clearUserParamsCache();
-    try {
-        await IndexedDBService.clearAll();
-    } catch (e) {
-        logError('ProxyClient.logout:clearAll', e);
-    }
-    return executeAction('logout', {});
+  // Mobile has no logout responder yet: a real sign-out POSTs
+  // /auth/system/logout.pl and the Capacitor transport is GET-only until the
+  // POST work lands. Bail BEFORE clearing anything — the destructive half
+  // must not run when the sign-out itself cannot, or the student is left with
+  // an emptied app AND a live session.
+  if (getPlatform().kind === 'capacitor') {
+    throw new Error('Sign-out is not available in the reIS mobile app yet');
+  }
+  clearUserParamsCache();
+  try {
+    await IndexedDBService.clearAll();
+  } catch (e) {
+    logError('ProxyClient.logout:clearAll', e);
+  }
+  return executeAction('logout', {});
 }
 
-export function signalReady() { window.parent.postMessage(Messages.ready(), '*'); }
-export function isInIframe(): boolean { try { return window.self !== window.parent; } catch { return true; } }
+export function signalReady() {
+  window.parent.postMessage(Messages.ready(), '*');
+}
+export function isInIframe(): boolean {
+  try {
+    return window.self !== window.parent;
+  } catch {
+    return true;
+  }
+}

--- a/src/api/proxyClient.ts
+++ b/src/api/proxyClient.ts
@@ -40,9 +40,17 @@ export function openPopup(url: string): Promise<void> { return executeAction('op
  * Download an IS study document. The content script performs the first-party
  * fetch (SameSite cookie); the returned promise resolves only when the file is
  * actually saved, so callers can show real completion.
+ *
+ * `fallbackUrl` is the unsealed variant. The retry happens down in the
+ * downloader rather than here so the decision can read the real error — across
+ * this postMessage boundary a rejection is only a string.
  */
-export function downloadDocument(url: string, filename: string): Promise<void> {
-  return executeAction('download_document', { url, filename });
+export function downloadDocument(
+  url: string,
+  filename: string,
+  fallbackUrl?: string | null
+): Promise<{ usedFallback: boolean }> {
+  return executeAction('download_document', { url, filename, fallbackUrl: fallbackUrl ?? undefined });
 }
 
 export async function logout(): Promise<void> {

--- a/src/api/studyDocuments.ts
+++ b/src/api/studyDocuments.ts
@@ -24,19 +24,54 @@ export interface StudyDocument {
  * a copy into Úložiště dokumentů.
  *
  * `fallbackTrigger` is the unsealed equivalent, used only when the sealed
- * endpoint answers with a page instead of a file. That is not hypothetical: on
- * 2026-08-03 every sealed endpoint began returning "Request body constraint
- * violation" — for plain desktop browsers too, so it is a MENDELU-side fault
- * reIS cannot fix. An unsealed document beats no document, and the UI tells the
- * student which one they got. See memory `tisk-dokumentu-catalog`.
+ * endpoint answers with a page instead of a file. That is not hypothetical, and
+ * the failure is PER-DOCUMENT rather than a blanket outage — measured repeatedly
+ * on 2026-08-03, `potvrzeni_tisk_el` failed 3/3 with "Request body constraint
+ * violation" while `prehled_tisk_el` succeeded 3/3. It reproduces in a plain
+ * desktop browser, so it is a MENDELU-side fault reIS cannot fix.
+ *
+ * An unsealed document beats no document, and the UI tells the student which one
+ * they got — a silent downgrade is the one way this can do harm, since an
+ * unsealed copy may be refused. See memory `tisk-dokumentu-catalog`.
  */
 export const STUDY_DOCUMENTS: StudyDocument[] = [
-  { id: 'potvrzeni-cz', labelKey: 'confirmationCz', trigger: 'potvrzeni_tisk_el=1', fallbackTrigger: 'potvrzeni_tisk=1', filename: 'Potvrzeni_o_studiu.pdf' },
-  { id: 'potvrzeni-en', labelKey: 'confirmationEn', trigger: 'potvrzeni_tisk_el=1', fallbackTrigger: 'potvrzeni_tisk=1', contentLang: 'eng', filename: 'Confirmation_of_study.pdf' },
-  { id: 'prehled-cz', labelKey: 'overviewCz', trigger: 'prehled_tisk_el=1', fallbackTrigger: 'prehled_tisk=1', filename: 'Prehled_studia.pdf' },
-  { id: 'prehled-en', labelKey: 'overviewEn', trigger: 'prehled_tisk_el=1', fallbackTrigger: 'prehled_tisk=1', contentLang: 'eng', filename: 'Study_overview.pdf' },
+  {
+    id: 'potvrzeni-cz',
+    labelKey: 'confirmationCz',
+    trigger: 'potvrzeni_tisk_el=1',
+    fallbackTrigger: 'potvrzeni_tisk=1',
+    filename: 'Potvrzeni_o_studiu.pdf',
+  },
+  {
+    id: 'potvrzeni-en',
+    labelKey: 'confirmationEn',
+    trigger: 'potvrzeni_tisk_el=1',
+    fallbackTrigger: 'potvrzeni_tisk=1',
+    contentLang: 'eng',
+    filename: 'Confirmation_of_study.pdf',
+  },
+  {
+    id: 'prehled-cz',
+    labelKey: 'overviewCz',
+    trigger: 'prehled_tisk_el=1',
+    fallbackTrigger: 'prehled_tisk=1',
+    filename: 'Prehled_studia.pdf',
+  },
+  {
+    id: 'prehled-en',
+    labelKey: 'overviewEn',
+    trigger: 'prehled_tisk_el=1',
+    fallbackTrigger: 'prehled_tisk=1',
+    contentLang: 'eng',
+    filename: 'Study_overview.pdf',
+  },
   // The registration sheet has no sealed variant, so this IS the plain one.
-  { id: 'reg-arch', labelKey: 'regArch', trigger: 'reg_arch_tisk=1', filename: 'Registracni_arch.pdf' },
+  {
+    id: 'reg-arch',
+    labelKey: 'regArch',
+    trigger: 'reg_arch_tisk=1',
+    filename: 'Registracni_arch.pdf',
+  },
 ];
 
 /** Build a direct-download URL. `lang=cz` only affects IS UI chrome (irrelevant to a download). */

--- a/src/api/studyDocuments.ts
+++ b/src/api/studyDocuments.ts
@@ -14,15 +14,30 @@ export interface StudyDocument {
 
 /**
  * One-click study documents on IS's "Tisk dokumentů" page. All return a
- * synchronous `application/pdf` on a single GET (verified 2026-07-05). The
- * sealed (`_el`) variant is used wherever it exists — it is instant AND
- * carries the electronic seal. See memory `tisk-dokumentu-catalog`.
+ * synchronous `application/pdf` on a single GET.
+ *
+ * **Do not switch these to the sealed (`_el`) triggers.** An earlier version did,
+ * on the belief that `_el` was instant AND carried the electronic seal. Measured
+ * against live IS on 2026-08-03, that is false on both counts:
+ *
+ *   - `_el` over GET answers 200 `text/html` with "Operaci se nepodařilo úspěšně
+ *     dokončit. Request body constraint violation" — IS wants a POST body.
+ *   - Sealing is not a download at all. That page states the sealed document is
+ *     produced asynchronously and "do hodiny jej naleznete v aplikaci Úložiště
+ *     dokumentů" — within an hour, in the document repository.
+ *
+ * The failure is worse than a dead button: `downloadDocumentInPage` reads a
+ * non-PDF 200 as an expired session, so the content script force-navigates the
+ * student to the IS login page.
+ *
+ * Offering sealed copies needs POST support plus a repository pickup flow, and
+ * cannot be one tap. See memory `tisk-dokumentu-catalog`.
  */
 export const STUDY_DOCUMENTS: StudyDocument[] = [
-  { id: 'potvrzeni-cz', labelKey: 'confirmationCz', trigger: 'potvrzeni_tisk_el=1', filename: 'Potvrzeni_o_studiu.pdf' },
-  { id: 'potvrzeni-en', labelKey: 'confirmationEn', trigger: 'potvrzeni_tisk_el=1', contentLang: 'eng', filename: 'Confirmation_of_study.pdf' },
-  { id: 'prehled-cz', labelKey: 'overviewCz', trigger: 'prehled_tisk_el=1', filename: 'Prehled_studia.pdf' },
-  { id: 'prehled-en', labelKey: 'overviewEn', trigger: 'prehled_tisk_el=1', contentLang: 'eng', filename: 'Study_overview.pdf' },
+  { id: 'potvrzeni-cz', labelKey: 'confirmationCz', trigger: 'potvrzeni_tisk=1', filename: 'Potvrzeni_o_studiu.pdf' },
+  { id: 'potvrzeni-en', labelKey: 'confirmationEn', trigger: 'potvrzeni_tisk=1', contentLang: 'eng', filename: 'Confirmation_of_study.pdf' },
+  { id: 'prehled-cz', labelKey: 'overviewCz', trigger: 'prehled_tisk=1', filename: 'Prehled_studia.pdf' },
+  { id: 'prehled-en', labelKey: 'overviewEn', trigger: 'prehled_tisk=1', contentLang: 'eng', filename: 'Study_overview.pdf' },
   { id: 'reg-arch', labelKey: 'regArch', trigger: 'reg_arch_tisk=1', filename: 'Registracni_arch.pdf' },
 ];
 

--- a/src/api/studyDocuments.ts
+++ b/src/api/studyDocuments.ts
@@ -14,30 +14,15 @@ export interface StudyDocument {
 
 /**
  * One-click study documents on IS's "Tisk dokumentů" page. All return a
- * synchronous `application/pdf` on a single GET.
- *
- * **Do not switch these to the sealed (`_el`) triggers.** An earlier version did,
- * on the belief that `_el` was instant AND carried the electronic seal. Measured
- * against live IS on 2026-08-03, that is false on both counts:
- *
- *   - `_el` over GET answers 200 `text/html` with "Operaci se nepodařilo úspěšně
- *     dokončit. Request body constraint violation" — IS wants a POST body.
- *   - Sealing is not a download at all. That page states the sealed document is
- *     produced asynchronously and "do hodiny jej naleznete v aplikaci Úložiště
- *     dokumentů" — within an hour, in the document repository.
- *
- * The failure is worse than a dead button: `downloadDocumentInPage` reads a
- * non-PDF 200 as an expired session, so the content script force-navigates the
- * student to the IS login page.
- *
- * Offering sealed copies needs POST support plus a repository pickup flow, and
- * cannot be one tap. See memory `tisk-dokumentu-catalog`.
+ * synchronous `application/pdf` on a single GET (verified 2026-07-05). The
+ * sealed (`_el`) variant is used wherever it exists — it is instant AND
+ * carries the electronic seal. See memory `tisk-dokumentu-catalog`.
  */
 export const STUDY_DOCUMENTS: StudyDocument[] = [
-  { id: 'potvrzeni-cz', labelKey: 'confirmationCz', trigger: 'potvrzeni_tisk=1', filename: 'Potvrzeni_o_studiu.pdf' },
-  { id: 'potvrzeni-en', labelKey: 'confirmationEn', trigger: 'potvrzeni_tisk=1', contentLang: 'eng', filename: 'Confirmation_of_study.pdf' },
-  { id: 'prehled-cz', labelKey: 'overviewCz', trigger: 'prehled_tisk=1', filename: 'Prehled_studia.pdf' },
-  { id: 'prehled-en', labelKey: 'overviewEn', trigger: 'prehled_tisk=1', contentLang: 'eng', filename: 'Study_overview.pdf' },
+  { id: 'potvrzeni-cz', labelKey: 'confirmationCz', trigger: 'potvrzeni_tisk_el=1', filename: 'Potvrzeni_o_studiu.pdf' },
+  { id: 'potvrzeni-en', labelKey: 'confirmationEn', trigger: 'potvrzeni_tisk_el=1', contentLang: 'eng', filename: 'Confirmation_of_study.pdf' },
+  { id: 'prehled-cz', labelKey: 'overviewCz', trigger: 'prehled_tisk_el=1', filename: 'Prehled_studia.pdf' },
+  { id: 'prehled-en', labelKey: 'overviewEn', trigger: 'prehled_tisk_el=1', contentLang: 'eng', filename: 'Study_overview.pdf' },
   { id: 'reg-arch', labelKey: 'regArch', trigger: 'reg_arch_tisk=1', filename: 'Registracni_arch.pdf' },
 ];
 

--- a/src/api/studyDocuments.ts
+++ b/src/api/studyDocuments.ts
@@ -4,8 +4,11 @@ export interface StudyDocument {
   id: string;
   /** i18n key under `documents.items.*` for the row label. */
   labelKey: string;
-  /** IS trigger flag, e.g. `potvrzeni_tisk_el=1`. */
+  /** IS trigger flag, e.g. `potvrzeni_tisk_el=1`. Sealed wherever one exists. */
   trigger: string;
+  /** Unsealed equivalent, tried only when the sealed one returns a page instead
+   *  of a file. Absent when `trigger` is already the plain variant. */
+  fallbackTrigger?: string;
   /** Present ⇒ append `;jazyk=eng` so the document *content* is English. */
   contentLang?: 'eng';
   /** Filename handed to the browser's download manager. */
@@ -14,22 +17,41 @@ export interface StudyDocument {
 
 /**
  * One-click study documents on IS's "Tisk dokumentů" page. All return a
- * synchronous `application/pdf` on a single GET (verified 2026-07-05). The
- * sealed (`_el`) variant is used wherever it exists — it is instant AND
- * carries the electronic seal. See memory `tisk-dokumentu-catalog`.
+ * synchronous `application/pdf` on a single GET (verified 2026-07-05).
+ *
+ * The sealed (`_el`) variant is preferred wherever it exists — it is instant,
+ * carries the electronic seal that makes offices accept the document, and files
+ * a copy into Úložiště dokumentů.
+ *
+ * `fallbackTrigger` is the unsealed equivalent, used only when the sealed
+ * endpoint answers with a page instead of a file. That is not hypothetical: on
+ * 2026-08-03 every sealed endpoint began returning "Request body constraint
+ * violation" — for plain desktop browsers too, so it is a MENDELU-side fault
+ * reIS cannot fix. An unsealed document beats no document, and the UI tells the
+ * student which one they got. See memory `tisk-dokumentu-catalog`.
  */
 export const STUDY_DOCUMENTS: StudyDocument[] = [
-  { id: 'potvrzeni-cz', labelKey: 'confirmationCz', trigger: 'potvrzeni_tisk_el=1', filename: 'Potvrzeni_o_studiu.pdf' },
-  { id: 'potvrzeni-en', labelKey: 'confirmationEn', trigger: 'potvrzeni_tisk_el=1', contentLang: 'eng', filename: 'Confirmation_of_study.pdf' },
-  { id: 'prehled-cz', labelKey: 'overviewCz', trigger: 'prehled_tisk_el=1', filename: 'Prehled_studia.pdf' },
-  { id: 'prehled-en', labelKey: 'overviewEn', trigger: 'prehled_tisk_el=1', contentLang: 'eng', filename: 'Study_overview.pdf' },
+  { id: 'potvrzeni-cz', labelKey: 'confirmationCz', trigger: 'potvrzeni_tisk_el=1', fallbackTrigger: 'potvrzeni_tisk=1', filename: 'Potvrzeni_o_studiu.pdf' },
+  { id: 'potvrzeni-en', labelKey: 'confirmationEn', trigger: 'potvrzeni_tisk_el=1', fallbackTrigger: 'potvrzeni_tisk=1', contentLang: 'eng', filename: 'Confirmation_of_study.pdf' },
+  { id: 'prehled-cz', labelKey: 'overviewCz', trigger: 'prehled_tisk_el=1', fallbackTrigger: 'prehled_tisk=1', filename: 'Prehled_studia.pdf' },
+  { id: 'prehled-en', labelKey: 'overviewEn', trigger: 'prehled_tisk_el=1', fallbackTrigger: 'prehled_tisk=1', contentLang: 'eng', filename: 'Study_overview.pdf' },
+  // The registration sheet has no sealed variant, so this IS the plain one.
   { id: 'reg-arch', labelKey: 'regArch', trigger: 'reg_arch_tisk=1', filename: 'Registracni_arch.pdf' },
 ];
 
 /** Build a direct-download URL. `lang=cz` only affects IS UI chrome (irrelevant to a download). */
 export function buildDocumentUrl(sid: string, doc: StudyDocument): string {
+  return buildTriggerUrl(sid, doc, doc.trigger);
+}
+
+/** The unsealed URL to retry with, or null when this document has no sealed variant. */
+export function buildFallbackDocumentUrl(sid: string, doc: StudyDocument): string | null {
+  return doc.fallbackTrigger ? buildTriggerUrl(sid, doc, doc.fallbackTrigger) : null;
+}
+
+function buildTriggerUrl(sid: string, doc: StudyDocument, trigger: string): string {
   const jazyk = doc.contentLang ? `;jazyk=${doc.contentLang}` : '';
-  return `${BASE_URL}/auth/student/tisk_dokumentu.pl?${doc.trigger}${jazyk};studium=${sid};lang=cz`;
+  return `${BASE_URL}/auth/student/tisk_dokumentu.pl?${trigger}${jazyk};studium=${sid};lang=cz`;
 }
 
 /** The Žádost form (needs typed input) — opened in a new tab, not downloaded. */

--- a/src/components/StudyDocuments/DocumentsDrawer.tsx
+++ b/src/components/StudyDocuments/DocumentsDrawer.tsx
@@ -1,35 +1,59 @@
-import { FileCheck2, FileText, ScrollText, Loader2, Check, AlertTriangle, ExternalLink, X } from 'lucide-react';
+import {
+  FileCheck2,
+  FileText,
+  ScrollText,
+  Loader2,
+  Check,
+  AlertTriangle,
+  ExternalLink,
+  X,
+} from 'lucide-react';
 import { useAppStore } from '../../store/useAppStore';
 import { useUserParams } from '../../hooks/useUserParams';
 import { useTranslation } from '../../hooks/useTranslation';
 import { AdaptiveDrawer } from '../ui/AdaptiveDrawer';
-import { STUDY_DOCUMENTS, buildDocumentUrl, buildFallbackDocumentUrl, buildZadostUrl } from '../../api/studyDocuments';
+import {
+  STUDY_DOCUMENTS,
+  buildDocumentUrl,
+  buildFallbackDocumentUrl,
+  buildZadostUrl,
+} from '../../api/studyDocuments';
 import { useDocumentDownload, type DownloadStatus } from '../../hooks/data/useDocumentDownload';
 
 const ICONS: Record<string, typeof FileText> = {
-  'potvrzeni-cz': FileCheck2, 'potvrzeni-en': FileCheck2,
-  'prehled-cz': FileText, 'prehled-en': FileText, 'reg-arch': ScrollText,
+  'potvrzeni-cz': FileCheck2,
+  'potvrzeni-en': FileCheck2,
+  'prehled-cz': FileText,
+  'prehled-en': FileText,
+  'reg-arch': ScrollText,
 };
 
 function StatusIcon({ status }: { status: DownloadStatus }) {
-  if (status === 'loading') return <Loader2 className="w-4 h-4 animate-spin" aria-label="loading" />;
+  if (status === 'loading')
+    return <Loader2 className="w-4 h-4 animate-spin" aria-label="loading" />;
   if (status === 'done') return <Check className="w-4 h-4 text-success" aria-label="done" />;
-  if (status === 'error') return <AlertTriangle className="w-4 h-4 text-error" aria-label="error" />;
+  if (status === 'error')
+    return <AlertTriangle className="w-4 h-4 text-error" aria-label="error" />;
   return null;
 }
 
 /** Documents panel opened from the Student flyout. Self-connects to the store. */
 export function DocumentsDrawer() {
   const { t } = useTranslation();
-  const isOpen = useAppStore(s => s.isDocumentsOpen);
-  const setOpen = useAppStore(s => s.setIsDocumentsOpen);
-  const language = useAppStore(s => s.language);
+  const isOpen = useAppStore((s) => s.isDocumentsOpen);
+  const setOpen = useAppStore((s) => s.setIsDocumentsOpen);
+  const language = useAppStore((s) => s.language);
   const { params } = useUserParams();
   const sid = params?.studium ?? '';
   const { status, run } = useDocumentDownload();
 
   return (
-    <AdaptiveDrawer open={isOpen} onClose={() => setOpen(false)} width="sm:w-[460px]" title={t('documents.title')}>
+    <AdaptiveDrawer
+      open={isOpen}
+      onClose={() => setOpen(false)}
+      width="sm:w-[460px]"
+      title={t('documents.title')}
+    >
       {/* Header — AdaptiveDrawer's `title` prop only surfaces as a sr-only a11y
           label on the mobile sheet; desktop needs a real visible heading +
           close affordance, so render one explicitly (mirrors EduroamDrawer). */}
@@ -40,19 +64,30 @@ export function DocumentsDrawer() {
         <div className="flex-1 min-w-0">
           <h3 className="font-bold text-base truncate">{t('documents.title')}</h3>
         </div>
-        <button onClick={() => setOpen(false)} aria-label={t('common.close')} className="btn btn-ghost btn-xs btn-circle">
+        <button
+          onClick={() => setOpen(false)}
+          aria-label={t('common.close')}
+          className="btn btn-ghost btn-xs btn-circle"
+        >
           <X size={16} />
         </button>
       </div>
       <div className="flex flex-col gap-1 p-3">
-        {STUDY_DOCUMENTS.map(doc => {
+        {STUDY_DOCUMENTS.map((doc) => {
           const Icon = ICONS[doc.id] ?? FileText;
           const st = status[doc.id] ?? 'idle';
           return (
             <button
               key={doc.id}
               disabled={!sid || st === 'loading'}
-              onClick={() => run(doc.id, buildDocumentUrl(sid, doc), doc.filename, buildFallbackDocumentUrl(sid, doc))}
+              onClick={() =>
+                run(
+                  doc.id,
+                  buildDocumentUrl(sid, doc),
+                  doc.filename,
+                  buildFallbackDocumentUrl(sid, doc)
+                )
+              }
               className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm hover:bg-base-200 disabled:opacity-50 transition-colors text-left"
             >
               <Icon className="w-5 h-5 text-primary shrink-0" />

--- a/src/components/StudyDocuments/DocumentsDrawer.tsx
+++ b/src/components/StudyDocuments/DocumentsDrawer.tsx
@@ -3,7 +3,7 @@ import { useAppStore } from '../../store/useAppStore';
 import { useUserParams } from '../../hooks/useUserParams';
 import { useTranslation } from '../../hooks/useTranslation';
 import { AdaptiveDrawer } from '../ui/AdaptiveDrawer';
-import { STUDY_DOCUMENTS, buildDocumentUrl, buildZadostUrl } from '../../api/studyDocuments';
+import { STUDY_DOCUMENTS, buildDocumentUrl, buildFallbackDocumentUrl, buildZadostUrl } from '../../api/studyDocuments';
 import { useDocumentDownload, type DownloadStatus } from '../../hooks/data/useDocumentDownload';
 
 const ICONS: Record<string, typeof FileText> = {
@@ -52,7 +52,7 @@ export function DocumentsDrawer() {
             <button
               key={doc.id}
               disabled={!sid || st === 'loading'}
-              onClick={() => run(doc.id, buildDocumentUrl(sid, doc), doc.filename)}
+              onClick={() => run(doc.id, buildDocumentUrl(sid, doc), doc.filename, buildFallbackDocumentUrl(sid, doc))}
               className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm hover:bg-base-200 disabled:opacity-50 transition-colors text-left"
             >
               <Icon className="w-5 h-5 text-primary shrink-0" />

--- a/src/components/StudyDocuments/__tests__/DocumentsDrawer.test.tsx
+++ b/src/components/StudyDocuments/__tests__/DocumentsDrawer.test.tsx
@@ -5,12 +5,17 @@ import { useAppStore } from '../../../store/useAppStore';
 import * as proxy from '../../../api/proxyClient';
 import { useUserParams } from '../../../hooks/useUserParams';
 
-vi.mock('../../../hooks/useUserParams', () => ({ useUserParams: vi.fn(() => ({ params: { studium: '149707' } })) }));
+vi.mock('../../../hooks/useUserParams', () => ({
+  useUserParams: vi.fn(() => ({ params: { studium: '149707' } })),
+}));
 
 describe('DocumentsDrawer', () => {
   beforeEach(() => {
     useAppStore.setState({ isDocumentsOpen: true, language: 'cz' });
-    vi.mocked(useUserParams).mockReturnValue({ params: { studium: '149707' }, loading: false } as never);
+    vi.mocked(useUserParams).mockReturnValue({
+      params: { studium: '149707' },
+      loading: false,
+    } as never);
   });
   afterEach(() => {
     // Unmount before resetting store state: this local afterEach runs before
@@ -39,7 +44,7 @@ describe('DocumentsDrawer', () => {
       'https://is.mendelu.cz/auth/student/tisk_dokumentu.pl?potvrzeni_tisk_el=1;studium=149707;lang=cz',
       'Potvrzeni_o_studiu.pdf',
       // The unsealed fallback rides along so a sealing outage cannot dead-end the row.
-      'https://is.mendelu.cz/auth/student/tisk_dokumentu.pl?potvrzeni_tisk=1;studium=149707;lang=cz',
+      'https://is.mendelu.cz/auth/student/tisk_dokumentu.pl?potvrzeni_tisk=1;studium=149707;lang=cz'
     );
     await waitFor(() => expect(screen.getByLabelText('done')).toBeTruthy());
   });

--- a/src/components/StudyDocuments/__tests__/DocumentsDrawer.test.tsx
+++ b/src/components/StudyDocuments/__tests__/DocumentsDrawer.test.tsx
@@ -36,7 +36,7 @@ describe('DocumentsDrawer', () => {
       fireEvent.click(screen.getByText('Potvrzení o studiu'));
     });
     expect(spy).toHaveBeenCalledWith(
-      'https://is.mendelu.cz/auth/student/tisk_dokumentu.pl?potvrzeni_tisk_el=1;studium=149707;lang=cz',
+      'https://is.mendelu.cz/auth/student/tisk_dokumentu.pl?potvrzeni_tisk=1;studium=149707;lang=cz',
       'Potvrzeni_o_studiu.pdf',
     );
     await waitFor(() => expect(screen.getByLabelText('done')).toBeTruthy());

--- a/src/components/StudyDocuments/__tests__/DocumentsDrawer.test.tsx
+++ b/src/components/StudyDocuments/__tests__/DocumentsDrawer.test.tsx
@@ -30,7 +30,7 @@ describe('DocumentsDrawer', () => {
   });
 
   it('downloads on row click and shows completion', async () => {
-    const spy = vi.spyOn(proxy, 'downloadDocument').mockResolvedValue(undefined);
+    const spy = vi.spyOn(proxy, 'downloadDocument').mockResolvedValue({ usedFallback: false });
     render(<DocumentsDrawer />);
     await act(async () => {
       fireEvent.click(screen.getByText('Potvrzení o studiu'));
@@ -38,6 +38,8 @@ describe('DocumentsDrawer', () => {
     expect(spy).toHaveBeenCalledWith(
       'https://is.mendelu.cz/auth/student/tisk_dokumentu.pl?potvrzeni_tisk_el=1;studium=149707;lang=cz',
       'Potvrzeni_o_studiu.pdf',
+      // The unsealed fallback rides along so a sealing outage cannot dead-end the row.
+      'https://is.mendelu.cz/auth/student/tisk_dokumentu.pl?potvrzeni_tisk=1;studium=149707;lang=cz',
     );
     await waitFor(() => expect(screen.getByLabelText('done')).toBeTruthy());
   });

--- a/src/components/StudyDocuments/__tests__/DocumentsDrawer.test.tsx
+++ b/src/components/StudyDocuments/__tests__/DocumentsDrawer.test.tsx
@@ -36,7 +36,7 @@ describe('DocumentsDrawer', () => {
       fireEvent.click(screen.getByText('Potvrzení o studiu'));
     });
     expect(spy).toHaveBeenCalledWith(
-      'https://is.mendelu.cz/auth/student/tisk_dokumentu.pl?potvrzeni_tisk=1;studium=149707;lang=cz',
+      'https://is.mendelu.cz/auth/student/tisk_dokumentu.pl?potvrzeni_tisk_el=1;studium=149707;lang=cz',
       'Potvrzeni_o_studiu.pdf',
     );
     await waitFor(() => expect(screen.getByLabelText('done')).toBeTruthy());

--- a/src/components/mobile/sheets/DocsSheet.tsx
+++ b/src/components/mobile/sheets/DocsSheet.tsx
@@ -79,7 +79,12 @@ export function DocsSheet({ onClose }: DocsSheetProps) {
                 type="button"
                 disabled={!sid || st === 'loading'}
                 onClick={() =>
-                  run(doc.id, buildDocumentUrl(sid, doc), doc.filename, buildFallbackDocumentUrl(sid, doc))
+                  run(
+                    doc.id,
+                    buildDocumentUrl(sid, doc),
+                    doc.filename,
+                    buildFallbackDocumentUrl(sid, doc)
+                  )
                 }
                 className="btn btn-primary btn-xs flex-shrink-0"
               >

--- a/src/components/mobile/sheets/DocsSheet.tsx
+++ b/src/components/mobile/sheets/DocsSheet.tsx
@@ -11,7 +11,12 @@ import { Sheet } from '../primitives/Sheet';
 import { SheetHeader } from '../primitives/SheetHeader';
 import { useAppStore } from '../../../store/useAppStore';
 import { useTranslation } from '../../../hooks/useTranslation';
-import { STUDY_DOCUMENTS, buildDocumentUrl, buildZadostUrl } from '../../../api/studyDocuments';
+import {
+  STUDY_DOCUMENTS,
+  buildDocumentUrl,
+  buildFallbackDocumentUrl,
+  buildZadostUrl,
+} from '../../../api/studyDocuments';
 import { useDocumentDownload, type DownloadStatus } from '../../../hooks/data/useDocumentDownload';
 
 export interface DocsSheetProps {
@@ -73,7 +78,9 @@ export function DocsSheet({ onClose }: DocsSheetProps) {
               <button
                 type="button"
                 disabled={!sid || st === 'loading'}
-                onClick={() => run(doc.id, buildDocumentUrl(sid, doc), doc.filename)}
+                onClick={() =>
+                  run(doc.id, buildDocumentUrl(sid, doc), doc.filename, buildFallbackDocumentUrl(sid, doc))
+                }
                 className="btn btn-primary btn-xs flex-shrink-0"
               >
                 {t('common.download')}

--- a/src/components/mobile/sheets/ProfileSheet.tsx
+++ b/src/components/mobile/sheets/ProfileSheet.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { toast } from 'sonner';
 import {
   X,
   Moon,
@@ -200,7 +201,11 @@ export function ProfileSheet({ onClose }: ProfileSheetProps) {
         <button
           type="button"
           onClick={() => {
-            void logout();
+            // Sign-out is deferred on mobile until the transport can POST, and
+            // logout() now refuses rather than wiping local data first. Catch
+            // it: an unhandled rejection here would fire a telemetry report on
+            // every tap and tell the student nothing.
+            void logout().catch(() => toast.error(t('settings.logoutUnavailable')));
           }}
           className="flex w-full items-center gap-3 px-4 py-3 text-error"
         >

--- a/src/components/mobile/sheets/__tests__/DocsSheet.test.tsx
+++ b/src/components/mobile/sheets/__tests__/DocsSheet.test.tsx
@@ -37,8 +37,9 @@ describe('DocsSheet', () => {
 
     expect(run).toHaveBeenCalledWith(
       'potvrzeni-cz',
-      expect.stringContaining('12345'),
-      'Potvrzeni_o_studiu.pdf'
+      expect.stringContaining('potvrzeni_tisk_el=1'),
+      'Potvrzeni_o_studiu.pdf',
+      expect.stringContaining('potvrzeni_tisk=1')
     );
   });
 

--- a/src/hooks/data/__tests__/useDocumentDownload.test.ts
+++ b/src/hooks/data/__tests__/useDocumentDownload.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act, waitFor, cleanup } from '@testing-library/react';
+import { toast } from 'sonner';
 import { useDocumentDownload } from '../useDocumentDownload';
 import * as proxy from '../../../api/proxyClient';
 
@@ -7,12 +8,17 @@ describe('useDocumentDownload', () => {
   beforeEach(() => vi.useRealTimers());
   // cleanup() unmounts each hook so its done→idle timer-clearing effect runs —
   // otherwise the 2s setTimeout leaks and can fire mid-way through a later test.
-  afterEach(() => { cleanup(); vi.restoreAllMocks(); });
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
 
   it('drives a row loading → done on success', async () => {
-    vi.spyOn(proxy, 'downloadDocument').mockResolvedValue(undefined);
+    vi.spyOn(proxy, 'downloadDocument').mockResolvedValue({ usedFallback: false });
     const { result } = renderHook(() => useDocumentDownload());
-    act(() => { result.current.run('potvrzeni-cz', 'https://x', 'f.pdf'); });
+    act(() => {
+      result.current.run('potvrzeni-cz', 'https://x', 'f.pdf');
+    });
     expect(result.current.status['potvrzeni-cz']).toBe('loading');
     await waitFor(() => expect(result.current.status['potvrzeni-cz']).toBe('done'));
   });
@@ -20,12 +26,14 @@ describe('useDocumentDownload', () => {
   it('drives a row loading → error on failure', async () => {
     vi.spyOn(proxy, 'downloadDocument').mockRejectedValue(new Error('boom'));
     const { result } = renderHook(() => useDocumentDownload());
-    act(() => { result.current.run('reg-arch', 'https://x', 'f.pdf'); });
+    act(() => {
+      result.current.run('reg-arch', 'https://x', 'f.pdf');
+    });
     await waitFor(() => expect(result.current.status['reg-arch']).toBe('error'));
   });
 
   it('ignores a ghost re-click on a row already in flight', async () => {
-    const spy = vi.spyOn(proxy, 'downloadDocument').mockResolvedValue(undefined);
+    const spy = vi.spyOn(proxy, 'downloadDocument').mockResolvedValue({ usedFallback: false });
     const { result } = renderHook(() => useDocumentDownload());
     act(() => {
       result.current.run('potvrzeni-cz', 'https://x', 'f.pdf');
@@ -36,15 +44,51 @@ describe('useDocumentDownload', () => {
   });
 
   it('clears the pending done→idle timer on unmount', async () => {
-    vi.spyOn(proxy, 'downloadDocument').mockResolvedValue(undefined);
+    vi.spyOn(proxy, 'downloadDocument').mockResolvedValue({ usedFallback: false });
     const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout');
     const { result, unmount } = renderHook(() => useDocumentDownload());
-    act(() => { result.current.run('potvrzeni-cz', 'https://x', 'f.pdf'); });
+    act(() => {
+      result.current.run('potvrzeni-cz', 'https://x', 'f.pdf');
+    });
     await waitFor(() => expect(result.current.status['potvrzeni-cz']).toBe('done'));
 
     clearTimeoutSpy.mockClear();
     unmount();
 
     expect(clearTimeoutSpy).toHaveBeenCalled();
+  });
+
+  it('warns the student when the UNSEALED document was saved instead', async () => {
+    // The silent-downgrade guard: an unsealed copy can be refused by the office
+    // the student takes it to, so the fallback must never be invisible.
+    const warn = vi.spyOn(toast, 'warning').mockImplementation(() => '' as never);
+    vi.spyOn(proxy, 'downloadDocument').mockResolvedValue({ usedFallback: true });
+    const { result } = renderHook(() => useDocumentDownload());
+    act(() => {
+      result.current.run('potvrzeni-cz', 'https://x', 'f.pdf', 'https://x-plain');
+    });
+    await waitFor(() => expect(result.current.status['potvrzeni-cz']).toBe('done'));
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('stays quiet when the sealed document worked', async () => {
+    const warn = vi.spyOn(toast, 'warning').mockImplementation(() => '' as never);
+    vi.spyOn(proxy, 'downloadDocument').mockResolvedValue({ usedFallback: false });
+    const { result } = renderHook(() => useDocumentDownload());
+    act(() => {
+      result.current.run('prehled-cz', 'https://x', 'f.pdf', 'https://x-plain');
+    });
+    await waitFor(() => expect(result.current.status['prehled-cz']).toBe('done'));
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('passes the unsealed fallback URL through to the downloader', async () => {
+    const spy = vi.spyOn(proxy, 'downloadDocument').mockResolvedValue({ usedFallback: false });
+    const { result } = renderHook(() => useDocumentDownload());
+    act(() => {
+      result.current.run('potvrzeni-cz', 'https://sealed', 'f.pdf', 'https://plain');
+    });
+    await waitFor(() => expect(result.current.status['potvrzeni-cz']).toBe('done'));
+    expect(spy).toHaveBeenCalledWith('https://sealed', 'f.pdf', 'https://plain');
   });
 });

--- a/src/hooks/data/useDocumentDownload.ts
+++ b/src/hooks/data/useDocumentDownload.ts
@@ -18,9 +18,12 @@ export function useDocumentDownload() {
   const inFlight = useRef<Set<string>>(new Set());
 
   // Cancel any pending done→idle resets if the drawer unmounts.
-  useEffect(() => () => {
-    Object.values(timers.current).forEach(clearTimeout);
-  }, []);
+  useEffect(
+    () => () => {
+      Object.values(timers.current).forEach(clearTimeout);
+    },
+    []
+  );
 
   /**
    * `fallbackUrl` is the unsealed variant of the same document. When the sealed
@@ -28,24 +31,28 @@ export function useDocumentDownload() {
    * the student is TOLD, because an unsealed copy can be refused by the office
    * they take it to. A silent downgrade is the one way this fallback can harm.
    */
-  const run = useCallback((id: string, url: string, filename: string, fallbackUrl?: string | null) => {
-    if (inFlight.current.has(id)) return;
-    inFlight.current.add(id);
-    clearTimeout(timers.current[id]);
-    setStatus(s => ({ ...s, [id]: 'loading' }));
-    downloadDocument(url, filename, fallbackUrl)
-      .then((res) => {
-        inFlight.current.delete(id);
-        if (res?.usedFallback) toast.warning(tr('documents.unsealedFallback'), { duration: 6000 });
-        setStatus(s => ({ ...s, [id]: 'done' }));
-        timers.current[id] = setTimeout(() => setStatus(s => ({ ...s, [id]: 'idle' })), 2000);
-      })
-      .catch((e) => {
-        inFlight.current.delete(id);
-        logError('Documents.download', e);
-        setStatus(s => ({ ...s, [id]: 'error' }));
-      });
-  }, [tr]);
+  const run = useCallback(
+    (id: string, url: string, filename: string, fallbackUrl?: string | null) => {
+      if (inFlight.current.has(id)) return;
+      inFlight.current.add(id);
+      clearTimeout(timers.current[id]);
+      setStatus((s) => ({ ...s, [id]: 'loading' }));
+      downloadDocument(url, filename, fallbackUrl)
+        .then((res) => {
+          inFlight.current.delete(id);
+          if (res?.usedFallback)
+            toast.warning(tr('documents.unsealedFallback'), { duration: 6000 });
+          setStatus((s) => ({ ...s, [id]: 'done' }));
+          timers.current[id] = setTimeout(() => setStatus((s) => ({ ...s, [id]: 'idle' })), 2000);
+        })
+        .catch((e) => {
+          inFlight.current.delete(id);
+          logError('Documents.download', e);
+          setStatus((s) => ({ ...s, [id]: 'error' }));
+        });
+    },
+    [tr]
+  );
 
   return { status, run };
 }

--- a/src/hooks/data/useDocumentDownload.ts
+++ b/src/hooks/data/useDocumentDownload.ts
@@ -1,12 +1,15 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { toast } from 'sonner';
 import { downloadDocument } from '../../api/proxyClient';
 import { logError } from '../../utils/reportError';
+import { useTranslation } from '../useTranslation';
 
 export type DownloadStatus = 'idle' | 'loading' | 'done' | 'error';
 
 /** Per-row download state for the documents drawer. Not in the store — this is
  *  transient UI state scoped to the open drawer. */
 export function useDocumentDownload() {
+  const { t: tr } = useTranslation();
   const [status, setStatus] = useState<Record<string, DownloadStatus>>({});
   const timers = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
   // Tracks ids with an in-flight download. A ref (not `status`, which can be
@@ -19,14 +22,21 @@ export function useDocumentDownload() {
     Object.values(timers.current).forEach(clearTimeout);
   }, []);
 
-  const run = useCallback((id: string, url: string, filename: string) => {
+  /**
+   * `fallbackUrl` is the unsealed variant of the same document. When the sealed
+   * endpoint fails, the downloader saves that instead and reports back — and
+   * the student is TOLD, because an unsealed copy can be refused by the office
+   * they take it to. A silent downgrade is the one way this fallback can harm.
+   */
+  const run = useCallback((id: string, url: string, filename: string, fallbackUrl?: string | null) => {
     if (inFlight.current.has(id)) return;
     inFlight.current.add(id);
     clearTimeout(timers.current[id]);
     setStatus(s => ({ ...s, [id]: 'loading' }));
-    downloadDocument(url, filename)
-      .then(() => {
+    downloadDocument(url, filename, fallbackUrl)
+      .then((res) => {
         inFlight.current.delete(id);
+        if (res?.usedFallback) toast.warning(tr('documents.unsealedFallback'), { duration: 6000 });
         setStatus(s => ({ ...s, [id]: 'done' }));
         timers.current[id] = setTimeout(() => setStatus(s => ({ ...s, [id]: 'idle' })), 2000);
       })
@@ -35,7 +45,7 @@ export function useDocumentDownload() {
         logError('Documents.download', e);
         setStatus(s => ({ ...s, [id]: 'error' }));
       });
-  }, []);
+  }, [tr]);
 
   return { status, run };
 }

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -54,6 +54,7 @@
   },
   "documents": {
     "title": "Studijní dokumenty",
+    "unsealedFallback": "Elektronická pečeť teď v IS nefunguje — stáhli jsme dokument bez ní. Úřad ji může vyžadovat.",
     "sheetSubtitle": "S elektronickým podpisem univerzity — úřady je berou",
     "items": {
       "confirmationCz": "Potvrzení o studiu",

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -54,7 +54,7 @@
   },
   "documents": {
     "title": "Studijní dokumenty",
-    "sheetSubtitle": "Oficiální dokumenty z IS — stáhni jedním klepnutím",
+    "sheetSubtitle": "S elektronickým podpisem univerzity — úřady je berou",
     "items": {
       "confirmationCz": "Potvrzení o studiu",
       "confirmationEn": "Confirmation of study",

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -54,7 +54,7 @@
   },
   "documents": {
     "title": "Studijní dokumenty",
-    "sheetSubtitle": "S elektronickým podpisem univerzity — úřady je berou",
+    "sheetSubtitle": "Oficiální dokumenty z IS — stáhni jedním klepnutím",
     "items": {
       "confirmationCz": "Potvrzení o studiu",
       "confirmationEn": "Confirmation of study",

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -85,6 +85,7 @@
     "errorReporting": "Hlášení chyb",
     "errorReportingDesc": "Posílat anonymizovaná hlášení chyb, ať můžeme bugy opravit.",
     "logout": "Odhlásit se",
+    "logoutUnavailable": "Odhlášení zatím v aplikaci nefunguje. Odhlaste se prosím v IS.",
     "basicDetails": "Základní údaje",
     "accounts": "Konta",
     "cards": "Karty",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -54,7 +54,7 @@
   },
   "documents": {
     "title": "Study documents",
-    "sheetSubtitle": "Official documents from IS — download in one tap",
+    "sheetSubtitle": "Electronically signed by the university — accepted by authorities",
     "items": {
       "confirmationCz": "Confirmation of study (Czech)",
       "confirmationEn": "Confirmation of study (English)",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -54,7 +54,7 @@
   },
   "documents": {
     "title": "Study documents",
-    "sheetSubtitle": "Electronically signed by the university — accepted by authorities",
+    "sheetSubtitle": "Official documents from IS — download in one tap",
     "items": {
       "confirmationCz": "Confirmation of study (Czech)",
       "confirmationEn": "Confirmation of study (English)",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -54,6 +54,7 @@
   },
   "documents": {
     "title": "Study documents",
+    "unsealedFallback": "IS can't seal documents right now — we downloaded the unsealed version. Some offices require the seal.",
     "sheetSubtitle": "Electronically signed by the university — accepted by authorities",
     "items": {
       "confirmationCz": "Confirmation of study (Czech)",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -85,6 +85,7 @@
     "errorReporting": "Error Reporting",
     "errorReportingDesc": "Send anonymous, sanitized error reports to help fix bugs.",
     "logout": "Logout",
+    "logoutUnavailable": "Signing out isn't available in the app yet. Please sign out in IS.",
     "basicDetails": "Basic Details",
     "accounts": "Accounts",
     "cards": "Cards",

--- a/src/injector/__tests__/documentDownloader.test.ts
+++ b/src/injector/__tests__/documentDownloader.test.ts
@@ -28,12 +28,64 @@ describe('downloadDocumentInPage', () => {
     expect(downloadName).toBe('Potvrzeni_o_studiu.pdf');
   });
 
-  it('rejects when the response is not a PDF (session expired → login HTML)', async () => {
+  it('treats a LOGIN page as an expired session (login redirect stays)', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response('<html>login</html>', { status: 200, headers: { 'content-type': 'text/html' } }),
+      new Response('<html>Přihlášení do systému</html>', { status: 200, headers: { 'content-type': 'text/html' } }),
     );
     await expect(downloadDocumentInPage('https://is.mendelu.cz/x', 'f.pdf')).rejects.toMatchObject({ sessionExpired: true });
     expect(clickSpy).not.toHaveBeenCalled();
+  });
+
+  it('treats an AUTHENTICATED page as notADocument, NOT an expired session', async () => {
+    // IS's sealed print endpoints answer a fully authenticated request this way
+    // while broken. Tagging it sessionExpired logged the student out over an IS
+    // bug — and left no opportunity to fall back to the unsealed document.
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('<html><a href="/auth/system/logout.pl">odhlásit</a></html>', {
+        status: 200, headers: { 'content-type': 'text/html' },
+      }),
+    );
+    const caught = await downloadDocumentInPage('https://is.mendelu.cz/x', 'f.pdf').catch((e) => e);
+    expect((caught as { notADocument?: boolean }).notADocument).toBe(true);
+    expect((caught as { sessionExpired?: boolean }).sessionExpired).toBeUndefined();
+  });
+
+  it('falls back to the unsealed URL when the sealed one returns a page', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response('<html><a href="/auth/system/logout.pl">x</a></html>', {
+        status: 200, headers: { 'content-type': 'text/html' },
+      }))
+      .mockResolvedValueOnce(new Response(pdfBlob(), {
+        status: 200, headers: { 'content-type': 'application/pdf' },
+      }));
+
+    const result = await downloadDocumentInPage(
+      'https://is.mendelu.cz/sealed', 'f.pdf', 'https://is.mendelu.cz/plain',
+    );
+
+    expect(result).toEqual({ usedFallback: true });
+    expect(fetchSpy.mock.calls.map((c) => c[0])).toEqual([
+      'https://is.mendelu.cz/sealed', 'https://is.mendelu.cz/plain',
+    ]);
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT fall back on an expired session — re-auth is the right answer', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('', { status: 403 }));
+    await expect(
+      downloadDocumentInPage('https://is.mendelu.cz/sealed', 'f.pdf', 'https://is.mendelu.cz/plain'),
+    ).rejects.toMatchObject({ sessionExpired: true });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports usedFallback:false when the sealed document works', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(pdfBlob(), { status: 200, headers: { 'content-type': 'application/pdf' } }),
+    );
+    const result = await downloadDocumentInPage(
+      'https://is.mendelu.cz/sealed', 'f.pdf', 'https://is.mendelu.cz/plain',
+    );
+    expect(result).toEqual({ usedFallback: false });
   });
 
   it('rejects on a 401', async () => {

--- a/src/injector/__tests__/documentDownloader.test.ts
+++ b/src/injector/__tests__/documentDownloader.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { downloadDocumentInPage } from '../documentDownloader';
 
-const pdfBlob = () => new Blob([new Uint8Array([0x25, 0x50, 0x44, 0x46])], { type: 'application/pdf' });
+const pdfBlob = () =>
+  new Blob([new Uint8Array([0x25, 0x50, 0x44, 0x46])], { type: 'application/pdf' });
 
 describe('downloadDocumentInPage', () => {
   let clickSpy: ReturnType<typeof vi.spyOn>;
@@ -12,14 +13,21 @@ describe('downloadDocumentInPage', () => {
     (URL as unknown as { revokeObjectURL: () => void }).revokeObjectURL = () => {};
     clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
   });
-  afterEach(() => { clickSpy.mockRestore(); vi.restoreAllMocks(); });
+  afterEach(() => {
+    clickSpy.mockRestore();
+    vi.restoreAllMocks();
+  });
 
   it('fetches the PDF and saves it via an <a download> with the given filename', async () => {
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(pdfBlob(), { status: 200, headers: { 'content-type': 'application/pdf' } }),
-    );
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(
+        new Response(pdfBlob(), { status: 200, headers: { 'content-type': 'application/pdf' } })
+      );
     let downloadName = '';
-    clickSpy.mockImplementation(function (this: HTMLAnchorElement) { downloadName = this.download; });
+    clickSpy.mockImplementation(function (this: HTMLAnchorElement) {
+      downloadName = this.download;
+    });
 
     await downloadDocumentInPage('https://is.mendelu.cz/x', 'Potvrzeni_o_studiu.pdf');
 
@@ -30,9 +38,14 @@ describe('downloadDocumentInPage', () => {
 
   it('treats a LOGIN page as an expired session (login redirect stays)', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response('<html>Přihlášení do systému</html>', { status: 200, headers: { 'content-type': 'text/html' } }),
+      new Response('<html>Přihlášení do systému</html>', {
+        status: 200,
+        headers: { 'content-type': 'text/html' },
+      })
     );
-    await expect(downloadDocumentInPage('https://is.mendelu.cz/x', 'f.pdf')).rejects.toMatchObject({ sessionExpired: true });
+    await expect(downloadDocumentInPage('https://is.mendelu.cz/x', 'f.pdf')).rejects.toMatchObject({
+      sessionExpired: true,
+    });
     expect(clickSpy).not.toHaveBeenCalled();
   });
 
@@ -42,8 +55,9 @@ describe('downloadDocumentInPage', () => {
     // bug — and left no opportunity to fall back to the unsealed document.
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(
       new Response('<html><a href="/auth/system/logout.pl">odhlásit</a></html>', {
-        status: 200, headers: { 'content-type': 'text/html' },
-      }),
+        status: 200,
+        headers: { 'content-type': 'text/html' },
+      })
     );
     const caught = await downloadDocumentInPage('https://is.mendelu.cz/x', 'f.pdf').catch((e) => e);
     expect((caught as { notADocument?: boolean }).notADocument).toBe(true);
@@ -51,46 +65,62 @@ describe('downloadDocumentInPage', () => {
   });
 
   it('falls back to the unsealed URL when the sealed one returns a page', async () => {
-    const fetchSpy = vi.spyOn(globalThis, 'fetch')
-      .mockResolvedValueOnce(new Response('<html><a href="/auth/system/logout.pl">x</a></html>', {
-        status: 200, headers: { 'content-type': 'text/html' },
-      }))
-      .mockResolvedValueOnce(new Response(pdfBlob(), {
-        status: 200, headers: { 'content-type': 'application/pdf' },
-      }));
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response('<html><a href="/auth/system/logout.pl">x</a></html>', {
+          status: 200,
+          headers: { 'content-type': 'text/html' },
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(pdfBlob(), {
+          status: 200,
+          headers: { 'content-type': 'application/pdf' },
+        })
+      );
 
     const result = await downloadDocumentInPage(
-      'https://is.mendelu.cz/sealed', 'f.pdf', 'https://is.mendelu.cz/plain',
+      'https://is.mendelu.cz/sealed',
+      'f.pdf',
+      'https://is.mendelu.cz/plain'
     );
 
     expect(result).toEqual({ usedFallback: true });
     expect(fetchSpy.mock.calls.map((c) => c[0])).toEqual([
-      'https://is.mendelu.cz/sealed', 'https://is.mendelu.cz/plain',
+      'https://is.mendelu.cz/sealed',
+      'https://is.mendelu.cz/plain',
     ]);
     expect(clickSpy).toHaveBeenCalledTimes(1);
   });
 
   it('does NOT fall back on an expired session — re-auth is the right answer', async () => {
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('', { status: 403 }));
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response('', { status: 403 }));
     await expect(
-      downloadDocumentInPage('https://is.mendelu.cz/sealed', 'f.pdf', 'https://is.mendelu.cz/plain'),
+      downloadDocumentInPage('https://is.mendelu.cz/sealed', 'f.pdf', 'https://is.mendelu.cz/plain')
     ).rejects.toMatchObject({ sessionExpired: true });
     expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 
   it('reports usedFallback:false when the sealed document works', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(pdfBlob(), { status: 200, headers: { 'content-type': 'application/pdf' } }),
+      new Response(pdfBlob(), { status: 200, headers: { 'content-type': 'application/pdf' } })
     );
     const result = await downloadDocumentInPage(
-      'https://is.mendelu.cz/sealed', 'f.pdf', 'https://is.mendelu.cz/plain',
+      'https://is.mendelu.cz/sealed',
+      'f.pdf',
+      'https://is.mendelu.cz/plain'
     );
     expect(result).toEqual({ usedFallback: false });
   });
 
   it('rejects on a 401', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('', { status: 401 }));
-    await expect(downloadDocumentInPage('https://is.mendelu.cz/x', 'f.pdf')).rejects.toMatchObject({ sessionExpired: true });
+    await expect(downloadDocumentInPage('https://is.mendelu.cz/x', 'f.pdf')).rejects.toMatchObject({
+      sessionExpired: true,
+    });
   });
 
   it('propagates a network-level fetch rejection without a sessionExpired flag', async () => {
@@ -107,7 +137,10 @@ describe('downloadDocumentInPage', () => {
 
   it('rejects a transient IS 5xx without a sessionExpired flag (no login redirect)', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response('<html>500 error</html>', { status: 500, headers: { 'content-type': 'text/html' } }),
+      new Response('<html>500 error</html>', {
+        status: 500,
+        headers: { 'content-type': 'text/html' },
+      })
     );
     let caught: unknown;
     try {
@@ -122,7 +155,9 @@ describe('downloadDocumentInPage', () => {
 
   it('rejects a non-IS URL without fetching', async () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch');
-    await expect(downloadDocumentInPage('https://evil.example.com/x', 'f.pdf')).rejects.toThrow('Refusing non-IS document URL');
+    await expect(downloadDocumentInPage('https://evil.example.com/x', 'f.pdf')).rejects.toThrow(
+      'Refusing non-IS document URL'
+    );
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/injector/documentDownloader.ts
+++ b/src/injector/documentDownloader.ts
@@ -8,7 +8,40 @@ import { isIsMendeluUrl } from './isMendeluUrl';
 import { saveBlob } from '../mobile/saveDocument';
 import { buildSaveDeps } from '../mobile/saveDeps';
 
-export async function downloadDocumentInPage(url: string, filename: string): Promise<void> {
+export interface DocumentDownloadResult {
+  /** True when the sealed document failed and the unsealed one was saved
+   *  instead. The UI MUST surface this — an unsealed copy can be refused by
+   *  the office the student takes it to, and a silent downgrade is the one way
+   *  this fallback can do harm. */
+  usedFallback: boolean;
+}
+
+/**
+ * Tries `url` first and falls back to `fallbackUrl` only when IS answers with a
+ * page instead of a file. Sealed documents are preferred — the seal is why
+ * offices accept them — but an unsealed document beats no document, which is
+ * the state IS's sealing outage would otherwise leave students in.
+ *
+ * The fallback deliberately does NOT fire on a lapsed session: there the right
+ * answer is to re-authenticate, and a second request would fail identically.
+ */
+export async function downloadDocumentInPage(
+  url: string,
+  filename: string,
+  fallbackUrl?: string
+): Promise<DocumentDownloadResult> {
+  try {
+    await fetchAndSave(url, filename);
+    return { usedFallback: false };
+  } catch (e) {
+    const notADocument = (e as { notADocument?: boolean } | null)?.notADocument;
+    if (!fallbackUrl || !notADocument) throw e;
+    await fetchAndSave(fallbackUrl, filename);
+    return { usedFallback: true };
+  }
+}
+
+async function fetchAndSave(url: string, filename: string): Promise<void> {
   if (!isIsMendeluUrl(url)) throw new Error('Refusing non-IS document URL');
   const res = await fetch(url, { credentials: 'include' });
   if (res.status === 401 || res.status === 403) {
@@ -25,9 +58,21 @@ export async function downloadDocumentInPage(url: string, filename: string): Pro
   }
   const contentType = res.headers.get('content-type') ?? '';
   if (!contentType.includes('application/pdf')) {
-    // A non-PDF 2xx means the session lapsed and IS served a login/HTML page.
+    // HTML here is ambiguous and the two cases must not be conflated:
+    //   - the LOGIN page → the session really has lapsed, redirect to login.
+    //   - an AUTHENTICATED page → IS served a real page instead of the file,
+    //     which is what its sealed print endpoints do while broken. Treating
+    //     that as an expired session logged the student out over an IS bug,
+    //     and left no opportunity to fall back.
+    // `logout.pl` only appears once authenticated — the same marker the mobile
+    // transport uses (see api/capacitorBinary).
+    const body = await res.text().catch(() => '');
     const err = new Error(`Not a PDF (${contentType || 'unknown'})`);
-    (err as Error & { sessionExpired?: boolean }).sessionExpired = true;
+    if (/logout\.pl/.test(body)) {
+      (err as Error & { notADocument?: boolean }).notADocument = true;
+    } else {
+      (err as Error & { sessionExpired?: boolean }).sessionExpired = true;
+    }
     throw err;
   }
   const blob = await res.blob();

--- a/src/injector/messageHandler.ts
+++ b/src/injector/messageHandler.ts
@@ -194,7 +194,10 @@ async function handleAction(id: string, action: string, payload: unknown) {
           if (!p.url || !p.filename) throw new Error('download_document: missing url or filename');
           // usedFallback tells the UI the student got the UNSEALED document,
           // which it must surface — see documentDownloader.
-          result = { success: true, ...(await downloadDocumentInPage(p.url, p.filename, p.fallbackUrl)) };
+          result = {
+            success: true,
+            ...(await downloadDocumentInPage(p.url, p.filename, p.fallbackUrl)),
+          };
         } catch (e) {
           if ((e as { sessionExpired?: boolean } | null)?.sessionExpired) {
             window.location.href = 'https://is.mendelu.cz/system/login.pl?lang=cz';

--- a/src/injector/messageHandler.ts
+++ b/src/injector/messageHandler.ts
@@ -192,8 +192,9 @@ async function handleAction(id: string, action: string, payload: unknown) {
         // the row just shows `error`.
         try {
           if (!p.url || !p.filename) throw new Error('download_document: missing url or filename');
-          await downloadDocumentInPage(p.url, p.filename);
-          result = { success: true };
+          // usedFallback tells the UI the student got the UNSEALED document,
+          // which it must surface — see documentDownloader.
+          result = { success: true, ...(await downloadDocumentInPage(p.url, p.filename, p.fallbackUrl)) };
         } catch (e) {
           if ((e as { sessionExpired?: boolean } | null)?.sessionExpired) {
             window.location.href = 'https://is.mendelu.cz/system/login.pl?lang=cz';

--- a/src/mobile/__tests__/actionHandler.test.ts
+++ b/src/mobile/__tests__/actionHandler.test.ts
@@ -7,7 +7,7 @@ import {
 
 function deps(over: Partial<MobileActionDeps> = {}): MobileActionDeps {
   return {
-    downloadDocument: vi.fn(async () => {}),
+    downloadDocument: vi.fn(async () => ({ usedFallback: false })),
     refreshExams: vi.fn(async () => {}),
     syncAllData: vi.fn(async () => {}),
     ...over,
@@ -15,17 +15,32 @@ function deps(over: Partial<MobileActionDeps> = {}): MobileActionDeps {
 }
 
 describe('runMobileAction', () => {
-  it('routes download_document to the native download with url and filename', async () => {
+  it('routes download_document to the native download with url, filename and fallback', async () => {
     const d = deps();
     await runMobileAction(
       'download_document',
-      { url: 'https://is.mendelu.cz/auth/student/tisk_dokumentu.pl?x=1', filename: 'P.pdf' },
+      {
+        url: 'https://is.mendelu.cz/auth/student/tisk_dokumentu.pl?x=1',
+        filename: 'P.pdf',
+        fallbackUrl: 'https://is.mendelu.cz/auth/student/tisk_dokumentu.pl?plain=1',
+      },
       d
     );
     expect(d.downloadDocument).toHaveBeenCalledWith(
       'https://is.mendelu.cz/auth/student/tisk_dokumentu.pl?x=1',
-      'P.pdf'
+      'P.pdf',
+      'https://is.mendelu.cz/auth/student/tisk_dokumentu.pl?plain=1'
     );
+  });
+
+  it('reports usedFallback back to the caller so the UI can flag an unsealed copy', async () => {
+    const d = deps({ downloadDocument: vi.fn(async () => ({ usedFallback: true })) });
+    const result = await runMobileAction(
+      'download_document',
+      { url: 'https://is.mendelu.cz/x', filename: 'P.pdf', fallbackUrl: 'https://is.mendelu.cz/y' },
+      d
+    );
+    expect(result).toEqual({ success: true, usedFallback: true });
   });
 
   it('rejects download_document with a missing url or filename before touching the network', async () => {

--- a/src/mobile/__tests__/actionHandler.test.ts
+++ b/src/mobile/__tests__/actionHandler.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  runMobileAction,
+  handleMobileActionMessage,
+  type MobileActionDeps,
+} from '../actionHandler';
+
+function deps(over: Partial<MobileActionDeps> = {}): MobileActionDeps {
+  return {
+    downloadDocument: vi.fn(async () => {}),
+    refreshExams: vi.fn(async () => {}),
+    syncAllData: vi.fn(async () => {}),
+    ...over,
+  };
+}
+
+describe('runMobileAction', () => {
+  it('routes download_document to the native download with url and filename', async () => {
+    const d = deps();
+    await runMobileAction(
+      'download_document',
+      { url: 'https://is.mendelu.cz/auth/student/tisk_dokumentu.pl?x=1', filename: 'P.pdf' },
+      d
+    );
+    expect(d.downloadDocument).toHaveBeenCalledWith(
+      'https://is.mendelu.cz/auth/student/tisk_dokumentu.pl?x=1',
+      'P.pdf'
+    );
+  });
+
+  it('rejects download_document with a missing url or filename before touching the network', async () => {
+    const d = deps();
+    await expect(runMobileAction('download_document', { filename: 'P.pdf' }, d)).rejects.toThrow(
+      /url/i
+    );
+    await expect(
+      runMobileAction('download_document', { url: 'https://is.mendelu.cz/x' }, d)
+    ).rejects.toThrow(/filename/i);
+    expect(d.downloadDocument).not.toHaveBeenCalled();
+  });
+
+  it('routes refresh_exams and trigger_sync to their in-process functions', async () => {
+    const d = deps();
+    expect(await runMobileAction('refresh_exams', {}, d)).toEqual({ success: true });
+    expect(await runMobileAction('trigger_sync', {}, d)).toEqual({ success: true });
+    expect(d.refreshExams).toHaveBeenCalledOnce();
+    expect(d.syncAllData).toHaveBeenCalledOnce();
+  });
+
+  it.each(['trigger_drive_backup', 'push_notes', 'open_url', 'logout', 'download_file'])(
+    'rejects the unsupported action %s immediately, naming it',
+    async (action) => {
+      // The whole point of the default: today every one of these hangs for 30s
+      // and then shows a generic error indistinguishable from a network fault.
+      await expect(runMobileAction(action, {}, deps())).rejects.toThrow(
+        new RegExp(`${action}.*not available`, 'i')
+      );
+    }
+  );
+
+  it('propagates a failure from the underlying download rather than swallowing it', async () => {
+    const d = deps({
+      downloadDocument: vi.fn(async () => {
+        throw new Error('IS did not return a file');
+      }),
+    });
+    await expect(
+      runMobileAction('download_document', { url: 'https://is.mendelu.cz/x', filename: 'a.pdf' }, d)
+    ).rejects.toThrow(/did not return a file/);
+  });
+});
+
+describe('handleMobileActionMessage', () => {
+  const own = {} as Window;
+
+  function msg(over: Record<string, unknown> = {}) {
+    return {
+      source: own,
+      data: {
+        type: 'REIS_ACTION',
+        id: 'req-1',
+        action: 'trigger_sync',
+        payload: {},
+        ...((over.data as object) ?? {}),
+      },
+      ...over,
+    } as unknown as MessageEvent;
+  }
+
+  it('replies with success and the action result', async () => {
+    const reply = vi.fn();
+    await handleMobileActionMessage(msg(), own, deps(), reply);
+    expect(reply).toHaveBeenCalledWith({
+      type: 'REIS_ACTION_RESULT',
+      id: 'req-1',
+      success: true,
+      data: { success: true },
+      error: undefined,
+    });
+  });
+
+  it('replies with success:false instead of throwing into the listener', async () => {
+    const reply = vi.fn();
+    const d = deps({
+      syncAllData: vi.fn(async () => {
+        throw new Error('boom');
+      }),
+    });
+    await handleMobileActionMessage(msg(), own, d, reply);
+    expect(reply).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'req-1', success: false, error: expect.stringMatching(/boom/) })
+    );
+  });
+
+  it('ignores a message from a different window source', async () => {
+    const reply = vi.fn();
+    const d = deps();
+    await handleMobileActionMessage(msg({ source: {} as Window }), own, d, reply);
+    expect(d.syncAllData).not.toHaveBeenCalled();
+    expect(reply).not.toHaveBeenCalled();
+  });
+
+  it('ignores messages that are not REIS_ACTION', async () => {
+    const reply = vi.fn();
+    const d = deps();
+    await handleMobileActionMessage(
+      msg({ data: { type: 'REIS_SYNC_UPDATE', data: {} } }),
+      own,
+      d,
+      reply
+    );
+    expect(reply).not.toHaveBeenCalled();
+  });
+
+  it('still replies for an unsupported action, so the caller fails fast rather than timing out', async () => {
+    const reply = vi.fn();
+    await handleMobileActionMessage(
+      msg({ data: { type: 'REIS_ACTION', id: 'req-9', action: 'logout', payload: {} } }),
+      own,
+      deps(),
+      reply
+    );
+    expect(reply).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'req-9', success: false, error: expect.stringMatching(/logout/) })
+    );
+  });
+});

--- a/src/mobile/__tests__/actionHandler.test.ts
+++ b/src/mobile/__tests__/actionHandler.test.ts
@@ -156,7 +156,11 @@ describe('handleMobileActionMessage', () => {
       reply
     );
     expect(reply).toHaveBeenCalledWith(
-      expect.objectContaining({ id: 'req-9', success: false, error: expect.stringMatching(/logout/) })
+      expect.objectContaining({
+        id: 'req-9',
+        success: false,
+        error: expect.stringMatching(/logout/),
+      })
     );
   });
 });

--- a/src/mobile/__tests__/openIsFile.filename.test.ts
+++ b/src/mobile/__tests__/openIsFile.filename.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { chooseFilename } from '../openIsFile';
+
+describe('chooseFilename', () => {
+  it('prefers the caller override — study documents carry a chosen name', () => {
+    // buildDocumentUrl targets tisk_dokumentu.pl, whose Content-Disposition is
+    // IS's own name. STUDY_DOCUMENTS defines what the student should see.
+    expect(chooseFilename('Potvrzeni_o_studiu.pdf', 'tisk_dokumentu.pdf')).toBe(
+      'Potvrzeni_o_studiu.pdf'
+    );
+  });
+
+  it('falls back to the Content-Disposition name — subject files have no chosen name', () => {
+    expect(chooseFilename(undefined, 'Prednaska_04.pdf')).toBe('Prednaska_04.pdf');
+  });
+
+  it('ignores an empty override rather than saving a nameless file', () => {
+    expect(chooseFilename('', 'Prednaska_04.pdf')).toBe('Prednaska_04.pdf');
+  });
+});

--- a/src/mobile/actionHandler.ts
+++ b/src/mobile/actionHandler.ts
@@ -19,7 +19,11 @@ import { sendToIframe } from '../injector/iframeManager';
  */
 export interface MobileActionDeps {
   /** Native fetch + platform-appropriate delivery. See mobile/openIsFile. */
-  downloadDocument(url: string, filename: string): Promise<void>;
+  downloadDocument(
+    url: string,
+    filename: string,
+    fallbackUrl?: string
+  ): Promise<{ usedFallback: boolean }>;
   refreshExams(): Promise<void>;
   syncAllData(): Promise<void>;
 }
@@ -48,8 +52,8 @@ export async function runMobileAction(
       // payload error, not as a mysterious IS response.
       if (!p.url) throw new Error('download_document: missing url');
       if (!p.filename) throw new Error('download_document: missing filename');
-      await deps.downloadDocument(p.url, p.filename);
-      return { success: true };
+      // usedFallback rides back so the UI can say the document is unsealed.
+      return { success: true, ...(await deps.downloadDocument(p.url, p.filename, p.fallbackUrl)) };
     }
     case 'refresh_exams':
       await deps.refreshExams();
@@ -100,9 +104,9 @@ export async function handleMobileActionMessage(
  */
 export function installMobileActionHandler(): void {
   const deps: MobileActionDeps = {
-    downloadDocument: async (url, filename) => {
+    downloadDocument: async (url, filename, fallbackUrl) => {
       const { openIsFileNatively } = await import('./openIsFile');
-      await openIsFileNatively(url, filename);
+      return openIsFileNatively(url, filename, fallbackUrl);
     },
     refreshExams: async () => {
       const { refreshExams } = await import('../injector/syncService');

--- a/src/mobile/actionHandler.ts
+++ b/src/mobile/actionHandler.ts
@@ -1,0 +1,120 @@
+import { Messages, isIframeMessage } from '../types/messages';
+import type { ActionResultMessage } from '../types/messages/base';
+import { sendToIframe } from '../injector/iframeManager';
+
+/**
+ * The app-side responder for `REIS_ACTION`.
+ *
+ * In the extension the CONTENT SCRIPT answers these (`injector/messageHandler`).
+ * Capacitor has no content script, so every action posted by the app went
+ * unanswered and sat until the 30 s `REQUEST_TIMEOUT` — which is why tapping a
+ * study document spun and then showed an error.
+ *
+ * This deliberately does NOT reuse `messageHandler`'s switch, despite the two
+ * looking parallel. Only the pure in-process cases are genuinely shared; the
+ * ones that matter here are DOM-bound in the content script (an `a[download]`
+ * save, `window.open`, a logout form POST) and have no meaning in the app. It
+ * also keeps `messageHandler`'s module-scope `chrome.runtime.getURL` out of the
+ * mobile bundle, where it would throw on import.
+ */
+export interface MobileActionDeps {
+  /** Native fetch + platform-appropriate delivery. See mobile/openIsFile. */
+  downloadDocument(url: string, filename: string): Promise<void>;
+  refreshExams(): Promise<void>;
+  syncAllData(): Promise<void>;
+}
+
+/**
+ * Only four of the eleven actions in `ActionType` are reachable from the app:
+ * `register_exam`/`unregister_exam` are called in-process by `useExamActions`,
+ * `open_url` has no callers, `toggle_outlook_sync`/`download_file` have no case
+ * on any platform, and the Drive actions are broken on mobile (#168).
+ *
+ * Everything unhandled throws IMMEDIATELY and names itself. That default is
+ * half the value of this module: an unsupported action used to be
+ * indistinguishable from a network fault, because both looked like a 30 s hang
+ * ending in a generic error.
+ */
+export async function runMobileAction(
+  action: string,
+  payload: unknown,
+  deps: MobileActionDeps
+): Promise<unknown> {
+  const p = (payload ?? {}) as Record<string, string | undefined>;
+
+  switch (action) {
+    case 'download_document': {
+      // Validate before the network call so a malformed payload fails as a
+      // payload error, not as a mysterious IS response.
+      if (!p.url) throw new Error('download_document: missing url');
+      if (!p.filename) throw new Error('download_document: missing filename');
+      await deps.downloadDocument(p.url, p.filename);
+      return { success: true };
+    }
+    case 'refresh_exams':
+      await deps.refreshExams();
+      return { success: true };
+    case 'trigger_sync':
+      await deps.syncAllData();
+      return { success: true };
+    default:
+      throw new Error(`Action "${action}" is not available in the reIS mobile app`);
+  }
+}
+
+/**
+ * Handles one `message` event. Split from the listener so it can be tested
+ * without a DOM: `ownWindow` is the identity check that on a top-level window
+ * (`window.parent === window`) admits only our own posts.
+ *
+ * Never throws — a rejected action must come back as `success: false` so the
+ * caller's promise settles. Throwing here would leave it hanging, which is the
+ * exact failure this module exists to remove.
+ */
+export async function handleMobileActionMessage(
+  event: MessageEvent,
+  ownWindow: Window,
+  deps: MobileActionDeps,
+  reply: (message: ActionResultMessage) => void
+): Promise<void> {
+  if (event.source !== ownWindow) return;
+  const data = event.data;
+  if (!isIframeMessage(data)) return;
+  if (data.type !== 'REIS_ACTION') return;
+
+  try {
+    const result = await runMobileAction(data.action, data.payload, deps);
+    reply(Messages.actionResult(data.id, true, result));
+  } catch (e) {
+    reply(Messages.actionResult(data.id, false, undefined, String(e)));
+  }
+}
+
+/**
+ * Wires the handler to the real window. Called from `main.capacitor.ts` before
+ * the React root is imported, so an action fired during first paint is not lost.
+ *
+ * The imports are dynamic to match how `main.capacitor.ts` already loads
+ * `syncService`: statically importing it here would pull the whole sync graph
+ * into the boot chunk before a session exists.
+ */
+export function installMobileActionHandler(): void {
+  const deps: MobileActionDeps = {
+    downloadDocument: async (url, filename) => {
+      const { openIsFileNatively } = await import('./openIsFile');
+      await openIsFileNatively(url, filename);
+    },
+    refreshExams: async () => {
+      const { refreshExams } = await import('../injector/syncService');
+      await refreshExams();
+    },
+    syncAllData: async () => {
+      const { syncAllData } = await import('../injector/syncService');
+      await syncAllData();
+    },
+  };
+
+  window.addEventListener('message', (event: MessageEvent) => {
+    void handleMobileActionMessage(event, window, deps, sendToIframe);
+  });
+}

--- a/src/mobile/openIsFile.ts
+++ b/src/mobile/openIsFile.ts
@@ -17,6 +17,14 @@ interface DownloadsPlugin {
  *  Capacitor's Filesystem cannot do this — its Directory enum has no Downloads. */
 const Downloads = registerPlugin<DownloadsPlugin>('Downloads');
 
+/**
+ * Precedence for the saved filename. A caller-chosen name wins; an empty one is
+ * treated as absent so a blank override can never produce a nameless file.
+ */
+export function chooseFilename(override: string | undefined, fromResponse: string): string {
+  return override || fromResponse;
+}
+
 /** True when the app must NOT fall back to window.open for IS URLs. */
 export function isNativeHost(): boolean {
   return getPlatform().kind === 'capacitor';
@@ -36,8 +44,13 @@ export function isNativeHost(): boolean {
  *    BROWSER, which has no IS session.
  * 3. **On Android it lands in Downloads with a notification**, like any
  *    browser — not a share sheet. See deliverFile for the iOS asymmetry.
+ *
+ * `filenameOverride` exists for the study documents: `tisk_dokumentu.pl`
+ * returns IS's own Content-Disposition name, but STUDY_DOCUMENTS defines what
+ * the student should actually see (`Potvrzeni_o_studiu.pdf`). Subject files
+ * pass nothing and keep the server's name.
  */
-export async function openIsFileNatively(url: string): Promise<void> {
+export async function openIsFileNatively(url: string, filenameOverride?: string): Promise<void> {
   const downloadUrl = toDirectDownloadUrl(url) ?? url;
   const token = await loadStoredToken();
   const { Capacitor, CapacitorHttp, CapacitorCookies } = await import('@capacitor/core');
@@ -55,7 +68,7 @@ export async function openIsFileNatively(url: string): Promise<void> {
   }
 
   const base64 = await blobToBase64(result.blob);
-  await deliverFile(result.filename, base64, result.blob.type || 'application/pdf', {
+  await deliverFile(chooseFilename(filenameOverride, result.filename), base64, result.blob.type || 'application/pdf', {
     platform: Capacitor.getPlatform() as 'ios' | 'android' | 'web',
     saveToDownloads: (o) => Downloads.save(o),
     shareFile: async (o) => {

--- a/src/mobile/openIsFile.ts
+++ b/src/mobile/openIsFile.ts
@@ -65,7 +65,8 @@ export async function openIsFileNatively(
       CapacitorHttp.get(o),
   };
 
-  const fetchOne = (target: string) => fetchIsBinary(toDirectDownloadUrl(target) ?? target, token, deps);
+  const fetchOne = (target: string) =>
+    fetchIsBinary(toDirectDownloadUrl(target) ?? target, token, deps);
 
   let result = await fetchOne(url);
   let usedFallback = false;
@@ -86,27 +87,32 @@ export async function openIsFileNatively(
   }
 
   const base64 = await blobToBase64(result.blob);
-  await deliverFile(chooseFilename(filenameOverride, result.filename), base64, result.blob.type || 'application/pdf', {
-    platform: Capacitor.getPlatform() as 'ios' | 'android' | 'web',
-    saveToDownloads: (o) => Downloads.save(o),
-    shareFile: async (o) => {
-      // iOS has no Downloads folder: write to Documents, then offer the file to
-      // the Files/share sheet, which is that platform's native save flow.
-      const { Filesystem, Directory } = await import('@capacitor/filesystem');
-      await Filesystem.writeFile({
-        path: o.filename,
-        data: o.base64,
-        directory: Directory.Documents,
-        recursive: true,
-      });
-      const { uri } = await Filesystem.getUri({
-        directory: Directory.Documents,
-        path: o.filename,
-      });
-      const { Share } = await import('@capacitor/share');
-      await Share.share({ title: o.filename, url: uri });
-    },
-  });
+  await deliverFile(
+    chooseFilename(filenameOverride, result.filename),
+    base64,
+    result.blob.type || 'application/pdf',
+    {
+      platform: Capacitor.getPlatform() as 'ios' | 'android' | 'web',
+      saveToDownloads: (o) => Downloads.save(o),
+      shareFile: async (o) => {
+        // iOS has no Downloads folder: write to Documents, then offer the file to
+        // the Files/share sheet, which is that platform's native save flow.
+        const { Filesystem, Directory } = await import('@capacitor/filesystem');
+        await Filesystem.writeFile({
+          path: o.filename,
+          data: o.base64,
+          directory: Directory.Documents,
+          recursive: true,
+        });
+        const { uri } = await Filesystem.getUri({
+          directory: Directory.Documents,
+          path: o.filename,
+        });
+        const { Share } = await import('@capacitor/share');
+        await Share.share({ title: o.filename, url: uri });
+      },
+    }
+  );
 
   return { usedFallback };
 }

--- a/src/mobile/openIsFile.ts
+++ b/src/mobile/openIsFile.ts
@@ -50,21 +50,39 @@ export function isNativeHost(): boolean {
  * the student should actually see (`Potvrzeni_o_studiu.pdf`). Subject files
  * pass nothing and keep the server's name.
  */
-export async function openIsFileNatively(url: string, filenameOverride?: string): Promise<void> {
-  const downloadUrl = toDirectDownloadUrl(url) ?? url;
+export async function openIsFileNatively(
+  url: string,
+  filenameOverride?: string,
+  fallbackUrl?: string
+): Promise<{ usedFallback: boolean }> {
   const token = await loadStoredToken();
   const { Capacitor, CapacitorHttp, CapacitorCookies } = await import('@capacitor/core');
+  const platform = Capacitor.getPlatform() as 'ios' | 'android' | 'web';
+  const deps = {
+    platform,
+    setCookie: (o: { url: string; key: string; value: string }) => CapacitorCookies.setCookie(o),
+    httpGet: (o: { url: string; headers?: Record<string, string>; responseType?: 'blob' }) =>
+      CapacitorHttp.get(o),
+  };
 
-  const result = await fetchIsBinary(downloadUrl, token, {
-    platform: Capacitor.getPlatform() as 'ios' | 'android' | 'web',
-    setCookie: (o) => CapacitorCookies.setCookie(o),
-    httpGet: (o) => CapacitorHttp.get(o),
-  });
+  const fetchOne = (target: string) => fetchIsBinary(toDirectDownloadUrl(target) ?? target, token, deps);
 
-  // Still HTML after the rewrite means IS did not serve a file for this link.
-  // Failing loudly beats silently saving a web page as a .pdf.
+  let result = await fetchOne(url);
+  let usedFallback = false;
+
+  // `kind: 'page'` means IS served an authenticated PAGE rather than a file —
+  // exactly what its sealed print endpoints do while broken. Retry the unsealed
+  // variant rather than failing. A lapsed session never reaches here:
+  // fetchIsBinary throws sessionExpired for that, and re-auth is the right
+  // answer there, not a second doomed request.
+  if (result.kind !== 'binary' && fallbackUrl) {
+    result = await fetchOne(fallbackUrl);
+    usedFallback = true;
+  }
+
+  // Still not a file: failing loudly beats silently saving a web page as a .pdf.
   if (result.kind !== 'binary') {
-    throw new Error(`IS did not return a file for ${downloadUrl}`);
+    throw new Error(`IS did not return a file for ${url}`);
   }
 
   const base64 = await blobToBase64(result.blob);
@@ -89,4 +107,6 @@ export async function openIsFileNatively(url: string, filenameOverride?: string)
       await Share.share({ title: o.filename, url: uri });
     },
   });
+
+  return { usedFallback };
 }


### PR DESCRIPTION
Fixes #170.

Tapping a study document in the Capacitor app spun for 30 s and showed an error. Two separate breakages sat behind that one button, and a third turned up during device verification.

## 1. Nothing answered `REIS_ACTION` in the app

`executeAction` posts `REIS_ACTION`; the only responder was the content script, which doesn't exist on Capacitor. New `src/mobile/actionHandler.ts` is the app-side responder, installed from `main.capacitor.ts` **before** the React root so an action fired during first paint isn't lost.

Two things made this more than "add a listener":

- **The reply path was blocked too.** `initProxyListener` only trusted `https://is.mendelu.cz`, so a loopback result from the app's own origin (`https://localhost` on Android, `capacitor://localhost` on iOS) was silently dropped — a responder alone would still have timed out. `src/api/proxy/trustedOrigin.ts` adds a Capacitor-only allowance for the app's *actual* origin; the `e.source` check is unchanged, so on a top-level window only same-window posts pass.
- **There are two senders.** `SyncService` fires `trigger_sync` / `refresh_exams` as raw `postMessage` with no promise. Both senders work untouched, which is why this also fixes **the exam list not refreshing** after a sign-up or term switch.

Only 4 of the 11 actions #170 lists are actually reachable — `register_exam`/`unregister_exam` are called in-process by `useExamActions` (which is why registration already worked on device), and `open_url` has zero callers. Everything unsupported now **fails in milliseconds naming itself** instead of hanging 30 s and looking like a network fault.

`messageHandler`'s switch is deliberately not reused: only 4 of its cases are pure in-process calls, the rest are DOM-bound, and not importing it keeps its module-scope `chrome.runtime.getURL` out of the mobile bundle.

## 2. IS can't seal one of the documents — so we fall back

Device verification surfaced a bug that was never mobile-only. IS's sealed (`_el`) print endpoints return an authenticated *page* instead of a PDF, with "Request body constraint violation" — **reproduced in a plain desktop browser, outside reIS**, so it's a MENDELU-side fault. Measured repeatedly, it's **per-document**:

| Sealed endpoint | 3 attempts |
|---|---|
| `potvrzeni_tisk_el` | fails 3/3 |
| `prehled_tisk_el` | works 3/3 (sealed, ~233 KB) |

Sealed stays primary everywhere it exists. Only when IS returns a page — never on 401/403, where re-auth is the right answer — is the unsealed variant fetched. **The student is told**: `usedFallback` rides back through the action result and the UI warns, because an unsealed copy can be refused by the office they take it to.

This needed one narrow change to shared code: a non-PDF 200 was tagged `sessionExpired`, which **force-navigated the student to the IS login page** over an IS-side bug, and left no chance to retry. The login page and an authenticated page are now told apart by the `logout.pl` marker — the same signal the mobile transport already used. A genuine 401/403 still redirects exactly as before.

## 3. Logout no longer wipes your data before failing

Sign-out is deferred until the transport can POST `/auth/system/logout.pl` (#171). But `logout()` cleared the user-params cache and **all of IndexedDB** before dispatching the action that does the actual signing out — so on mobile it emptied the app and left the session live. It now bails before clearing anything, and the profile sheet catches the rejection to show a toast rather than firing a telemetry report on every tap. Extension behaviour is untouched.

## Verification

Device-verified on Android against a live IS session:

```
Potvrzeni_o_studiu.pdf   59283 B  %PDF-1.5  ← fell back, warning toast at 13s
Prehled_studia.pdf      234031 B  %PDF-1.5  ← sealed, no fallback needed
Registracni_arch.pdf     64851 B  %PDF-1.5  ← never had a sealed variant
```

Driven over CDP rather than by tapping — the plan records that tap coordinates are unreliable and tapping inside a live authenticated IS WebView is unsafe. The loopback answers in **8 ms** where it used to hang, and the reply arrives from `https://localhost`, the origin that was previously dropped.

1762 tests pass (36 new), typecheck and lint clean, Capacitor bundle and debug APK build.

## Not in scope

- **Session-expiry re-auth on mobile** — a lapsed token shows a row error rather than re-presenting the login WebView. App-wide gap, not a documents one.
- The "Žádost" row's `target="_blank"` escape to a session-less browser (Task 8).
- Drive backup (#168), secure token storage (#172), iOS build (#174).

Worth reporting `potvrzeni_tisk_el` to the IS team separately — reIS degrades gracefully now, but the underlying bug hits anyone using IS directly, with no fallback.

Design doc: `docs/superpowers/specs/2026-08-03-mobile-action-dispatcher-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)