### PR TITLE
docs(mobile): bring the Capacitor resume point up to date

### DIFF
--- a/docs/superpowers/plans/2026-08-02-capacitor-remaining-work.md
+++ b/docs/superpowers/plans/2026-08-02-capacitor-remaining-work.md
@@ -19,7 +19,7 @@ measurements) and `2026-08-02-capacitor-transport-decision.md` (why Model C).
 |---|---|
 | Shell: boot, login, session restore, back button | **Done**, device-verified on Android |
 | Transport (`CapacitorHttp`, per-platform cookie) | **Done** — GET **and POST**, plus raw bytes |
-| Sync (14 endpoints, ~236 requests) | **Done** via postMessage loopback |
+| Sync (14 endpoints, ~236 requests) | **Done** via postMessage loopback — **except the zaznamnik batch**, see below |
 | File download → Downloads + notification | **Done**, device-verified |
 | Duplicate file listings | **Fixed** (also fixes the extension) |
 | Study documents (Task 1/2) | **Done**, device-verified — PR #179 |
@@ -30,6 +30,12 @@ measurements) and `2026-08-02-capacitor-transport-decision.md` (why Model C).
 **The one owed check:** PR #181 merged on green unit tests with the Android device
 verification still undone. Nothing has ever exercised POST on real hardware. Do that
 before treating eduroam on mobile as working — details in Task 3.
+
+**"Sync is done" has one hole.** `syncZaznamnik` runs *inside* the same sync
+(`injector/syncService.ts:381`) but reaches IS through a bare `fetch`
+(`api/zaznamnik.ts:186`), so it is CORS-blocked on Capacitor. In student terms:
+continuous assessment — průběžné hodnocení and practice-test scores — silently never
+arrives on the phone, while everything around it does. It is row 6 of Task 4.
 
 ---
 
@@ -163,7 +169,7 @@ constant or a variable at most of these sites.
 | `src/api/odevzdavarny.ts` | 56 | submissions | open |
 | `src/api/kontrola.ts` | 17 | study check | open |
 | `src/utils/serverTime.ts` | 29 | tablet-only path | open |
-| `src/api/zaznamnik.ts` | 186 (two in one `Promise.all`) | **sync** (`services/sync/syncZaznamnik.ts`) | open |
+| `src/api/zaznamnik.ts` | 186 (two in one `Promise.all`) | **sync** — `syncZaznamnik` runs inside the main sync run (`injector/syncService.ts:381`), so continuous assessment silently never arrives on the phone | open |
 | `src/api/search/searchService.ts` | 22, 38, 57, 80, 102 | search + `PersonHoverCard` | open |
 | `src/hooks/ui/useFileActions.ts` | 45, 85, 104, 142, 144 | **`components/mobile/sheets/SubjectDrawerSheet.tsx`** | open |
 | `src/hooks/ui/useFileDownload.ts` + `useFileDownload/urlResolver.ts` | 19, 45 / 16 | nothing — dead code, see Task 8 | delete, don't migrate |
@@ -186,11 +192,19 @@ These all work on the extension only because a Chrome extension's `fetch` bypass
 hosts in `host_permissions` — a privilege the Capacitor app does not have. That is the whole
 reason this task exists, and why "it works in the extension" proves nothing here.
 
-Genuinely fine, verified: `iskam/*` (out of scope), `injector/*` (content-script-only —
-`menuScraper` is imported solely by `injector/sniper.ts`, which never runs on Capacitor),
-`client.ts:76,124` (the transport itself), `PdfViewer.tsx:15` (`chrome.runtime.getURL`, a
-local asset), `loadRealDataSnapshot`/`logger` (dev-only), and the CDN / Google / Supabase /
-MS-Bookings / Photon / HuggingFace / Discord-webhook calls.
+**Not Task 4 targets** (verified — "not a target" is not the same as "works"):
+
+- `iskam/*` — **still broken on mobile**, just not fixable here: ISKAM is Shibboleth, a
+  second sign-in flow rather than a transport problem, and is out of scope for a first
+  release (see the status table and "Out of scope" below). Do not read this row as green.
+- `injector/*` — content-script-only, so it never executes on Capacitor. `menuScraper` is
+  imported solely by `injector/sniper.ts`.
+- `client.ts:76,124` — the transport itself.
+- `PdfViewer.tsx:15` — `chrome.runtime.getURL`, a local asset. (It *does* break on the
+  tablet path, for a different reason — see Task 8.)
+- `loadRealDataSnapshot`, `logger` — dev-only.
+- CDN / Google / Supabase / MS-Bookings / Photon / HuggingFace / Discord-webhook — not IS,
+  and CORS-clean.
 
 **Adjacent, found while doing eduroam:** `src/api/outlookSync.ts:73` passes its own
 `Content-Type` into `fetchWithAuth`, which already sets a lowercase one — both keys

--- a/docs/superpowers/plans/2026-08-02-capacitor-remaining-work.md
+++ b/docs/superpowers/plans/2026-08-02-capacitor-remaining-work.md
@@ -144,33 +144,53 @@ shapes the **native layer never produces**. Assume this trap on any future trans
 These call `fetch(...)` directly instead of `fetchWithAuth`, so they are CORS-blocked on
 Capacitor:
 
-| File | Line | State |
-|---|---|---|
-| `src/api/eduroam.ts` | ~~31, 37, 55~~ | ✅ done in PR #181 — all four gone |
-| `src/api/cvicneTests.ts` | 23 | open |
-| `src/api/odevzdavarny.ts` | 56 | open |
-| `src/api/kontrola.ts` | 17 | open |
-| `src/utils/serverTime.ts` | 29 (tablet-only path) | open |
-| `src/api/zaznamnik.ts` | 186 (two, in one `Promise.all`) | open — **missing from the original list** |
-| `src/api/search/searchService.ts` | 57, 80, 102 | open — **missing from the original list** |
+**The list below was wrong twice before it was right.** It originally held 5 files and a
+line dismissing everything else as CDN/Google/Supabase; two review rounds on PR #182 found
+more each time. Do not trust it as folklore — **re-derive it** and diff against this table:
+
+```bash
+grep -rn "\bfetch(" src/ --include='*.ts' --include='*.tsx' \
+  | grep -v "__tests__\|\.test\.\|fetchWithAuth(\|fetchViaProxy(\|fetchJsonViaProxy(\|fetchAuthedBytes(\|fetchIsBinary(\|fetchViaCapacitor("
+```
+
+Grepping for `mendelu` on the same line as `fetch(` is what missed them — the URL is a
+constant or a variable at most of these sites.
+
+| File | Line | Reaches mobile via | State |
+|---|---|---|---|
+| `src/api/eduroam.ts` | ~~31, 37, 55~~ | eduroam sheet | ✅ done, PR #181 |
+| `src/api/cvicneTests.ts` | 23 | subject detail | open |
+| `src/api/odevzdavarny.ts` | 56 | submissions | open |
+| `src/api/kontrola.ts` | 17 | study check | open |
+| `src/utils/serverTime.ts` | 29 | tablet-only path | open |
+| `src/api/zaznamnik.ts` | 186 (two in one `Promise.all`) | **sync** (`services/sync/syncZaznamnik.ts`) | open |
+| `src/api/search/searchService.ts` | 22, 38, 57, 80, 102 | search + `PersonHoverCard` | open |
+| `src/hooks/ui/useFileActions.ts` | 45, 85, 104, 142, 144 | **`components/mobile/sheets/SubjectDrawerSheet.tsx`** | open |
+| `src/hooks/ui/useFileDownload.ts` + `useFileDownload/urlResolver.ts` | 19, 45 / 16 | nothing — dead code, see Task 8 | delete, don't migrate |
+| `src/utils/user_id_fetcher.ts` | 7 | nothing — **orphaned**, zero importers | delete, don't migrate |
+
+`useFileActions` is the sharpest of these: it is imported by a **mobile sheet**, and
+`normalizeFileUrl` (`src/utils/fileUrl.ts:14`) resolves every one of its links to
+`https://is.mendelu.cz`. Subject-file open and download on mobile go through it.
+
+Two rows are traps rather than work: `useFileDownload` has no consumer but the
+`hooks/ui/index.ts` barrel, and `user_id_fetcher.ts` has **no importer at all** — the live
+path is `api/user.ts`, which already uses `fetchWithAuth` against the same URL. Migrating
+either one is wasted effort; deleting them is the actual fix.
 
 ⚠️ Not a blind sed: `fetchWithAuth` also imposes `DEFAULT_HEADERS` and a 401/403 login
 redirect, which changes **extension** behaviour. Check each call site. The remaining ones
-are independent of each other, so they need not land together.
+are independent, so they need not land together.
 
-The last two rows were **absent from this table until 2026-08-04** — the line below used to
-claim every other bare fetch was a CDN/Google/Supabase call, which was wrong, and anyone
-working the list would have skipped them. They matter: `zaznamnik.ts` is called from the
-**sync** path (`src/services/sync/syncZaznamnik.ts`), and `searchService.ts` backs search
-and the person hover card. Both are reachable on mobile and both are CORS-blocked there.
+These all work on the extension only because a Chrome extension's `fetch` bypasses CORS for
+hosts in `host_permissions` — a privilege the Capacitor app does not have. That is the whole
+reason this task exists, and why "it works in the extension" proves nothing here.
 
-These work on the extension only because a Chrome extension's `fetch` bypasses CORS for
-hosts in `host_permissions` — a privilege the Capacitor app does not have. That is the
-whole reason this task exists, and it is why "it works in the extension" proves nothing here.
-
-Genuinely fine, for the record: `iskam/skmDocuments.ts:5` (ISKAM, out of scope),
-`injector/menuScraper.ts:132` (content-script-only — imported solely by `injector/sniper.ts`,
-which never runs on Capacitor), and the `CDN_BASE_URL` / Google / Supabase calls.
+Genuinely fine, verified: `iskam/*` (out of scope), `injector/*` (content-script-only —
+`menuScraper` is imported solely by `injector/sniper.ts`, which never runs on Capacitor),
+`client.ts:76,124` (the transport itself), `PdfViewer.tsx:15` (`chrome.runtime.getURL`, a
+local asset), `loadRealDataSnapshot`/`logger` (dev-only), and the CDN / Google / Supabase /
+MS-Bookings / Photon / HuggingFace / Discord-webhook calls.
 
 **Adjacent, found while doing eduroam:** `src/api/outlookSync.ts:73` passes its own
 `Content-Type` into `fetchWithAuth`, which already sets a lowercase one — both keys
@@ -234,7 +254,11 @@ should be re-checked, in particular:
   (`ShortcutGrid.tsx:53-66`). Present these in the in-app browser instead.
 - **Dead code that is a live trap:** `src/hooks/ui/useFileDownload.ts` has no consumers
   but contains every breakage class at once (bare `fetch`, `window.open`, `a[download]`,
-  `saveAs`). Delete it before someone ports by example.
+  `saveAs`). Delete it before someone ports by example. Take
+  `useFileDownload/urlResolver.ts` with it, and `src/utils/user_id_fetcher.ts` too —
+  the latter is orphaned outright (zero importers; the live path is `api/user.ts`, which
+  already uses `fetchWithAuth` against the same URL). All three surface in the Task 4
+  grep, so deleting them shortens that list rather than adding to it.
 - **Tablet path is unhandled.** `resolvePhoneViewport` needs touch **and** narrow, so a
   tablet renders the *desktop* tree — which reaches `PdfViewer.tsx:15`
   (`chrome.runtime.getURL` → `ReferenceError`, swallowed at `:61` → permanent spinner) and

--- a/docs/superpowers/plans/2026-08-02-capacitor-remaining-work.md
+++ b/docs/superpowers/plans/2026-08-02-capacitor-remaining-work.md
@@ -151,12 +151,26 @@ Capacitor:
 | `src/api/odevzdavarny.ts` | 56 | open |
 | `src/api/kontrola.ts` | 17 | open |
 | `src/utils/serverTime.ts` | 29 (tablet-only path) | open |
+| `src/api/zaznamnik.ts` | 186 (two, in one `Promise.all`) | open — **missing from the original list** |
+| `src/api/search/searchService.ts` | 57, 80, 102 | open — **missing from the original list** |
 
 ⚠️ Not a blind sed: `fetchWithAuth` also imposes `DEFAULT_HEADERS` and a 401/403 login
-redirect, which changes **extension** behaviour. Check each call site. The four remaining
+redirect, which changes **extension** behaviour. Check each call site. The remaining ones
 are independent of each other, so they need not land together.
 
-Other bare fetches in `src/api/` target the CDN, Google or Supabase and are fine.
+The last two rows were **absent from this table until 2026-08-04** — the line below used to
+claim every other bare fetch was a CDN/Google/Supabase call, which was wrong, and anyone
+working the list would have skipped them. They matter: `zaznamnik.ts` is called from the
+**sync** path (`src/services/sync/syncZaznamnik.ts`), and `searchService.ts` backs search
+and the person hover card. Both are reachable on mobile and both are CORS-blocked there.
+
+These work on the extension only because a Chrome extension's `fetch` bypasses CORS for
+hosts in `host_permissions` — a privilege the Capacitor app does not have. That is the
+whole reason this task exists, and it is why "it works in the extension" proves nothing here.
+
+Genuinely fine, for the record: `iskam/skmDocuments.ts:5` (ISKAM, out of scope),
+`injector/menuScraper.ts:132` (content-script-only — imported solely by `injector/sniper.ts`,
+which never runs on Capacitor), and the `CDN_BASE_URL` / Google / Supabase calls.
 
 **Adjacent, found while doing eduroam:** `src/api/outlookSync.ts:73` passes its own
 `Content-Type` into `fetchWithAuth`, which already sets a lowercase one — both keys

--- a/docs/superpowers/plans/2026-08-02-capacitor-remaining-work.md
+++ b/docs/superpowers/plans/2026-08-02-capacitor-remaining-work.md
@@ -13,19 +13,46 @@ measurements) and `2026-08-02-capacitor-transport-decision.md` (why Model C).
 
 ## Where it stands
 
+*Updated 2026-08-04, after PR #179 (`1ad5d030`) and PR #181 (`c9e6160f`).*
+
 | Area | State |
 |---|---|
 | Shell: boot, login, session restore, back button | **Done**, device-verified on Android |
-| Transport (`CapacitorHttp`, per-platform cookie) | **Done** — GET only |
+| Transport (`CapacitorHttp`, per-platform cookie) | **Done** — GET **and POST**, plus raw bytes |
 | Sync (14 endpoints, ~236 requests) | **Done** via postMessage loopback |
 | File download → Downloads + notification | **Done**, device-verified |
 | Duplicate file listings | **Fixed** (also fixes the extension) |
+| Study documents (Task 1/2) | **Done**, device-verified — PR #179 |
+| eduroam cert fetch (Task 3 + eduroam half of Task 4) | **Merged unverified** — PR #181, see Task 3 |
 | iOS app | **Never built** — only the throwaway spike ran there |
-| Study documents, eduroam, ISKAM, Drive | **Broken** — see below |
+| ISKAM, Drive, native Wi-Fi | **Broken** — see below |
+
+**The one owed check:** PR #181 merged on green unit tests with the Android device
+verification still undone. Nothing has ever exercised POST on real hardware. Do that
+before treating eduroam on mobile as working — details in Task 3.
 
 ---
 
-## Task 1 — The `REIS_ACTION` loopback (highest value, unblocks the most)
+## Task 1 — The `REIS_ACTION` loopback ✅ DONE (PR #179, `1ad5d030`)
+
+Shipped as `src/mobile/actionHandler.ts`, an app-side responder that receives
+`REIS_ACTION` from its own window. Study documents download in one tap and the exam list
+refreshes after a write — both device-verified on Android against a live session
+(`Registracni_arch.pdf`, 64851 B, `%PDF-1.5`).
+
+Two traps found while tracing, both handled: the **reply** path was origin-blocked too
+(`initProxyListener` trusted only `is.mendelu.cz` — hence `src/api/proxy/trustedOrigin.ts`),
+and `SyncService` is a second, promise-less sender. Only **4** of the eleven actions below
+are actually reachable: `register_exam`/`unregister_exam` are called in-process by
+`useExamActions`, and `open_url` has zero callers.
+
+`logout` is still deliberately absent — the transport can POST now, but a real server-side
+sign-out was scoped out. `proxyClient.logout()` throws early on Capacitor *before* clearing
+IndexedDB, so a student is never left with an emptied app **and** a live IS session.
+
+Design: `docs/superpowers/specs/2026-08-03-mobile-action-dispatcher-design.md`.
+
+<details><summary>Original analysis, kept for the file:line map</summary>
 
 `executeAction` (`src/api/proxyClient.ts:25-33`) posts `REIS_ACTION` and waits for
 `REIS_ACTION_RESULT`. The only responder is `src/injector/messageHandler.ts:45` — the
@@ -50,7 +77,13 @@ into the Capacitor bundle will throw. Extract the switch, or guard that line.
   `src/api/proxy/pendingRequests.ts:4`) then shows a red error icon.
 - **Exam refresh** — see Task 2.
 
-## Task 2 — Exam refresh after a write
+</details>
+
+## Task 2 — Exam refresh after a write ✅ DONE (PR #179, `1ad5d030`)
+
+Fixed by the same handler — `refresh_exams` is one of the actions it answers.
+
+<details><summary>Original analysis</summary>
 
 **Correction to an earlier belief: exam registration itself WORKS on mobile.** The write
 goes through `fetchWithAuth`. What is dead is the follow-up.
@@ -67,35 +100,69 @@ state is wrong.
 `refreshExams()` already exists in-process (`src/injector/syncService.ts:459`), so once
 Task 1 lands this may be as small as calling it directly.
 
-## Task 3 — Transport gaps: POST and raw bytes
+</details>
 
-The Capacitor branch (`src/api/client.ts:38-46`) calls **only** `CapacitorHttp.get` and
-drops `options.method` / `options.body`. Two shapes are missing:
+## Task 3 — Transport gaps: POST and raw bytes ✅ DONE (PR #181, `c9e6160f`)
 
-- **POST** — needed for eduroam cert generation (`src/api/eduroam.ts:55`) and any future
-  write that is not a GET. Nothing exercises it today, which is why it has not surfaced.
-- **Raw bytes** — `fetchIsBinary` (`src/api/capacitorBinary.ts:57`) returns a `Blob`;
-  eduroam needs `Uint8Array`. Note `capacitorTransport.ts:86`'s `logout.pl` auth check
-  must **not** be applied to binary bodies — routing eduroam through `fetchWithAuth`
-  unchanged would fail *harder*, not softer.
+`fetchViaCapacitor` now takes an options bag (`method`/`body`/`headers`) and dispatches
+POST to `httpPost`. Raw bytes are a **sibling** function, `fetchAuthedBytes(url)`, not an
+option on `fetchWithAuth` — `fetchWithAuth` imposes `DEFAULT_HEADERS` (`accept: text/html…`),
+which are wrong when asking for a `.p12`. The `logout.pl` check stays HTML-only, so it
+never runs against binary.
 
-## Task 4 — Bare `fetch` call sites that bypass the transport
+Design: `docs/superpowers/specs/2026-08-03-capacitor-transport-post-bytes-design.md`.
+
+### ⚠️ Still owed: the Android device check
+
+Merged on unit tests alone. Verify on a handset:
+
+- opening the eduroam sheet fires **no** telemetry report
+- the extraction password renders
+- the POST reaches IS and returns an authenticated page
+- both cert downloads start `0x30 0x82` (DER SEQUENCE) — **assert the magic bytes, not a
+  non-zero length**; an HTML error page is also non-empty, and that is the exact failure
+  this is meant to catch
+
+Send `data: 'lang=cz'` **without `gen=`** while testing, so no certificate is actually
+generated — generating one rotates a 366-day credential the student may already have
+installed on other devices.
+
+### What the unit tests could not see
+
+Four real bugs shipped green and were caught only in review, all because the tests stubbed
+shapes the **native layer never produces**. Assume this trap on any future transport work:
+
+- a `URLSearchParams` body → the bridge JSON-stringifies it → `"{}"`, an empty POST
+- a JSON body → both native layers parse JSON *before* it crosses the bridge, so `res.data`
+  is an **object**; `String(obj)` gave `"[object Object]"`
+- the `logout.pl` gate applied to JSON rejected healthy schedule responses
+- a `Text/Html` content-type slipped exact-cased guards, returning a login page as
+  certificate bytes (`Headers` lowercases header *names*, not *values*)
+
+## Task 4 — Bare `fetch` call sites that bypass the transport (eduroam done)
 
 These call `fetch(...)` directly instead of `fetchWithAuth`, so they are CORS-blocked on
 Capacitor:
 
-| File | Line |
-|---|---|
-| `src/api/cvicneTests.ts` | 23 |
-| `src/api/odevzdavarny.ts` | 56 |
-| `src/api/kontrola.ts` | 17 |
-| `src/api/eduroam.ts` | 31, 37, 55 |
-| `src/utils/serverTime.ts` | 29 (tablet-only path) |
+| File | Line | State |
+|---|---|---|
+| `src/api/eduroam.ts` | ~~31, 37, 55~~ | ✅ done in PR #181 — all four gone |
+| `src/api/cvicneTests.ts` | 23 | open |
+| `src/api/odevzdavarny.ts` | 56 | open |
+| `src/api/kontrola.ts` | 17 | open |
+| `src/utils/serverTime.ts` | 29 (tablet-only path) | open |
 
 ⚠️ Not a blind sed: `fetchWithAuth` also imposes `DEFAULT_HEADERS` and a 401/403 login
-redirect, which changes **extension** behaviour. Check each call site.
+redirect, which changes **extension** behaviour. Check each call site. The four remaining
+are independent of each other, so they need not land together.
 
 Other bare fetches in `src/api/` target the CDN, Google or Supabase and are fine.
+
+**Adjacent, found while doing eduroam:** `src/api/outlookSync.ts:73` passes its own
+`Content-Type` into `fetchWithAuth`, which already sets a lowercase one — both keys
+survive the object spread and `Headers` *appends*, so IS receives the value twice, parses
+no body, and yet `response.ok` is true and the UI reports success. Extension-only; the
+Capacitor path forwards caller headers alone and is unaffected.
 
 ## Task 5 — eduroam native one-tap (#159)
 
@@ -104,12 +171,16 @@ holds only `MainActivity.java` and `DownloadsPlugin.java`; the manifest declares
 `ACCESS_WIFI_STATE` / `CHANGE_WIFI_STATE`; there is no iOS hotspot code or entitlement.
 Only the throwaway spike proved the approach.
 
-Today the sheet is **100% non-functional and fails at the first network call** — opening
-it auto-fires a CORS-blocked `fetchEduroamPassword()` whose error is swallowed into
-`logError`, so row 1 sits on a placeholder forever **and a telemetry report fires on every
-sheet open before the student touches anything**.
+~~Today the sheet is 100% non-functional and fails at the first network call~~ — **the
+network half is fixed** (Task 3 / PR #181). `fetchEduroamPassword` is no longer a
+CORS-blocked bare `fetch`, so the sheet should stop firing a telemetry report on every
+open and the password should render. **Unconfirmed on a device** — that is the owed check
+in Task 3, and it is the first thing to do here, because everything below assumes the
+cert material actually arrives.
 
-Depends on Task 3 (POST + bytes). Then:
+What remains is the **native Wi-Fi configuration** — nothing joins a network yet.
+
+Task 3 (POST + bytes) is now **done**, so this is unblocked. Then:
 
 1. Android plugin `configure({p12Base64, passphrase, caDerBase64, login})` — the spike's
    `EduroamProbePlugin` is the working reference. **`setWifiEnterpriseConfig()` does not


### PR DESCRIPTION
Docs only — no code changes.

`docs/superpowers/plans/2026-08-02-capacitor-remaining-work.md` is the document the mobile work resumes from, and it still described Tasks 1, 2 and 3 as outstanding after they shipped in #179 and #181. Left alone it would send the next person to re-solve finished problems.

## What changed

- **Tasks 1, 2, 3 marked done** with their merge commits. The original `file:line` analysis is kept in collapsed `<details>` blocks rather than deleted — it is still the best map of that code.
- **Task 4 narrowed** to the four call sites actually left (`cvicneTests`, `odevzdavarny`, `kontrola`, `serverTime`); eduroam's are gone.
- **Task 5 unblocked** — its network half is fixed, so what remains is the native Wi-Fi configuration, not the fetch layer.
- **Status table refreshed.**

## Two things this deliberately carries forward

**PR #181 merged with the Android device check still undone.** Nothing has ever exercised POST on real hardware, so eduroam on mobile is unproven in production regardless of the green unit tests. The checklist now lives in Task 3 — including why to assert the DER magic bytes (`0x30 0x82`) rather than a non-zero length, since an HTML error page is also non-empty, and why to omit `gen=` while testing so no 366-day credential is rotated.

**The four bugs that shipped green.** All of them survived a full unit suite because the tests stubbed response shapes the native layer never actually produces — `URLSearchParams` bodies, JSON bodies arriving pre-parsed as objects, the `logout.pl` gate applied to JSON, and a `Text/Html` content-type slipping exact-cased guards. Written into Task 3 as a standing warning for future transport work.

Also records the doubled-`Content-Type` defect still live at `src/api/outlookSync.ts:73`, found while migrating eduroam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the implementation plan to reflect completed transport, action loopback, exam refresh, duplicate-listing, and eduroam work.
  - Documented support for GET/POST requests and binary data retrieval.
  - Clarified remaining Android verification and native Wi‑Fi configuration tasks.
  - Expanded the inventory of outstanding network-related work and noted known native-layer serialization issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->