### PR TITLE
fix(mobile): stop a stale session-expired prompt from destroying a fresh session

### DIFF
--- a/docs/superpowers/plans/2026-08-02-capacitor-remaining-work.md
+++ b/docs/superpowers/plans/2026-08-02-capacitor-remaining-work.md
@@ -307,6 +307,10 @@ fixed after #185 merged:
   token is threaded from `capacitorTransport`/`capacitorBinary` for comparison only; it is
   never logged or transmitted.
 
+  Consequently `hooks/ui/openNativeFile.ts` no longer raises the prompt itself — it returns
+  silently on a lapsed session. The transport already prompted, *with* the token; a second
+  call from there would pass none, which is precisely the case the filter cannot catch.
+
 ⚠️ **The notification fires from where the error is MINTED, not where it is caught.** This
 was wrong in the first draft and both PR reviewers caught it. The original hook sat in
 `syncAllData`'s outer catch, which *cannot* fire: `getUserParams` swallows into `null`

--- a/docs/superpowers/plans/2026-08-02-capacitor-remaining-work.md
+++ b/docs/superpowers/plans/2026-08-02-capacitor-remaining-work.md
@@ -293,6 +293,20 @@ not throw a full-screen WebView over whatever the student is reading, so
 choose. On success it re-syncs immediately — otherwise the student signs back in and is still
 looking at the pre-expiry data until the next `SYNC_INTERVAL` tick.
 
+⚠️ **A prompt must never be able to destroy a healthy session.** Two ways it could, both
+fixed after #185 merged:
+
+- The prompt is `duration: Infinity` with a stable id, so it did **not** disappear once the
+  student signed back in. Left on screen, a second tap ran recovery again — which clears the
+  token. `recoverSession` now dismisses it on success.
+- A request issued *before* a re-login carries the dead token and can land well after it.
+  That response is unauthenticated because *its* token is dead, not because the current
+  session is. `promptSessionRecovery(failedToken)` now discards it by comparing against the
+  token the last recovery installed — **exact, not a grace period**: there is no window to
+  tune, and a genuine second lapse (which carries the *current* token) still prompts. The
+  token is threaded from `capacitorTransport`/`capacitorBinary` for comparison only; it is
+  never logged or transmitted.
+
 ⚠️ **The notification fires from where the error is MINTED, not where it is caught.** This
 was wrong in the first draft and both PR reviewers caught it. The original hook sat in
 `syncAllData`'s outer catch, which *cannot* fire: `getUserParams` swallows into `null`

--- a/src/api/__tests__/sessionExpiryNotify.test.ts
+++ b/src/api/__tests__/sessionExpiryNotify.test.ts
@@ -54,6 +54,24 @@ describe('session expiry reaches the handler from the transport', () => {
     expect(handler).not.toHaveBeenCalled();
   });
 
+  // The handler discards stragglers by comparing this against the token it
+  // last installed, so a notification that arrives without one cannot be
+  // filtered and would re-prompt after a successful re-login.
+  it.each([
+    ['a 401', { status: 401, data: '', headers: {} }],
+    [
+      'an unauthenticated 200',
+      { status: 200, data: '<html>login</html>', headers: { 'content-type': 'text/html' } },
+    ],
+  ])('forwards the token the failing request used on %s', async (_name, response) => {
+    deps.httpGet.mockResolvedValue(response);
+
+    await expect(
+      fetchViaCapacitor('https://is.mendelu.cz/auth/x', 'DEAD-TOKEN', deps)
+    ).rejects.toThrow();
+    expect(handler).toHaveBeenCalledWith('DEAD-TOKEN');
+  });
+
   it('stays silent on a healthy authenticated page', async () => {
     deps.httpGet.mockResolvedValue({
       status: 200,

--- a/src/api/capacitorBinary.ts
+++ b/src/api/capacitorBinary.ts
@@ -39,10 +39,10 @@ export function filenameFromResponse(headers: Record<string, string>): string {
 
 /** Mints the tagged auth error and reports it — see the twin in
  *  capacitorTransport for why reporting happens here and not at a catch. */
-function sessionExpired(message: string): Error {
+function sessionExpired(message: string, failedToken?: string): Error {
   const err = new Error(message) as Error & { sessionExpired?: boolean };
   err.sessionExpired = true;
-  notifySessionExpired();
+  notifySessionExpired(failedToken);
   return err;
 }
 
@@ -78,7 +78,7 @@ export async function fetchIsBinary(
   });
 
   if (res.status === 401 || res.status === 403) {
-    throw sessionExpired(`HTTP ${res.status}`);
+    throw sessionExpired(`HTTP ${res.status}`, token);
   }
   // Anything else non-2xx is IS being broken, not the student being logged out
   // — the same separation fetchViaCapacitor makes. It has to happen BEFORE the
@@ -107,7 +107,7 @@ export async function fetchIsBinary(
   // error message and the blob's MIME type.
   if (contentType.toLowerCase().includes('text/html')) {
     if (isAuthenticatedBase64Html(body)) return { kind: 'page' };
-    throw sessionExpired(`Expected a document, got ${contentType}`);
+    throw sessionExpired(`Expected a document, got ${contentType}`, token);
   }
 
   const blob = base64ToBlob(body, contentType || 'application/octet-stream');

--- a/src/api/capacitorTransport.ts
+++ b/src/api/capacitorTransport.ts
@@ -71,10 +71,12 @@ export function isAuthenticatedHtml(html: string): boolean {
  * `notifySessionExpired` is a no-op wherever no handler is registered, which is
  * everywhere but the Capacitor app.
  */
-function sessionExpired(message: string): Error {
+function sessionExpired(message: string, failedToken?: string): Error {
   const err = new Error(message) as Error & { sessionExpired?: boolean };
   err.sessionExpired = true;
-  notifySessionExpired();
+  // The token is forwarded, never logged: it lets the handler discard a
+  // straggler from a session that has already been replaced.
+  notifySessionExpired(failedToken);
   return err;
 }
 
@@ -170,7 +172,7 @@ export async function fetchViaCapacitor(
         : JSON.stringify(res.data);
 
   if (res.status === 401 || res.status === 403) {
-    throw sessionExpired(`HTTP ${res.status}`);
+    throw sessionExpired(`HTTP ${res.status}`, token);
   }
   // Anything else non-2xx is IS being broken (5xx, a maintenance page), NOT the
   // student being logged out. Tagging it sessionExpired would throw them back to
@@ -197,7 +199,7 @@ export async function fetchViaCapacitor(
   // unauthenticated login page through as if it were data.
   const contentType = readHeader(res.headers, 'content-type') || 'text/html';
   if (contentType.toLowerCase().includes('text/html') && !isAuthenticatedHtml(body)) {
-    throw sessionExpired('Authenticated request returned an unauthenticated page');
+    throw sessionExpired('Authenticated request returned an unauthenticated page', token);
   }
 
   return new Response(body, {

--- a/src/hooks/ui/__tests__/useFileActions.native.test.ts
+++ b/src/hooks/ui/__tests__/useFileActions.native.test.ts
@@ -91,12 +91,12 @@ describe('useFileActions on Capacitor', () => {
     }
   );
 
-  // A lapsed session is the one failure the student can act on, so it gets the
-  // recovery prompt (message + "sign in" action) instead of the generic
-  // "couldn't open" toast. Before this the app could only say the session had
-  // died; there was no way back short of killing and reopening it.
+  // A lapsed session shows no toast from here. fetchIsBinary already raised
+  // the recovery prompt when it minted the error — and did so WITH the token
+  // the request used, which is what lets a straggler from a superseded session
+  // be filtered out. Re-prompting from here would pass no token and defeat it.
   it.each([['openFile'], ['downloadSingle']] as const)(
-    '%s offers session recovery rather than a generic failure',
+    '%s stays silent on a lapsed session, leaving the prompt to the transport',
     async (method) => {
       vi.mocked(openIsFileNatively).mockRejectedValue(expired());
       const { result } = renderHook(() => useFileActions());
@@ -105,7 +105,7 @@ describe('useFileActions on Capacitor', () => {
         await result.current[method]('slozka.pl?download=1');
       });
 
-      expect(promptSessionRecovery).toHaveBeenCalledTimes(1);
+      expect(promptSessionRecovery).not.toHaveBeenCalled();
       expect(toast.error).not.toHaveBeenCalled();
     }
   );

--- a/src/hooks/ui/openNativeFile.ts
+++ b/src/hooks/ui/openNativeFile.ts
@@ -1,7 +1,6 @@
 import { toast } from 'sonner';
 import { logError } from '../../utils/reportError';
 import { openIsFileNatively } from '../../mobile/openIsFile';
-import { promptSessionRecovery } from '../../mobile/sessionRecovery';
 
 /**
  * The native branch of useFileActions' openFile/downloadSingle, with the error
@@ -28,13 +27,16 @@ export async function openNativeFile(
     await openIsFileNatively(fullUrl);
   } catch (e) {
     logError(context, e);
-    // A lapsed session is the one failure the student can act on, so it gets
-    // the recovery prompt — a message plus a "sign in" action — rather than
-    // being folded into the generic "couldn't open" toast.
-    if ((e as { sessionExpired?: boolean } | null)?.sessionExpired) {
-      promptSessionRecovery();
-      return;
-    }
+    // A lapsed session returns silently here on purpose: `fetchIsBinary`
+    // already raised the recovery prompt when it minted the error, and it did
+    // so WITH the token the request used. Prompting again from here would pass
+    // no token, which is exactly the case promptSessionRecovery cannot filter —
+    // so a straggler from a superseded session would slip through and offer to
+    // "repair" a session that is already healthy.
+    //
+    // The early return still matters: the generic toast must not fire on top
+    // of the recovery prompt.
+    if ((e as { sessionExpired?: boolean } | null)?.sessionExpired) return;
     toast.error(t('course.file.openFailed'));
   }
 }

--- a/src/mobile/__tests__/sessionRecovery.test.ts
+++ b/src/mobile/__tests__/sessionRecovery.test.ts
@@ -8,7 +8,7 @@ vi.mock('../../platform', () => ({
 vi.mock('../ensureSession', () => ({ ensureSession: vi.fn() }));
 vi.mock('../inAppLoginDeps', () => ({ buildInAppLoginDeps: vi.fn(async () => ({})) }));
 vi.mock('../../utils/reportError', () => ({ logError: vi.fn() }));
-vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn(), dismiss: vi.fn() } }));
 vi.mock('../../store/useAppStore', () => ({
   useAppStore: { getState: () => ({ language: 'cs' }) },
 }));
@@ -198,5 +198,72 @@ describe('re-sync after recovery', () => {
     vi.mocked(syncAllData).mockRejectedValueOnce(new Error('sync blew up'));
 
     await expect(recoverSession()).resolves.toBe(true);
+  });
+});
+
+/**
+ * Both defects here were found immediately after #185 merged. Neither loses
+ * data, but both end with a student who has a perfectly good session being
+ * made to log in again.
+ */
+describe('stale prompts cannot destroy a fresh session', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    syncState.busy = false;
+    vi.mocked(getPlatform).mockReturnValue({
+      kind: 'capacitor',
+      storage,
+    } as unknown as ReturnType<typeof getPlatform>);
+    vi.mocked(ensureSession).mockResolvedValue('NEW-TOKEN');
+  });
+
+  // The toast is duration: Infinity with a stable id, so without an explicit
+  // dismiss it simply stays on screen after a SUCCESSFUL re-login — and
+  // tapping it again runs recovery, which clears the valid token.
+  it('dismisses the prompt once recovery succeeds', async () => {
+    promptSessionRecovery('DEAD-TOKEN');
+    await recoverSession();
+
+    expect(toast.dismiss).toHaveBeenCalledWith('reis-session-expired');
+  });
+
+  it('leaves the prompt up when the student backs out of the login', async () => {
+    vi.mocked(ensureSession).mockRejectedValue(new Error('Login cancelled'));
+
+    promptSessionRecovery('DEAD-TOKEN');
+    await recoverSession();
+
+    expect(toast.dismiss).not.toHaveBeenCalled();
+  });
+
+  // A request issued BEFORE the re-login carries the old token and can land
+  // after it. Re-prompting on that would offer to "fix" a session that is
+  // already healthy, and accepting would delete the new token.
+  it('ignores a failure carrying a token that has already been replaced', async () => {
+    await recoverSession();
+    vi.mocked(toast.error).mockClear();
+
+    promptSessionRecovery('DEAD-TOKEN');
+
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  // A genuine second lapse carries the CURRENT token and must still prompt,
+  // otherwise recovery only ever works once per app launch.
+  it('still prompts when the current session lapses again', async () => {
+    await recoverSession();
+    vi.mocked(toast.error).mockClear();
+
+    promptSessionRecovery('NEW-TOKEN');
+
+    expect(toast.error).toHaveBeenCalledTimes(1);
+  });
+
+  // Before any recovery has run there is nothing to compare against, so a
+  // failure with no token must not be silently swallowed.
+  it('prompts for an untagged failure before any recovery has happened', () => {
+    promptSessionRecovery();
+
+    expect(toast.error).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/mobile/sessionRecovery.ts
+++ b/src/mobile/sessionRecovery.ts
@@ -27,12 +27,27 @@ const PROMPT_ID = 'reis-session-expired';
 /** In-flight recovery, so a fanned-out failure opens one login, not a dozen. */
 let inFlight: Promise<string> | null = null;
 
+/**
+ * The token the last successful recovery installed, used to tell a live failure
+ * from a straggler.
+ *
+ * Never logged, never sent anywhere — it exists only to be compared by identity
+ * with the token a failing request used.
+ */
+let activeToken: string | null = null;
+
 async function runRecovery(): Promise<string> {
   // ensureSession returns the stored token when it still looks plausible, and
   // a lapsed UISAuth looks exactly like a live one. Clearing first is what
   // makes this a re-login rather than a no-op that returns the dead token.
   await getPlatform().storage.remove(TOKEN_KEY);
   const token = await ensureSession(await buildInAppLoginDeps());
+
+  activeToken = token;
+  // The prompt is `duration: Infinity` with a stable id, so it does NOT go away
+  // on its own once the student has signed back in. Left up, it invites a
+  // second tap that would clear the token they just obtained.
+  toast.dismiss(PROMPT_ID);
 
   // Re-sync. Whatever failed during the lapse left the store holding
   // pre-expiry data, and without this it would sit there until the next
@@ -128,9 +143,25 @@ export async function recoverSession(): Promise<boolean> {
  * Safe to call from anywhere that catches a `sessionExpired` error, including
  * non-React code — the string is resolved through `translate` against the
  * store's current language rather than a hook.
+ *
+ * `failedToken` is the token the failing request actually used. A sync fans out
+ * ~236 requests, and one issued BEFORE a re-login can land well after it — that
+ * response is unauthenticated because its token is dead, not because the
+ * current session is. Prompting on it would offer to repair a session that is
+ * already healthy, and accepting would delete the token the student had just
+ * obtained and send them through the login again.
+ *
+ * Comparing tokens rather than waiting out a grace period keeps this exact:
+ * there is no window to tune, and a genuine second lapse — which carries the
+ * CURRENT token — still prompts.
  */
-export function promptSessionRecovery(): void {
+export function promptSessionRecovery(failedToken?: string): void {
   if (getPlatform().kind !== 'capacitor') return;
+
+  // Only suppress when we can prove the failure belongs to a superseded
+  // session. Before any recovery has run, activeToken is null and everything
+  // through — a failure must never be swallowed for lack of information.
+  if (failedToken && activeToken && failedToken !== activeToken) return;
 
   const language = useAppStore.getState().language;
   toast.error(translate(language, 'session.expired'), {

--- a/src/services/sessionExpiry.ts
+++ b/src/services/sessionExpiry.ts
@@ -14,7 +14,9 @@
  * and pays nothing.
  */
 
-type SessionExpiredHandler = () => void;
+/** Receives the token the failing request used, so the handler can tell a
+ *  live lapse from a straggler issued before an earlier re-login. */
+type SessionExpiredHandler = (failedToken?: string) => void;
 
 let handler: SessionExpiredHandler | null = null;
 
@@ -28,6 +30,6 @@ export function setSessionExpiredHandler(fn: SessionExpiredHandler | null): void
  * handler is registered — on the extension the content script has already
  * navigated the host page to login.pl, so there is nothing to add.
  */
-export function notifySessionExpired(): void {
-  handler?.();
+export function notifySessionExpired(failedToken?: string): void {
+  handler?.(failedToken);
 }


### PR DESCRIPTION
Follow-up to #185. Two defects in the session recovery it introduced, both found immediately after merge — one by review, one while checking that review comment.

Neither loses data. Both end with a student who has a perfectly good session being sent through the login again.

## 1. The prompt never went away on success

`promptSessionRecovery` raises a toast with `duration: Infinity` and a stable id. Nothing dismissed it. So after a **successful** re-login it simply stayed on screen, and tapping it again ran `recoverSession()` — which opens with `storage.remove(TOKEN_KEY)` and therefore deletes the token the student had just obtained.

`recoverSession` now dismisses it once the login succeeds, and only then: backing out of the login must leave the prompt up, which a test pins.

## 2. Late failures from the pre-login generation re-prompted

A sync fans out ~236 requests. One issued *before* the re-login carries the dead token and can land well after it — the login WebView alone takes 20–60s. That response is unauthenticated because **its** token is dead, not because the current session is. Prompting on it offers to repair a session that is already healthy, and accepting deletes the new token.

`promptSessionRecovery(failedToken)` now discards a notification whose token differs from the one the last recovery installed.

**Comparing tokens rather than waiting out a grace period** is the part worth reviewing: there is no window to tune, and a genuine second lapse — which carries the *current* token — still prompts. Before any recovery has run there is nothing to compare against, so nothing is suppressed; a failure is never swallowed for lack of information.

The token is threaded from `capacitorTransport` and `capacitorBinary` purely to be compared by identity. **It is never logged and never transmitted** — it does not reach `logError`, and telemetry never sees it.

## Verification

- 7 new tests; the 2 covering the defects failed before the fix and pass after
- Full suite **1908 passing** (1901 on `main`), nuia ratchet green, lint and format clean on changed files
- Both bundles build; `content.js` 416,549 bytes vs the 416,547 baseline — the two bytes are the optional parameter on `notifySessionExpired`

Still not device-verified, like everything else in the recovery path. The six-item Android check at the top of `docs/superpowers/plans/2026-08-02-capacitor-remaining-work.md` now covers this too: after signing back in, confirm the prompt clears itself and does not return.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CPcBgxBpgmfThZiRQQLojj

---
_Generated by [Claude Code](https://claude.ai/code/session_01CPcBgxBpgmfThZiRQQLojj)_