### PR TITLE
Mobile: first device-verified pass — downloads, file types, safe-area, gestures

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -9,8 +9,18 @@
          every byte of reIS data is re-synced from IS on first launch.
          dataExtractionRules covers Android 12+, where allowBackup alone no
          longer governs device transfer. -->
+    <!-- enableOnBackInvokedCallback is REQUIRED, not optional, at targetSdk 36.
+         Android 16 turns predictive back on by default: the back *gesture* goes
+         straight to the platform OnBackInvokedDispatcher, and with no callback
+         registered there the system just finishes the activity — so swiping back
+         anywhere closed the app instead of popping a sheet. The legacy KEYCODE_BACK
+         path kept working the whole time (verified on device), which is what made
+         this look like it worked. Setting this lets AndroidX's
+         OnBackPressedDispatcher — which @capacitor/app registers its backButton
+         callback on — receive the gesture too. -->
     <application
         android:allowBackup="false"
+        android:enableOnBackInvokedCallback="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         tools:targetApi="31"
         android:icon="@mipmap/ic_launcher"

--- a/android/app/src/main/java/cz/reis/app/DownloadsPlugin.java
+++ b/android/app/src/main/java/cz/reis/app/DownloadsPlugin.java
@@ -16,11 +16,18 @@ import android.util.Base64;
 
 import androidx.core.content.FileProvider;
 
+import android.Manifest;
+import android.content.pm.PackageManager;
+
+import androidx.core.content.ContextCompat;
+
 import com.getcapacitor.JSObject;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
+import com.getcapacitor.annotation.Permission;
+import com.getcapacitor.annotation.PermissionCallback;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -34,10 +41,52 @@ import java.io.OutputStream;
  * Android-only on purpose. iOS has no Downloads folder; there the Files/share
  * sheet IS the native pattern, so the JS side keeps using Share on iOS.
  */
-@CapacitorPlugin(name = "Downloads")
+@CapacitorPlugin(
+        name = "Downloads",
+        permissions = {
+                @Permission(alias = DownloadsPlugin.NOTIFICATIONS, strings = {
+                        Manifest.permission.POST_NOTIFICATIONS
+                })
+        })
 public class DownloadsPlugin extends Plugin {
 
+    static final String NOTIFICATIONS = "notifications";
+
     private static final String CHANNEL_ID = "reis-downloads";
+
+    /**
+     * POST_NOTIFICATIONS is a RUNTIME grant on Android 13+, and nothing ever
+     * asked for it — so notifyDownloaded's nm.notify() was dropped on the floor
+     * and every download completed with no visible sign whatsoever (verified on
+     * device: the file saved, granted=false, student saw nothing).
+     *
+     * Requested from the download path rather than at boot so the prompt appears
+     * when the student has just asked for a file, which is both the Android
+     * guidance and the only moment the request makes sense. Deliberately
+     * fire-and-forget: the save itself must never wait on, or fail because of,
+     * a notification permission. The in-app toast is the real confirmation; this
+     * only buys back the tap-to-open notification.
+     */
+    @PluginMethod
+    public void requestNotificationPermission(PluginCall call) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU || hasNotificationPermission()) {
+            call.resolve(new JSObject().put("granted", hasNotificationPermission()));
+            return;
+        }
+        requestPermissionForAlias(NOTIFICATIONS, call, "notificationPermissionResult");
+    }
+
+    @PermissionCallback
+    private void notificationPermissionResult(PluginCall call) {
+        call.resolve(new JSObject().put("granted", hasNotificationPermission()));
+    }
+
+    private boolean hasNotificationPermission() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return true;
+        return ContextCompat.checkSelfPermission(
+                getContext(), Manifest.permission.POST_NOTIFICATIONS)
+                == PackageManager.PERMISSION_GRANTED;
+    }
 
     @PluginMethod
     public void save(PluginCall call) {
@@ -116,6 +165,11 @@ public class DownloadsPlugin extends Plugin {
     }
 
     private void notifyDownloaded(String filename, String mime, Uri uri) {
+        // Without the runtime grant nm.notify() is a silent no-op on Android
+        // 13+. Returning early keeps that fact visible in the code instead of
+        // pretending a notification was posted.
+        if (!hasNotificationPermission()) return;
+
         NotificationManager nm =
                 (NotificationManager) getContext().getSystemService(Context.NOTIFICATION_SERVICE);
         if (nm == null) return;

--- a/capacitor/main.capacitor.ts
+++ b/capacitor/main.capacitor.ts
@@ -18,7 +18,13 @@ import { useAppStore } from '@/store/useAppStore';
  */
 void CapApp.addListener('backButton', () => {
   const s = useAppStore.getState();
-  if (handleBackPress({ sheetCount: s.mobileSheets.length, popSheet: s.popSheet }) === 'exit') {
+  const result = handleBackPress({
+    sheetCount: s.mobileSheets.length,
+    popSheet: s.popSheet,
+    bulletinOpen: s.bulletinExpanded,
+    closeBulletin: () => void s.setBulletinExpanded(false),
+  });
+  if (result === 'exit') {
     void CapApp.exitApp();
   }
 });

--- a/docs/superpowers/plans/2026-08-02-capacitor-remaining-work.md
+++ b/docs/superpowers/plans/2026-08-02-capacitor-remaining-work.md
@@ -13,7 +13,45 @@ measurements) and `2026-08-02-capacitor-transport-decision.md` (why Model C).
 
 ## Where it stands
 
-*Updated 2026-08-07, after PR #185 (Task 4, Task 8 external links, session recovery).*
+*Updated 2026-08-07 (evening), after the first real Android handset pass.*
+
+**THE DEVICE PASS HAPPENED.** Handset A001, 1080x2392, dpr 2.625. Cold start → login →
+**115 requests, all HTTP 200, zero telemetry**, covering all four Task 4 endpoint families
+(`student/list.pl` prubezne+test, `odevzdavarny.pl`, `studijni_povinnosti.pl`,
+`wifi/certifikat.pl`) plus 4 POSTs (`rozvrhy_view.pl` cz/en). The whole
+"silently CORS-blocked on Capacitor" class is confirmed dead on hardware.
+
+**How to debug this app on a device — reuse this, it found every root cause below.**
+The debug build exposes the WebView over Chrome DevTools Protocol:
+`adb forward tcp:9222 localabstract:webview_devtools_remote_<pid>`, then drive
+`Runtime.evaluate` over the websocket (Node 22+ has a global `WebSocket`; no dependency
+needed). That gives real geometry, scrollTop, computed styles, event streams — and it can
+fetch authenticated IS HTML on demand, which is exactly the "real IS sample" this repo
+requires before touching a parser. **Screenshots repeatedly lied** (one caught a login sheet
+mid-close and read as a failure; two raced a toast). Resolve tap targets from the DOM in
+device px (`rect * devicePixelRatio`), never by eyeballing a screenshot. Gate every
+screencap on `dumpsys window | grep mCurrentFocus` containing `cz.reis.app` — this is the
+user's personal phone.
+
+**Fixed and device-verified this session**
+
+| Symptom | Root cause | Verified |
+|---|---|---|
+| Downloads "do nothing" | File saved fine (577500 B); the only feedback was a notification, and `POST_NOTIFICATIONS` was never requested → denied → silence | Toast on device; permission now `granted=true` |
+| Every file badge reads "FILE" | **IS changed its markup**: `img[sysid]` → `span[data-sysid]`. Zero `img[sysid]` left. **Hits the extension too** | Badges read PDF / DOCX / ZIP |
+| Header under the status bar | `ScreenHeader` used flat `pt-5`, never read `--safe-top` (which correctly reports 48px) | Date title clear of the clock |
+| Sheets won't swipe closed | `Sheet` drew a drag pill with no drag handling; adding one was not enough — `touch-action: auto` let the browser claim the drag and fire `pointercancel` after ~20px of a 350px swipe | Panel 1 → 0 on a header drag; content still scrolls |
+| Two identical IS links per tab | Tab bodies render `ISBacklink` while the sheet pins its own footer | Exactly 1 link on all 5 tabs |
+| Back quits from vývěska | The overlay is NOT a sheet — own `bulletinExpanded` flag, portals to body, so the stack read empty | Back closes overlay, app stays |
+| Feedback is a desktop popup | Centred card on phones | Bottom sheet: flex-end, 20px top radius, flush |
+
+Also verified on device: eduroam sheet opens from settings and renders the extraction
+password with **no telemetry report** (the old symptom); map has no Knihovna tab; settings
+has the eduroam row and no Drive toggle.
+
+---
+
+*Previous update, after PR #185 (Task 4, Task 8 external links, session recovery).*
 
 ⚠️ **One coverage gap knowingly accepted at merge:** `searchService` moved from a direct
 iframe `fetch` onto the content-script proxy, and nothing tests that hop end to end —
@@ -44,7 +82,44 @@ in this document, and it compounds: this transport's own record is *four* bugs s
 green because the tests stubbed shapes the native layer never produces (Task 3). One
 Android session is now worth more than any further code.
 
-**The owed device check, in one place.** It started as eduroam-only and has grown:
+## What is still owed
+
+**1. The predictive-back GESTURE — the one thing a human must check.**
+`android:enableOnBackInvokedCallback="true"` is now in the merged manifest, which is the
+documented fix for targetSdk 36. It is NOT confirmed: `adb shell input swipe` only reaches
+the app window, and `input keyevent 4` exercises the legacy path, which worked all along.
+Only a thumb settles it. **The single decisive test: open vývěska and swipe back.** If the
+noticeboard closes and the app stays, both this and the bulletin fix are confirmed at once —
+before, the two failure modes were indistinguishable (the app closed either way).
+
+**2. eduroam, the half that must not be automated.** The sheet opens and the extraction
+password renders. The cert download was deliberately NOT tapped: it can generate a
+certificate and rotate a 366-day credential the student may have installed elsewhere. When
+checking by hand, assert the bytes start `0x30 0x82` — an HTML error page is also non-empty,
+so a length check proves nothing. Native Wi-Fi config (#159) remains unstarted.
+
+**3. Search and external links.** `searchService` moved onto the content-script proxy and
+still has no end-to-end coverage (`e2e/tests/search.spec.ts` only asserts the bar renders,
+and CI does not run e2e). External links opening in-app AND authenticated is likewise
+unverified. Both were mid-check when this session ended.
+
+**4. UI polish backlog.** `MobileSearchOverlay` still lacks its `--safe-top` inset and is
+BLOCKED by pre-existing react-hooks lint debt in the same file (a setState-in-effect error
+on HEAD) — the changed-files CI gate makes that file untouchable until the effect is fixed.
+Other top-anchored surfaces were swept. The bottom nav sits at `bottom-[18px]` against a
+24px `--safe-bottom`.
+
+**5. Unchanged blockers.** Secure storage for `UISAuth` (#172) is still the one hard release
+gate. iOS has still never been built (#174). Drive on mobile (#168) is now hidden rather
+than fixed. The Discord webhook still ships in the client bundle (#163/#183).
+
+**6. Other parsers may share the FILE bug.** IS's `img[sysid]` → `span[data-sysid]`
+migration is unlikely to stop at the document server. Audit `grep -rn "sysid" src/` and
+verify each against real IS HTML via the CDP route above.
+
+---
+
+**The original device checklist, for reference.** It started as eduroam-only and grew:
 
 1. **eduroam** — sheet opens with no telemetry report; extraction password renders; the
    POST returns an authenticated page; both certs start `0x30 0x82`. Full method and the

--- a/src/api/documents/__tests__/mimeSysid.test.ts
+++ b/src/api/documents/__tests__/mimeSysid.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import { parseServerFiles } from '../parser';
+
+/**
+ * IS changed how it publishes a file's mime type.
+ *
+ * Captured live from is.mendelu.cz on 2026-08-07 (slozka.pl?ds=1;id=153918):
+ * the old `<img sysid="mime-pdf">` is gone entirely — zero `img[sysid]` in the
+ * whole document — and the type now rides on a `<span class="uf-icon"
+ * data-sysid="mime-pdf">` wrapping an inline SVG. The parser still looked for
+ * the old attribute, so every file fell through to 'unknown' and the UI badge
+ * rendered "FILE" for a folder of PDFs. Not a mobile bug: the extension parses
+ * the same HTML.
+ *
+ * The trap this pins: a row carries THREE data-sysid values — 'stav-precteno'
+ * (read status), 'prohlizeni-info' (a view link) and 'mime-pdf'. A bare
+ * `[data-sysid]` selector picks up the first and yields nonsense, so the
+ * selector has to be mime-specific.
+ */
+const row = (name: string, downloadId: string, mime: string) => `
+  <tr class=" uis-hl-table lbn">
+    <td class="odsazena" align="center" nowrap="1">
+      <span class="uf-icon xs" role="img" data-sysid="stav-precteno" data-id="2128"></span>
+    </td>
+    <td class="odsazena" align="left">${name}</td>
+    <td class="odsazena" align="left"></td>
+    <td class="odsazena" nowrap="1" align="left"><a href="/auth/lide/clovek.pl?id=118622;lang=cz">J. Gallus</a></td>
+    <td class="odsazena" nowrap="1" align="left">30.04.2026</td>
+    <td class="odsazena" nowrap="1" align="left">30.04.2026</td>
+    <td class="odsazena" align="center">
+      <a href="dokumenty_cteni.pl?id=153918;on=0;dok=${downloadId};lang=cz">
+        <span class="uf-icon sm" role="img" data-sysid="prohlizeni-info" data-id="1146"></span>
+      </a>
+    </td>
+    <td class="odsazena" align="center" nowrap="1">
+      <a href="/auth/dok_server/slozka.pl?download=${downloadId};id=153918;z=1;lang=cz">
+        <span class="uf-icon sm" role="img" data-sysid="${mime}" data-id="0" aria-label="${name}"></span>
+      </a>
+    </td>
+  </tr>`;
+
+const folderHtml = `
+  <html><body>
+    <table>
+      <thead><tr><th>St</th><th>Název</th><th>Komentář</th><th>Vložil</th><th>Vloženo</th><th>Změněno</th><th>Info</th><th>Stáhnout</th></tr></thead>
+      <tbody>
+        ${row('JSON dokumentace', '359058', 'mime-pdf')}
+        ${row('Projekt IoT 2026', '359059', 'mime-zip')}
+      </tbody>
+    </table>
+  </body></html>`;
+
+describe('parseServerFiles mime type', () => {
+  it('reads the type from the current data-sysid markup', () => {
+    const parsed = parseServerFiles(folderHtml);
+    const all = parsed.files.flatMap((f) => f.files);
+    const byName = (n: string) => all.find((f) => f.name.includes(n) || f.link.includes(n));
+
+    expect(all.length).toBeGreaterThan(0);
+    expect(byName('359058')?.type).toBe('pdf');
+    expect(byName('359059')?.type).toBe('zip');
+  });
+
+  it('never reports a type of unknown when IS published one', () => {
+    const parsed = parseServerFiles(folderHtml);
+    const types = parsed.files.flatMap((f) => f.files).map((f) => f.type);
+    expect(types).not.toContain('unknown');
+  });
+
+  /**
+   * Each row holds TWO qualifying anchors — IS's view-info link and the real
+   * download — and the view link is skipped by recognising its
+   * 'prohlizeni-info' icon. A first cut of the data-sysid fix looked only for
+   * `mime-` icons, so that link reported no icon at all, dodged the skip, and
+   * every file gained a phantom 'unknown' sibling. Only a count catches it.
+   */
+  it('emits one attachment per file, not a phantom for the view link', () => {
+    const parsed = parseServerFiles(folderHtml);
+    const all = parsed.files.flatMap((f) => f.files);
+    expect(all).toHaveLength(2);
+    expect(all.every((f) => f.link.includes('download='))).toBe(true);
+  });
+
+  /**
+   * The read-status icon comes first in DOM order. If the selector is not
+   * mime-specific it wins, and the badge shows "STAV-PRECTENO".
+   */
+  it('does not mistake the read-status icon for a mime type', () => {
+    const parsed = parseServerFiles(folderHtml);
+    const types = parsed.files.flatMap((f) => f.files).map((f) => f.type);
+    expect(types).not.toContain('stav-precteno');
+    expect(types).not.toContain('prohlizeni-info');
+  });
+
+  /** The pre-2026-08 markup must keep working — other IS pages may still use it. */
+  it('still reads the legacy img[sysid] markup', () => {
+    const legacy = `
+      <html><body><table>
+        <thead><tr><th>Název</th><th>Stáhnout</th></tr></thead>
+        <tbody><tr>
+          <td>Stará prezentace</td>
+          <td><a href="/auth/dok_server/slozka.pl?download=111;id=1;z=1;lang=cz"><img sysid="mime-pptx" /></a></td>
+        </tr></tbody>
+      </table></body></html>`;
+    const parsed = parseServerFiles(legacy);
+    const all = parsed.files.flatMap((f) => f.files);
+    expect(all.find((f) => f.link.includes('download=111'))?.type).toBe('pptx');
+  });
+});

--- a/src/api/documents/columnIndices.ts
+++ b/src/api/documents/columnIndices.ts
@@ -1,0 +1,46 @@
+/**
+ * Maps table header names to their corresponding column indices.
+ *
+ * Moved out of parser.ts unchanged. These indices are load-bearing — a one-off
+ * change silently breaks production data — so this is a pure relocation: the
+ * matching order, the `=== undefined` first-wins guards and the header strings
+ * are byte-for-byte what the parser has always run.
+ */
+export function getColumnIndices(table: Element): Record<string, number> {
+  const indices: Record<string, number> = {};
+  const headers = Array.from(table.querySelectorAll('thead th, tr.zahlavi th, tr.zahlavi td'));
+
+  headers.forEach((th, i) => {
+    const text = th.textContent?.trim().toLowerCase() || '';
+    if ((text.includes('název') || text.includes('name')) && indices.name === undefined)
+      indices.name = i;
+    else if (
+      (text.includes('vložil') || text.includes('entered by')) &&
+      indices.author === undefined
+    )
+      indices.author = i;
+    else if (
+      (text.includes('datum dokumentu') || text.includes('document date')) &&
+      indices.date === undefined
+    )
+      indices.date = i;
+    else if (
+      text.includes('poslední změna') ||
+      text.includes('last change') ||
+      text.includes('modifikace')
+    ) {
+      if (indices.date === undefined) indices.date = i;
+    } else if (
+      (text.includes('komentář') || text.includes('comment')) &&
+      indices.comment === undefined
+    )
+      indices.comment = i;
+    else if (
+      (text.includes('ozn.') || text.includes('subfolder')) &&
+      indices.subfolder === undefined
+    )
+      indices.subfolder = i;
+  });
+
+  return indices;
+}

--- a/src/api/documents/iconSysid.ts
+++ b/src/api/documents/iconSysid.ts
@@ -1,0 +1,33 @@
+/**
+ * The icon sysid within `scope`, across both markups IS has served, preferring
+ * the mime icon over any other.
+ *
+ * On 2026-08-07 a live fetch of `slozka.pl?ds=1;id=153918` contained ZERO
+ * `img[sysid]` elements: IS had replaced `<img sysid="mime-pdf">` with
+ * `<span class="uf-icon" data-sysid="mime-pdf">` wrapping an inline SVG. Every
+ * file therefore parsed as 'unknown' and the UI badge read "FILE" for a folder
+ * of PDFs.
+ *
+ * Two orderings matter, and both are load-bearing:
+ *  - mime FIRST, because a row also carries 'stav-precteno' (read status) and
+ *    'prohlizeni-info', and the read-status icon comes earlier in DOM order.
+ *  - a non-mime data-sysid STILL returned when there is no mime icon, because
+ *    callers below identify IS's view-info link by its 'prohlizeni-info' icon
+ *    and skip it. Returning '' there let that link through as a phantom
+ *    'unknown' attachment beside every real file.
+ *
+ * The legacy branch stays: only slozka.pl was re-verified, and other IS pages
+ * may still serve the old markup.
+ *
+ * Lives in its own file rather than inside parser.ts: that parser is brittle and
+ * load-bearing, and keeping this beside it means a markup change is reviewed on
+ * its own instead of buried in a 250-line diff.
+ */
+export function iconSysid(scope: Element | null | undefined): string {
+  if (!scope) return '';
+  const mime = scope.querySelector('[data-sysid^="mime-"]')?.getAttribute('data-sysid');
+  if (mime) return mime;
+  const anyModern = scope.querySelector('[data-sysid]')?.getAttribute('data-sysid');
+  if (anyModern) return anyModern;
+  return scope.querySelector('img[sysid]')?.getAttribute('sysid') || '';
+}

--- a/src/api/documents/parser.ts
+++ b/src/api/documents/parser.ts
@@ -2,78 +2,8 @@ import { sanitizeString, validateFileName, validateUrl } from '../../utils/valid
 import { ParserError } from '../../utils/parsers/parserGuards';
 import { logError } from '../../utils/reportError';
 import type { ParsedFile, FileAttachment } from '../../types/documents';
-
-/**
- * Maps table header names to their corresponding column indices.
- */
-function getColumnIndices(table: Element): Record<string, number> {
-  const indices: Record<string, number> = {};
-  const headers = Array.from(table.querySelectorAll('thead th, tr.zahlavi th, tr.zahlavi td'));
-
-  headers.forEach((th, i) => {
-    const text = th.textContent?.trim().toLowerCase() || '';
-    if ((text.includes('název') || text.includes('name')) && indices.name === undefined)
-      indices.name = i;
-    else if (
-      (text.includes('vložil') || text.includes('entered by')) &&
-      indices.author === undefined
-    )
-      indices.author = i;
-    else if (
-      (text.includes('datum dokumentu') || text.includes('document date')) &&
-      indices.date === undefined
-    )
-      indices.date = i;
-    else if (
-      text.includes('poslední změna') ||
-      text.includes('last change') ||
-      text.includes('modifikace')
-    ) {
-      if (indices.date === undefined) indices.date = i;
-    } else if (
-      (text.includes('komentář') || text.includes('comment')) &&
-      indices.comment === undefined
-    )
-      indices.comment = i;
-    else if (
-      (text.includes('ozn.') || text.includes('subfolder')) &&
-      indices.subfolder === undefined
-    )
-      indices.subfolder = i;
-  });
-
-  return indices;
-}
-
-/**
- * The icon sysid within `scope`, across both markups IS has served, preferring
- * the mime icon over any other.
- *
- * On 2026-08-07 a live fetch of `slozka.pl?ds=1;id=153918` contained ZERO
- * `img[sysid]` elements: IS had replaced `<img sysid="mime-pdf">` with
- * `<span class="uf-icon" data-sysid="mime-pdf">` wrapping an inline SVG. Every
- * file therefore parsed as 'unknown' and the UI badge read "FILE" for a folder
- * of PDFs.
- *
- * Two orderings matter, and both are load-bearing:
- *  - mime FIRST, because a row also carries 'stav-precteno' (read status) and
- *    'prohlizeni-info', and the read-status icon comes earlier in DOM order.
- *  - a non-mime data-sysid STILL returned when there is no mime icon, because
- *    callers below identify IS's view-info link by its 'prohlizeni-info' icon
- *    and skip it. Returning '' there let that link through as a phantom
- *    'unknown' attachment beside every real file.
- *
- * The legacy branch stays: only slozka.pl was re-verified, and other IS pages
- * may still serve the old markup.
- */
-function iconSysid(scope: Element | null | undefined): string {
-  if (!scope) return '';
-  const mime = scope.querySelector('[data-sysid^="mime-"]')?.getAttribute('data-sysid');
-  if (mime) return mime;
-  const anyModern = scope.querySelector('[data-sysid]')?.getAttribute('data-sysid');
-  if (anyModern) return anyModern;
-  return scope.querySelector('img[sysid]')?.getAttribute('sysid') || '';
-}
+import { getColumnIndices } from './columnIndices';
+import { iconSysid } from './iconSysid';
 
 export function parseServerFiles(html: string): {
   files: ParsedFile[];

--- a/src/api/documents/parser.ts
+++ b/src/api/documents/parser.ts
@@ -1,143 +1,248 @@
-import { sanitizeString, validateFileName, validateUrl } from "../../utils/validation/index";
-import { ParserError } from "../../utils/parsers/parserGuards";
-import { logError } from "../../utils/reportError";
-import type { ParsedFile, FileAttachment } from "../../types/documents";
+import { sanitizeString, validateFileName, validateUrl } from '../../utils/validation/index';
+import { ParserError } from '../../utils/parsers/parserGuards';
+import { logError } from '../../utils/reportError';
+import type { ParsedFile, FileAttachment } from '../../types/documents';
 
 /**
  * Maps table header names to their corresponding column indices.
  */
 function getColumnIndices(table: Element): Record<string, number> {
-    const indices: Record<string, number> = {};
-    const headers = Array.from(table.querySelectorAll('thead th, tr.zahlavi th, tr.zahlavi td'));
-    
-    headers.forEach((th, i) => {
-        const text = th.textContent?.trim().toLowerCase() || '';
-        if ((text.includes('název') || text.includes('name')) && indices.name === undefined) indices.name = i;
-        else if ((text.includes('vložil') || text.includes('entered by')) && indices.author === undefined) indices.author = i;
-        else if ((text.includes('datum dokumentu') || text.includes('document date')) && indices.date === undefined) indices.date = i;
-        else if (text.includes('poslední změna') || text.includes('last change') || text.includes('modifikace')) {
-            if (indices.date === undefined) indices.date = i;
-        }
-        else if ((text.includes('komentář') || text.includes('comment')) && indices.comment === undefined) indices.comment = i;
-        else if ((text.includes('ozn.') || text.includes('subfolder')) && indices.subfolder === undefined) indices.subfolder = i;
-    });
-    
-    return indices;
+  const indices: Record<string, number> = {};
+  const headers = Array.from(table.querySelectorAll('thead th, tr.zahlavi th, tr.zahlavi td'));
+
+  headers.forEach((th, i) => {
+    const text = th.textContent?.trim().toLowerCase() || '';
+    if ((text.includes('název') || text.includes('name')) && indices.name === undefined)
+      indices.name = i;
+    else if (
+      (text.includes('vložil') || text.includes('entered by')) &&
+      indices.author === undefined
+    )
+      indices.author = i;
+    else if (
+      (text.includes('datum dokumentu') || text.includes('document date')) &&
+      indices.date === undefined
+    )
+      indices.date = i;
+    else if (
+      text.includes('poslední změna') ||
+      text.includes('last change') ||
+      text.includes('modifikace')
+    ) {
+      if (indices.date === undefined) indices.date = i;
+    } else if (
+      (text.includes('komentář') || text.includes('comment')) &&
+      indices.comment === undefined
+    )
+      indices.comment = i;
+    else if (
+      (text.includes('ozn.') || text.includes('subfolder')) &&
+      indices.subfolder === undefined
+    )
+      indices.subfolder = i;
+  });
+
+  return indices;
 }
 
-export function parseServerFiles(html: string): { files: ParsedFile[], paginationLinks: string[], totalRecords?: number } {
-    const doc = new DOMParser().parseFromString(html, 'text/html');
-    const files: ParsedFile[] = [];
-    const paginationLinks: string[] = [];
-    let totalRecords: number | undefined;
+/**
+ * The icon sysid within `scope`, across both markups IS has served, preferring
+ * the mime icon over any other.
+ *
+ * On 2026-08-07 a live fetch of `slozka.pl?ds=1;id=153918` contained ZERO
+ * `img[sysid]` elements: IS had replaced `<img sysid="mime-pdf">` with
+ * `<span class="uf-icon" data-sysid="mime-pdf">` wrapping an inline SVG. Every
+ * file therefore parsed as 'unknown' and the UI badge read "FILE" for a folder
+ * of PDFs.
+ *
+ * Two orderings matter, and both are load-bearing:
+ *  - mime FIRST, because a row also carries 'stav-precteno' (read status) and
+ *    'prohlizeni-info', and the read-status icon comes earlier in DOM order.
+ *  - a non-mime data-sysid STILL returned when there is no mime icon, because
+ *    callers below identify IS's view-info link by its 'prohlizeni-info' icon
+ *    and skip it. Returning '' there let that link through as a phantom
+ *    'unknown' attachment beside every real file.
+ *
+ * The legacy branch stays: only slozka.pl was re-verified, and other IS pages
+ * may still serve the old markup.
+ */
+function iconSysid(scope: Element | null | undefined): string {
+  if (!scope) return '';
+  const mime = scope.querySelector('[data-sysid^="mime-"]')?.getAttribute('data-sysid');
+  if (mime) return mime;
+  const anyModern = scope.querySelector('[data-sysid]')?.getAttribute('data-sysid');
+  if (anyModern) return anyModern;
+  return scope.querySelector('img[sysid]')?.getAttribute('sysid') || '';
+}
 
-    // Case 1: Read document page (detail page)
-    const attachmentsLabel = Array.from(doc.querySelectorAll('td')).find(td => td.textContent?.includes('Attachments:') || td.textContent?.includes('Přílohy:'));
-    if (attachmentsLabel) {
-        const row = attachmentsLabel.parentElement;
-        const link = row?.querySelector('a')?.getAttribute('href');
-        if (link) {
-            const tableRows = Array.from(doc.querySelectorAll('tr'));
-            const findValue = (regex: RegExp) => tableRows.find(tr => regex.test(tr.textContent || ''))?.querySelectorAll('td')[1]?.textContent?.trim() || '';
-            
-            const name = findValue(/Name:|Názov:|Název:/);
-            const author = findValue(/Entered by:|Vložil:|Zadal:/);
-            const date = findValue(/Document date:|Datum dokumentu:|Dátum dokumentu:/);
-            const comment = findValue(/Comments:|Poznámka:|Komentář:/);
-            const type = row?.querySelector('img[sysid]')?.getAttribute('sysid')?.replace('mime-', '') || 'unknown';
+export function parseServerFiles(html: string): {
+  files: ParsedFile[];
+  paginationLinks: string[];
+  totalRecords?: number;
+} {
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+  const files: ParsedFile[] = [];
+  const paginationLinks: string[] = [];
+  let totalRecords: number | undefined;
 
-            const sName = validateFileName(name || 'Unknown');
-            const vUrl = validateUrl(link, 'is.mendelu.cz');
-            if (sName && vUrl) {
-                return { files: [{ subfolder: '', file_name: sName, file_comment: sanitizeString(comment, 500), author: sanitizeString(author, 200), date, files: [{ name: sName, type, link: vUrl }] }], paginationLinks: [], totalRecords: 1 };
-            }
-        }
+  // Case 1: Read document page (detail page)
+  const attachmentsLabel = Array.from(doc.querySelectorAll('td')).find(
+    (td) => td.textContent?.includes('Attachments:') || td.textContent?.includes('Přílohy:')
+  );
+  if (attachmentsLabel) {
+    const row = attachmentsLabel.parentElement;
+    const link = row?.querySelector('a')?.getAttribute('href');
+    if (link) {
+      const tableRows = Array.from(doc.querySelectorAll('tr'));
+      const findValue = (regex: RegExp) =>
+        tableRows
+          .find((tr) => regex.test(tr.textContent || ''))
+          ?.querySelectorAll('td')[1]
+          ?.textContent?.trim() || '';
+
+      const name = findValue(/Name:|Názov:|Název:/);
+      const author = findValue(/Entered by:|Vložil:|Zadal:/);
+      const date = findValue(/Document date:|Datum dokumentu:|Dátum dokumentu:/);
+      const comment = findValue(/Comments:|Poznámka:|Komentář:/);
+      const type = iconSysid(row).replace('mime-', '') || 'unknown';
+
+      const sName = validateFileName(name || 'Unknown');
+      const vUrl = validateUrl(link, 'is.mendelu.cz');
+      if (sName && vUrl) {
+        return {
+          files: [
+            {
+              subfolder: '',
+              file_name: sName,
+              file_comment: sanitizeString(comment, 500),
+              author: sanitizeString(author, 200),
+              date,
+              files: [{ name: sName, type, link: vUrl }],
+            },
+          ],
+          paginationLinks: [],
+          totalRecords: 1,
+        };
+      }
     }
+  }
 
-    // Case 2: Folder list / Tables
-    const tables = Array.from(doc.querySelectorAll('table')).filter(t => !t.classList.contains('portal_menu'));
+  // Case 2: Folder list / Tables
+  const tables = Array.from(doc.querySelectorAll('table')).filter(
+    (t) => !t.classList.contains('portal_menu')
+  );
 
-    tables.forEach(table => {
-        const indices = getColumnIndices(table);
-        if (indices.name === undefined) return;
+  tables.forEach((table) => {
+    const indices = getColumnIndices(table);
+    if (indices.name === undefined) return;
 
-        const rows = Array.from(table.querySelectorAll('tr.uis-hl-table.lbn, tbody tr')).filter(r => r.querySelectorAll('td').length >= 2);
-        
-        rows.forEach(row => {
-          try {
-            const cells = row.querySelectorAll('td');
-            if (cells.length === 0) return;
+    const rows = Array.from(table.querySelectorAll('tr.uis-hl-table.lbn, tbody tr')).filter(
+      (r) => r.querySelectorAll('td').length >= 2
+    );
 
-            const adder = (cells[0]?.classList.contains("UISTMNumberCell") || cells[0]?.classList.contains("UISTMNumberCellHidden") || cells[0]?.querySelector('input[type="checkbox"]')) ? 1 : 0;
+    rows.forEach((row) => {
+      try {
+        const cells = row.querySelectorAll('td');
+        if (cells.length === 0) return;
 
-            const nameIdx = indices.name ?? (1 + adder);
-            const authorIdx = indices.author ?? (3 + adder);
-            const dateIdx = indices.date ?? (4 + adder);
-            const commentIdx = indices.comment ?? (2 + adder);
-            const subfolderIdx = indices.subfolder ?? adder;
+        const adder =
+          cells[0]?.classList.contains('UISTMNumberCell') ||
+          cells[0]?.classList.contains('UISTMNumberCellHidden') ||
+          cells[0]?.querySelector('input[type="checkbox"]')
+            ? 1
+            : 0;
 
-            if (nameIdx >= cells.length) {
-                throw new ParserError('name', 'parseServerFiles', `nameIdx ${nameIdx} >= cells.length ${cells.length}`, row.outerHTML.slice(0, 500));
-            }
+        const nameIdx = indices.name ?? 1 + adder;
+        const authorIdx = indices.author ?? 3 + adder;
+        const dateIdx = indices.date ?? 4 + adder;
+        const commentIdx = indices.comment ?? 2 + adder;
+        const subfolderIdx = indices.subfolder ?? adder;
 
-            const nameCell = cells[nameIdx];
-            const file_name = validateFileName(nameCell?.textContent || '');
-            if (!file_name) return;
+        if (nameIdx >= cells.length) {
+          throw new ParserError(
+            'name',
+            'parseServerFiles',
+            `nameIdx ${nameIdx} >= cells.length ${cells.length}`,
+            row.outerHTML.slice(0, 500)
+          );
+        }
 
-            const subfolder = sanitizeString(cells[subfolderIdx]?.textContent || '', 100);
-            const author = sanitizeString(cells[authorIdx]?.textContent || '', 200);
-            const date = sanitizeString(cells[dateIdx]?.textContent || '', 50);
-            const file_comment = sanitizeString(cells[commentIdx]?.textContent || '', 500);
+        const nameCell = cells[nameIdx];
+        const file_name = validateFileName(nameCell?.textContent || '');
+        if (!file_name) return;
 
-            const extractedFiles: FileAttachment[] = [];
-            Array.from(row.querySelectorAll('a')).forEach(l => {
-                const href = l.getAttribute('href');
-                if (!href) return;
-                const vUrl = validateUrl(href.startsWith('http') ? href : (href.startsWith('/') ? href : `/auth/dok_server/${href.replace(/^\.\//, '')}`), 'is.mendelu.cz');
-                
-                const isSystemLabel = /Všechny moje složky|Nadřazená složka|All my folders|Parent folder|Document tree|New documents|DS settings|Searching|Dokumentový strom|Nové dokumenty|Nastavení stromu|Vyhledávání/i.test(file_name);
-                const isSystemUrl = /moje_dok\.pl|nove_dok\.pl|nastaveni_stromu\.pl|vyhledavani\.pl|index\.pl|clovek\.pl|dokumenty_ct\.pl/.test(vUrl || '');
+        const subfolder = sanitizeString(cells[subfolderIdx]?.textContent || '', 100);
+        const author = sanitizeString(cells[authorIdx]?.textContent || '', 200);
+        const date = sanitizeString(cells[dateIdx]?.textContent || '', 50);
+        const file_comment = sanitizeString(cells[commentIdx]?.textContent || '', 500);
 
-                if (!vUrl || isSystemLabel || isSystemUrl) return;
+        const extractedFiles: FileAttachment[] = [];
+        Array.from(row.querySelectorAll('a')).forEach((l) => {
+          const href = l.getAttribute('href');
+          if (!href) return;
+          const vUrl = validateUrl(
+            href.startsWith('http')
+              ? href
+              : href.startsWith('/')
+                ? href
+                : `/auth/dok_server/${href.replace(/^\.\//, '')}`,
+            'is.mendelu.cz'
+          );
 
-                const sysid = l.querySelector('img[sysid]')?.getAttribute('sysid') || '';
-                if (sysid === 'mime-prohlizeni-info') return;
+          const isSystemLabel =
+            /Všechny moje složky|Nadřazená složka|All my folders|Parent folder|Document tree|New documents|DS settings|Searching|Dokumentový strom|Nové dokumenty|Nastavení stromu|Vyhledávání/i.test(
+              file_name
+            );
+          const isSystemUrl =
+            /moje_dok\.pl|nove_dok\.pl|nastaveni_stromu\.pl|vyhledavani\.pl|index\.pl|clovek\.pl|dokumenty_ct\.pl/.test(
+              vUrl || ''
+            );
 
-                const type = sysid ? sysid.replace('mime-', '') : 'unknown';
-                if (type === 'prohlizeni-info') return;
-                
-                const existing = extractedFiles.find(f => f.link === vUrl);
-                if (existing) {
-                    if (existing.type === 'unknown' && type !== 'unknown') existing.type = type;
-                    return;
-                }
+          if (!vUrl || isSystemLabel || isSystemUrl) return;
 
-                extractedFiles.push({ name: file_name, type, link: vUrl });
-            });
+          const sysid = iconSysid(l);
+          if (sysid === 'mime-prohlizeni-info') return;
 
-            if (extractedFiles.length > 0) {
-                files.push({ subfolder, file_name, file_comment, author, date, files: extractedFiles });
-            }
-          } catch (e) {
-            if (e instanceof ParserError) logError('Parser.parseServerFiles', e, { snippet: e.snippet });
-            else throw e;
+          const type = sysid ? sysid.replace('mime-', '') : 'unknown';
+          if (type === 'prohlizeni-info') return;
+
+          const existing = extractedFiles.find((f) => f.link === vUrl);
+          if (existing) {
+            if (existing.type === 'unknown' && type !== 'unknown') existing.type = type;
+            return;
           }
+
+          extractedFiles.push({ name: file_name, type, link: vUrl });
         });
-    });
 
-    doc.querySelectorAll('a').forEach(a => {
-        const href = a.getAttribute('href');
-        if (href?.includes('slozka.pl') && !href.includes('download') && a.textContent?.trim().match(/^\d+[-–]\d+$/)) {
-            if (!paginationLinks.includes(href)) paginationLinks.push(href);
+        if (extractedFiles.length > 0) {
+          files.push({ subfolder, file_name, file_comment, author, date, files: extractedFiles });
         }
+      } catch (e) {
+        if (e instanceof ParserError)
+          logError('Parser.parseServerFiles', e, { snippet: e.snippet });
+        else throw e;
+      }
     });
+  });
 
-    // Try to find total records count (e.g. "1-10 z 24")
-    const bodyText = doc.body.textContent || '';
-    const totalMatch = bodyText.match(/(\d+)\s*[-–]\s*(\d+)\s+(?:z|of)\s+(\d+)/i);
-    if (totalMatch) {
-        totalRecords = parseInt(totalMatch[3], 10);
+  doc.querySelectorAll('a').forEach((a) => {
+    const href = a.getAttribute('href');
+    if (
+      href?.includes('slozka.pl') &&
+      !href.includes('download') &&
+      a.textContent?.trim().match(/^\d+[-–]\d+$/)
+    ) {
+      if (!paginationLinks.includes(href)) paginationLinks.push(href);
     }
+  });
 
-    return { files, paginationLinks, totalRecords };
+  // Try to find total records count (e.g. "1-10 z 24")
+  const bodyText = doc.body.textContent || '';
+  const totalMatch = bodyText.match(/(\d+)\s*[-–]\s*(\d+)\s+(?:z|of)\s+(\d+)/i);
+  if (totalMatch) {
+    totalRecords = parseInt(totalMatch[3], 10);
+  }
+
+  return { files, paginationLinks, totalRecords };
 }

--- a/src/components/Bulletin/MobileBulletinOverlay.tsx
+++ b/src/components/Bulletin/MobileBulletinOverlay.tsx
@@ -7,18 +7,18 @@ import type { BulletinPost } from '../../types/bulletin';
 const VYVESKA_URL = 'https://is.mendelu.cz/auth/vyveska/nove_prispevky.pl?zalozka=2';
 
 const DOT_COLOR: Record<string, string> = {
-  'Ubytování': 'bg-info',
-  'Housing':   'bg-info',
-  'Inzerce':   'bg-primary',
-  'Notice':    'bg-primary',
-  'Nabízím':   'bg-success',
-  'Offered':   'bg-success',
-  'Prodám':    'bg-success',
-  'Hledám':    'bg-warning',
-  'Wanted':    'bg-warning',
-  'Koupím':    'bg-warning',
-  'Ostatní':   'bg-base-content/40',
-  'Other':     'bg-base-content/40',
+  Ubytování: 'bg-info',
+  Housing: 'bg-info',
+  Inzerce: 'bg-primary',
+  Notice: 'bg-primary',
+  Nabízím: 'bg-success',
+  Offered: 'bg-success',
+  Prodám: 'bg-success',
+  Hledám: 'bg-warning',
+  Wanted: 'bg-warning',
+  Koupím: 'bg-warning',
+  Ostatní: 'bg-base-content/40',
+  Other: 'bg-base-content/40',
 };
 
 function dotColor(cat: string | undefined): string {
@@ -47,7 +47,9 @@ export function MobileBulletinOverlay({
   // background scrolling and rubber-banding don't bleed through the overlay.
   useEffect(() => {
     if (!isOpen) return;
-    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
     document.addEventListener('keydown', onKey);
     const previousOverflow = document.body.style.overflow;
     document.body.style.overflow = 'hidden';
@@ -60,7 +62,13 @@ export function MobileBulletinOverlay({
   if (!isOpen) return null;
 
   const content = (
-    <div className="fixed inset-0 z-50 bg-base-100 flex flex-col md:hidden">
+    <div
+      className="fixed inset-0 z-50 bg-base-100 flex flex-col md:hidden"
+      // Full-screen and top-anchored: at targetSdk 36 the WebView draws under
+      // the status bar and camera cutout, so this surface must inset itself.
+      // --safe-top is 0 off-device, making this a no-op on desktop.
+      style={{ paddingTop: 'var(--safe-top, 0px)' }}
+    >
       {/* Header */}
       <div className="flex items-center justify-between px-4 py-3 border-b border-base-300">
         <div className="flex items-center gap-3">
@@ -73,9 +81,7 @@ export function MobileBulletinOverlay({
           </button>
           <div className="flex items-center gap-2">
             <Pin className="w-4 h-4 text-primary" />
-            <h1 className="text-base font-bold text-base-content">
-              {t('bulletin.title')}
-            </h1>
+            <h1 className="text-base font-bold text-base-content">{t('bulletin.title')}</h1>
           </div>
         </div>
         <a
@@ -111,7 +117,10 @@ export function MobileBulletinOverlay({
         )}
 
         {!loading && error && posts.length === 0 && (
-          <div className="alert alert-error shadow-sm rounded-xl text-sm" data-testid="bulletin-error">
+          <div
+            className="alert alert-error shadow-sm rounded-xl text-sm"
+            data-testid="bulletin-error"
+          >
             <span>{t('bulletin.error')}</span>
           </div>
         )}
@@ -139,7 +148,9 @@ export function MobileBulletinOverlay({
               {/* Categories */}
               {post.categories.length > 0 && (
                 <div className="flex flex-wrap gap-1.5 items-center">
-                  <span className={`w-2 h-2 rounded-full flex-shrink-0 ${dotColor(mainCategory)}`} />
+                  <span
+                    className={`w-2 h-2 rounded-full flex-shrink-0 ${dotColor(mainCategory)}`}
+                  />
                   {post.categories.map((cat, cIdx) => (
                     <span
                       key={cIdx}

--- a/src/components/ErasmusPanel/__tests__/kontrolaFetch.test.tsx
+++ b/src/components/ErasmusPanel/__tests__/kontrolaFetch.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { ErasmusPanel } from '../index';
+
+/**
+ * `fetchKontrolaData` pulls the student's date of birth, and the ONLY thing that
+ * renders it is StudentInfoSection inside the Learning Agreement tab. The phone
+ * hides that tab (`showLearningAgreement={false}`), so opening the mobile
+ * Erasmus sheet was fetching a date of birth nothing could display.
+ *
+ * `getUserParams` is deliberately NOT gated the same way: the Explore tab's
+ * faculty filter reads `userParams.facultyLabel`, so gating it would break the
+ * one tab the phone does show.
+ */
+const fetchKontrolaData = vi.hoisted(() => vi.fn().mockResolvedValue(null));
+const getUserParams = vi.hoisted(() => vi.fn().mockResolvedValue(null));
+
+vi.mock('@/api/kontrola', () => ({ fetchKontrolaData }));
+vi.mock('@/utils/userParams', () => ({ getUserParams }));
+vi.mock('@/hooks/data/useErasmus', () => ({
+  useErasmus: () => ({
+    reports: [],
+    countryFile: null,
+    setCountry: vi.fn(),
+    loading: false,
+    config: null,
+  }),
+}));
+vi.mock('@/hooks/useStudyPlan', () => ({ useStudyPlan: () => null }));
+vi.mock('../EuropeMap', () => ({ EuropeMap: () => null }));
+vi.mock('../ErasmusDrawer', () => ({ ErasmusDrawer: () => null }));
+vi.mock('../StudentInfoSection', () => ({ StudentInfoSection: () => null }));
+vi.mock('../LATableA', () => ({ LATableA: () => null }));
+vi.mock('../ErasmusExportButton', () => ({ ErasmusExportButton: () => null }));
+
+const noop = () => {};
+
+describe('ErasmusPanel personal-data fetches', () => {
+  beforeEach(() => {
+    fetchKontrolaData.mockClear();
+    getUserParams.mockClear();
+  });
+
+  afterEach(cleanup);
+
+  it('does not read the date of birth when the Learning Agreement is hidden', () => {
+    render(
+      <ErasmusPanel onOpenSubject={noop} onSearchSubject={noop} showLearningAgreement={false} />
+    );
+    expect(fetchKontrolaData).not.toHaveBeenCalled();
+  });
+
+  it('still reads user params, which the Explore faculty filter needs', () => {
+    render(
+      <ErasmusPanel onOpenSubject={noop} onSearchSubject={noop} showLearningAgreement={false} />
+    );
+    expect(getUserParams).toHaveBeenCalled();
+  });
+
+  it('reads the date of birth when the Learning Agreement is shown', () => {
+    render(<ErasmusPanel onOpenSubject={noop} onSearchSubject={noop} />);
+    expect(fetchKontrolaData).toHaveBeenCalled();
+  });
+});

--- a/src/components/ErasmusPanel/index.tsx
+++ b/src/components/ErasmusPanel/index.tsx
@@ -15,30 +15,40 @@ import { fetchKontrolaData } from '@/api/kontrola';
 import type { StudyPlan } from '@/types/studyPlan';
 
 const FACULTY_ABBREV_TO_NAME: Record<string, string> = {
-  'PEF': 'Provozně ekonomická fakulta',
-  'AF': 'Agronomická fakulta',
-  'LDF': 'Lesnická a dřevařská fakulta',
-  'FRRMS': 'Fakulta regionálního rozvoje a mezinárodních studií',
-  'ZF': 'Zahradnická fakulta',
-  'ICV': 'Institut celoživotního vzdělávání',
+  PEF: 'Provozně ekonomická fakulta',
+  AF: 'Agronomická fakulta',
+  LDF: 'Lesnická a dřevařská fakulta',
+  FRRMS: 'Fakulta regionálního rozvoje a mezinárodních studií',
+  ZF: 'Zahradnická fakulta',
+  ICV: 'Institut celoživotního vzdělávání',
 };
 
 interface ErasmusPanelProps {
   onOpenSubject: (courseCode: string, courseName?: string, courseId?: string) => void;
   onSearchSubject: (name: string) => void;
+  /**
+   * Hides the Learning Agreement tab, leaving only Explore. Off on mobile: the
+   * LA is a wide two-table editing surface that does not belong on a phone.
+   * Defaults to shown so the desktop sidebar is untouched.
+   */
+  showLearningAgreement?: boolean;
 }
 
-export function ErasmusPanel({ onOpenSubject, onSearchSubject }: ErasmusPanelProps) {
+export function ErasmusPanel({
+  onOpenSubject,
+  onSearchSubject,
+  showLearningAgreement = true,
+}: ErasmusPanelProps) {
   const { t, language } = useTranslation();
   const lang = language === 'en' ? 'en' : 'cs';
   const { reports, countryFile, setCountry, loading, config } = useErasmus();
   const plan = useStudyPlan();
-  const tableBCourses = useAppStore(s => s.erasmusTableBCourses);
-  const tableAOptions = useAppStore(s => s.erasmusTableAOptions);
-  const addOption = useAppStore(s => s.addErasmusTableAOption);
-  const activeTab = useAppStore(s => s.erasmusActiveTab);
-  const setActiveTab = useAppStore(s => s.setErasmusActiveTab);
-  const loadState = useAppStore(s => s.loadErasmusState);
+  const tableBCourses = useAppStore((s) => s.erasmusTableBCourses);
+  const tableAOptions = useAppStore((s) => s.erasmusTableAOptions);
+  const addOption = useAppStore((s) => s.addErasmusTableAOption);
+  const activeTab = useAppStore((s) => s.erasmusActiveTab);
+  const setActiveTab = useAppStore((s) => s.setErasmusActiveTab);
+  const loadState = useAppStore((s) => s.loadErasmusState);
 
   useEffect(() => {
     loadState();
@@ -49,7 +59,7 @@ export function ErasmusPanel({ onOpenSubject, onSearchSubject }: ErasmusPanelPro
   const [facultyFilter, setFacultyFilter] = useState(false);
   const [userParams, setUserParams] = useState<UserParams | null>(null);
   const [showAll, setShowAll] = useState(false);
-  
+
   // Track if we are "Peeking" (temp viewing) vs "Planning" (committing)
   const previousCountryRef = useRef<string | null>(null);
   const isPeekingRef = useRef(false);
@@ -58,7 +68,7 @@ export function ErasmusPanel({ onOpenSubject, onSearchSubject }: ErasmusPanelPro
 
   useEffect(() => {
     getUserParams().then(setUserParams);
-    fetchKontrolaData().then(data => {
+    fetchKontrolaData().then((data) => {
       if (!data) return;
       const [year, month, day] = data.datumNarozeni.split('-');
       const formatted = `${day}.${month}.${year}`;
@@ -66,18 +76,26 @@ export function ErasmusPanel({ onOpenSubject, onSearchSubject }: ErasmusPanelPro
     });
   }, []);
 
-  const currentCountry = useMemo(() => ERASMUS_COUNTRIES.find(c => c.file === countryFile), [countryFile]);
+  const currentCountry = useMemo(
+    () => ERASMUS_COUNTRIES.find((c) => c.file === countryFile),
+    [countryFile]
+  );
   const countryName = currentCountry ? currentCountry[lang] : '';
   const currentCountryId = currentCountry?.id ?? '';
 
-  const schools = useMemo(() => Array.from(new Set(reports.map(r => r.host.name))).sort(), [reports]);
+  const schools = useMemo(
+    () => Array.from(new Set(reports.map((r) => r.host.name))).sort(),
+    [reports]
+  );
 
   const filteredReports = useMemo(() => {
-    let base = reports.filter(r => r.stay.durationMonths > 2);
-    if (schoolFilter) base = base.filter(r => r.host.name === schoolFilter);
-    const fullFaculty = facultyFilter && userParams?.facultyLabel
-      ? FACULTY_ABBREV_TO_NAME[userParams.facultyLabel] : null;
-    if (fullFaculty) base = base.filter(r => r.student.faculty === fullFaculty);
+    let base = reports.filter((r) => r.stay.durationMonths > 2);
+    if (schoolFilter) base = base.filter((r) => r.host.name === schoolFilter);
+    const fullFaculty =
+      facultyFilter && userParams?.facultyLabel
+        ? FACULTY_ABBREV_TO_NAME[userParams.facultyLabel]
+        : null;
+    if (fullFaculty) base = base.filter((r) => r.student.faculty === fullFaculty);
     return base;
   }, [reports, schoolFilter, facultyFilter, userParams]);
 
@@ -85,32 +103,35 @@ export function ErasmusPanel({ onOpenSubject, onSearchSubject }: ErasmusPanelPro
     return showAll ? filteredReports : filteredReports.slice(0, 10);
   }, [filteredReports, showAll]);
 
-  const handleViewReports = useCallback((file: string, schoolName: string | null, isPermanent: boolean = false) => {
-    // If permanent, we update the store and ensure we don't restore later.
-    // If temporary (peek), we save the previous state to restore on close.
-    if (isPermanent) {
-      setCountry(file);
-      isPeekingRef.current = false;
-      previousCountryRef.current = null;
-    } else if (file !== countryFile) {
-      previousCountryRef.current = countryFile || null;
-      isPeekingRef.current = true;
-      setCountry(file);
-    }
-    setSchoolFilter(schoolName);
-    setDrawerOpen(true);
-  }, [setCountry, countryFile]);
+  const handleViewReports = useCallback(
+    (file: string, schoolName: string | null, isPermanent: boolean = false) => {
+      // If permanent, we update the store and ensure we don't restore later.
+      // If temporary (peek), we save the previous state to restore on close.
+      if (isPermanent) {
+        setCountry(file);
+        isPeekingRef.current = false;
+        previousCountryRef.current = null;
+      } else if (file !== countryFile) {
+        previousCountryRef.current = countryFile || null;
+        isPeekingRef.current = true;
+        setCountry(file);
+      }
+      setSchoolFilter(schoolName);
+      setDrawerOpen(true);
+    },
+    [setCountry, countryFile]
+  );
 
   const handleTabChange = (tab: 'plan' | 'explore') => {
     setActiveTab(tab);
     if (tab === 'plan') {
-       // Close drawer and restore original country if we were just peeking
-       setDrawerOpen(false);
-       if (isPeekingRef.current) {
-         setCountry(previousCountryRef.current || '');
-         isPeekingRef.current = false;
-         previousCountryRef.current = null;
-       }
+      // Close drawer and restore original country if we were just peeking
+      setDrawerOpen(false);
+      if (isPeekingRef.current) {
+        setCountry(previousCountryRef.current || '');
+        isPeekingRef.current = false;
+        previousCountryRef.current = null;
+      }
     }
   };
 
@@ -124,17 +145,29 @@ export function ErasmusPanel({ onOpenSubject, onSearchSubject }: ErasmusPanelPro
     }
   }, [setCountry]);
 
-  const hasAnyCoursesSelected = Object.values(tableBCourses).some(arr => arr.length > 0);
+  const hasAnyCoursesSelected = Object.values(tableBCourses).some((arr) => arr.length > 0);
+
+  // The store's activeTab persists, so a student who last used 'plan' on desktop
+  // would otherwise land on a tab this render has no button for — and no way
+  // back. Resolving it here rather than writing to the store keeps the desktop
+  // preference intact.
+  const tabs = showLearningAgreement ? (['plan', 'explore'] as const) : (['explore'] as const);
+  const currentTab = showLearningAgreement ? activeTab : 'explore';
 
   return (
     <div className="h-full flex flex-col">
-      <div className="flex items-center gap-1 px-4 pt-3 pb-1 border-b border-base-300">
-        {(['plan', 'explore'] as const).map(tab => (
+      {/* One tab is not a tab bar. */}
+      <div
+        className={`flex items-center gap-1 px-4 pt-3 pb-1 border-b border-base-300 ${
+          tabs.length > 1 ? '' : 'hidden'
+        }`}
+      >
+        {tabs.map((tab) => (
           <button
             key={tab}
             onClick={() => handleTabChange(tab)}
             className={`px-3 py-1.5 rounded-t-lg text-xs font-bold transition-all border-b-2 ${
-              activeTab === tab
+              currentTab === tab
                 ? 'border-primary text-primary bg-primary/5'
                 : 'border-transparent text-base-content/40 hover:text-base-content/60'
             }`}
@@ -144,12 +177,12 @@ export function ErasmusPanel({ onOpenSubject, onSearchSubject }: ErasmusPanelPro
         ))}
       </div>
 
-      {activeTab === 'plan' && (
+      {currentTab === 'plan' && (
         <div className="flex-1 overflow-y-auto px-4 py-3 flex flex-col gap-5">
           <StudentInfoSection userParams={userParams} dob={dob} />
 
           <LATableA
-            plan={plan ?? { blocks: [] } as unknown as StudyPlan}
+            plan={plan ?? ({ blocks: [] } as unknown as StudyPlan)}
             onOpenSubject={onOpenSubject}
             onSearchSubject={onSearchSubject}
             onViewReports={handleViewReports}
@@ -163,7 +196,9 @@ export function ErasmusPanel({ onOpenSubject, onSearchSubject }: ErasmusPanelPro
                   className="btn btn-ghost btn-sm rounded-full px-4 h-8 text-base-content/40 hover:text-base-content/70 border border-base-300 hover:border-base-content/20 font-normal"
                 >
                   <Plus size={14} className="opacity-70" />
-                  <span className="font-bold text-xs">{t('erasmus.addOption', { n: (tableAOptions.length + 1).toString() })}</span>
+                  <span className="font-bold text-xs">
+                    {t('erasmus.addOption', { n: (tableAOptions.length + 1).toString() })}
+                  </span>
                 </button>
               )}
               {hasAnyCoursesSelected && (
@@ -178,13 +213,13 @@ export function ErasmusPanel({ onOpenSubject, onSearchSubject }: ErasmusPanelPro
                 </a>
               )}
             </div>
-            
+
             <ErasmusExportButton className="btn-primary" />
           </div>
         </div>
       )}
 
-      {activeTab === 'explore' && (
+      {currentTab === 'explore' && (
         <div className="flex-1 min-h-0 px-4 pb-4 pt-2 flex flex-col gap-2">
           <div className="flex items-start gap-2 px-1 py-1.5 text-[10px] text-base-content/50 leading-relaxed">
             <Info size={12} className="shrink-0 mt-0.5 text-info" />
@@ -193,8 +228,8 @@ export function ErasmusPanel({ onOpenSubject, onSearchSubject }: ErasmusPanelPro
           <div className="bg-base-200/50 rounded-xl p-2 border border-base-300 flex-1 min-h-0">
             <EuropeMap
               selectedCountryId={drawerOpen ? currentCountryId : ''}
-              onSelectCountry={id => {
-                const c = ERASMUS_COUNTRIES.find(e => e.id === id);
+              onSelectCountry={(id) => {
+                const c = ERASMUS_COUNTRIES.find((e) => e.id === id);
                 if (c) handleViewReports(c.file, null);
               }}
               lang={lang}

--- a/src/components/ErasmusPanel/index.tsx
+++ b/src/components/ErasmusPanel/index.tsx
@@ -67,14 +67,21 @@ export function ErasmusPanel({
   const [dob, setDob] = useState('');
 
   useEffect(() => {
+    // getUserParams is unconditional: the Explore tab's faculty filter reads
+    // userParams.facultyLabel, and Explore is the one tab the phone shows.
     getUserParams().then(setUserParams);
+    // The date of birth is not. It renders in exactly one place —
+    // StudentInfoSection, inside the Learning Agreement tab — so with the LA
+    // hidden this was pulling a student's birth date that nothing could
+    // display. Fetch no personal data a surface cannot render.
+    if (!showLearningAgreement) return;
     fetchKontrolaData().then((data) => {
       if (!data) return;
       const [year, month, day] = data.datumNarozeni.split('-');
       const formatted = `${day}.${month}.${year}`;
       setDob(formatted);
     });
-  }, []);
+  }, [showLearningAgreement]);
 
   const currentCountry = useMemo(
     () => ERASMUS_COUNTRIES.find((c) => c.file === countryFile),

--- a/src/components/Events/EventsDropdown.tsx
+++ b/src/components/Events/EventsDropdown.tsx
@@ -1,6 +1,7 @@
 import { X, Newspaper } from 'lucide-react';
 import { createPortal } from 'react-dom';
 import { EventItem } from './EventItem';
+import { openExternal } from '../../mobile/openExternal';
 import { useEventsFacultySettings } from '../../hooks/useEventsFacultySettings';
 import { useTranslation } from '../../hooks/useTranslation';
 import { useIsMobile } from '../../hooks/ui/useIsMobile';
@@ -68,7 +69,12 @@ export function EventsDropdown({ events, loading, onClose, dropdownRef }: Events
               key={`${e.url}-${i}`}
               event={e}
               onClick={() => {
-                window.open(e.url, '_blank');
+                // openExternal, not window.open: this dropdown portals to a
+                // full-screen mobile surface too, and on Capacitor window.open
+                // hands the URL to the system browser. Off Capacitor it opens
+                // with noopener,noreferrer so the event page keeps no handle on
+                // the opener.
+                void openExternal(e.url);
                 onClose();
               }}
             />

--- a/src/components/Events/EventsDropdown.tsx
+++ b/src/components/Events/EventsDropdown.tsx
@@ -19,7 +19,7 @@ function FacultyFilters() {
 
   return (
     <div className="flex gap-1.5 px-4 py-2 overflow-x-auto border-b border-base-300">
-      {ALL_FACULTY_KEYS.map(key => {
+      {ALL_FACULTY_KEYS.map((key) => {
         const org = ORGANIZERS[key];
         const active = isSubscribed(key);
         return (
@@ -46,7 +46,9 @@ export function EventsDropdown({ events, loading, onClose, dropdownRef }: Events
   const isMobile = useIsMobile();
 
   const today = new Date();
-  const dayName = today.toLocaleDateString(language === 'en' ? 'en-US' : 'cs-CZ', { weekday: 'long' });
+  const dayName = today.toLocaleDateString(language === 'en' ? 'en-US' : 'cs-CZ', {
+    weekday: 'long',
+  });
   const dateStr = `${language === 'en' ? dayName : dayName.toLowerCase()} ${today.getDate()}.${today.getMonth() + 1}.`;
 
   const content = (
@@ -62,7 +64,14 @@ export function EventsDropdown({ events, loading, onClose, dropdownRef }: Events
       ) : (
         <div className="divide-y divide-base-300">
           {events.map((e, i) => (
-            <EventItem key={`${e.url}-${i}`} event={e} onClick={() => { window.open(e.url, '_blank'); onClose(); }} />
+            <EventItem
+              key={`${e.url}-${i}`}
+              event={e}
+              onClick={() => {
+                window.open(e.url, '_blank');
+                onClose();
+              }}
+            />
           ))}
         </div>
       )}
@@ -71,12 +80,21 @@ export function EventsDropdown({ events, loading, onClose, dropdownRef }: Events
 
   if (isMobile) {
     return createPortal(
-      <div ref={dropdownRef} className="fixed inset-0 z-50 bg-base-100 flex flex-col">
+      <div
+        ref={dropdownRef}
+        className="fixed inset-0 z-50 bg-base-100 flex flex-col"
+        // Full-screen and top-anchored: at targetSdk 36 the WebView draws under
+        // the status bar and camera cutout, so this surface must inset itself.
+        // --safe-top is 0 off-device, making this a no-op on desktop.
+        style={{ paddingTop: 'var(--safe-top, 0px)' }}
+      >
         <div className="flex items-center justify-between px-4 py-3 border-b border-base-300">
           <h3 className="font-semibold text-lg text-base-content whitespace-nowrap overflow-hidden">
             {t('events.title')} <span className="opacity-40 font-normal ml-1">- {dateStr}</span>
           </h3>
-          <button onClick={onClose} className="p-1 hover:bg-base-300 rounded ml-2 flex-shrink-0"><X size={20} /></button>
+          <button onClick={onClose} className="p-1 hover:bg-base-300 rounded ml-2 flex-shrink-0">
+            <X size={20} />
+          </button>
         </div>
         <div className="flex-1 overflow-y-auto">{content}</div>
       </div>,
@@ -85,12 +103,17 @@ export function EventsDropdown({ events, loading, onClose, dropdownRef }: Events
   }
 
   return (
-    <div ref={dropdownRef} className="absolute right-0 top-12 z-50 w-96 bg-base-100 border border-base-300 rounded-lg shadow-xl max-h-[400px] overflow-hidden flex flex-col">
+    <div
+      ref={dropdownRef}
+      className="absolute right-0 top-12 z-50 w-96 bg-base-100 border border-base-300 rounded-lg shadow-xl max-h-[400px] overflow-hidden flex flex-col"
+    >
       <div className="flex items-center justify-between px-4 py-3 border-b border-base-300">
         <h3 className="font-semibold text-lg text-base-content whitespace-nowrap overflow-hidden">
           {t('events.title')} <span className="opacity-40 font-normal ml-1">- {dateStr}</span>
         </h3>
-        <button onClick={onClose} className="p-1 hover:bg-base-300 rounded ml-2 flex-shrink-0"><X size={16} /></button>
+        <button onClick={onClose} className="p-1 hover:bg-base-300 rounded ml-2 flex-shrink-0">
+          <X size={16} />
+        </button>
       </div>
       <div className="flex-1 overflow-y-auto">{content}</div>
     </div>

--- a/src/components/Feedback/FeedbackModal.tsx
+++ b/src/components/Feedback/FeedbackModal.tsx
@@ -5,6 +5,7 @@ import { DISCORD_WEBHOOK_URL } from '../../constants/config';
 import { toast } from 'sonner';
 import { useTranslation } from '../../hooks/useTranslation';
 import { logError } from '../../utils/reportError';
+import { useAppStore } from '../../store/useAppStore';
 
 interface FeedbackModalProps {
   isOpen: boolean;
@@ -19,6 +20,10 @@ export function FeedbackModal({ isOpen, onClose }: FeedbackModalProps) {
   const [isSending, setIsSending] = useState(false);
   const [isSuccess, setIsSuccess] = useState(false);
   const { t } = useTranslation();
+  // Phones get a bottom sheet, not a centred dialog: a floating card with a
+  // blurred backdrop is a desktop idiom, and every other mobile surface here
+  // rises from the bottom edge.
+  const isPhone = useAppStore((s) => s.isTouch && s.isNarrow);
 
   const handleSubmit = async (e?: React.SyntheticEvent) => {
     if (e) e.preventDefault();
@@ -28,14 +33,14 @@ export function FeedbackModal({ isOpen, onClose }: FeedbackModalProps) {
       version: '4.0.0', // Updated for next release
       url: window.location.href,
       userAgent: navigator.userAgent,
-      screen: `${window.innerWidth}x${window.innerHeight}`
+      screen: `${window.innerWidth}x${window.innerHeight}`,
     };
 
     const payload = {
-      username: "reIS Feedback Bot",
-      avatar_url: "https://is.mendelu.cz/auth/images/logo_mendelu.png", // Using university logo
+      username: 'reIS Feedback Bot',
+      avatar_url: 'https://is.mendelu.cz/auth/images/logo_mendelu.png', // Using university logo
       thread_name: `[${type.toUpperCase()}] ${title}`, // For Forum Channels
-      content: `**Typ:** ${type}\n**Kontakt:** ${contact || 'N/A'}\n**Zpráva:**\n${message}\n\n__Technické info:__\n\`\`\`json\n${JSON.stringify(contextData, null, 2)}\n\`\`\``
+      content: `**Typ:** ${type}\n**Kontakt:** ${contact || 'N/A'}\n**Zpráva:**\n${message}\n\n__Technické info:__\n\`\`\`json\n${JSON.stringify(contextData, null, 2)}\n\`\`\``,
     };
 
     try {
@@ -44,7 +49,7 @@ export function FeedbackModal({ isOpen, onClose }: FeedbackModalProps) {
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify(payload)
+        body: JSON.stringify(payload),
       });
 
       if (response.ok) {
@@ -76,20 +81,28 @@ export function FeedbackModal({ isOpen, onClose }: FeedbackModalProps) {
   return (
     <AnimatePresence>
       {isOpen && (
-        <div className="fixed inset-0 z-[60] flex items-center justify-center px-4">
-          <motion.div 
+        <div
+          className={`fixed inset-0 z-[60] flex justify-center ${
+            isPhone ? 'items-end px-0' : 'items-center px-4'
+          }`}
+        >
+          <motion.div
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
             className="absolute inset-0 bg-black/60 backdrop-blur-sm"
             onClick={handleClose}
           />
-          
-          <motion.div 
-            initial={{ opacity: 0, scale: 0.95, y: 10 }}
-            animate={{ opacity: 1, scale: 1, y: 0 }}
-            exit={{ opacity: 0, scale: 0.95, y: 10 }}
-            className="w-full max-w-md bg-base-100 rounded-2xl shadow-2xl border border-base-300 overflow-hidden relative z-10"
+
+          <motion.div
+            initial={isPhone ? { y: '100%' } : { opacity: 0, scale: 0.95, y: 10 }}
+            animate={isPhone ? { y: 0 } : { opacity: 1, scale: 1, y: 0 }}
+            exit={isPhone ? { y: '100%' } : { opacity: 0, scale: 0.95, y: 10 }}
+            className={`w-full bg-base-100 shadow-2xl border-base-300 overflow-hidden relative z-10 ${
+              isPhone
+                ? 'max-w-none rounded-t-[20px] border-t max-h-[85dvh] overflow-y-auto'
+                : 'max-w-md rounded-2xl border'
+            }`}
           >
             {/* Header */}
             <div className="flex items-center justify-between px-6 py-4 border-b border-base-300/50">
@@ -105,127 +118,130 @@ export function FeedbackModal({ isOpen, onClose }: FeedbackModalProps) {
 
             {/* Content */}
             <div className="p-6">
-               {isSuccess ? (
-                  <div className="flex flex-col items-center justify-center py-8 text-center space-y-4">
-                    <div className="w-16 h-16 rounded-full bg-success/10 flex items-center justify-center text-success mb-2">
-                       <CheckCircle2 className="w-8 h-8" />
-                    </div>
-                    <h3 className="text-xl font-bold text-base-content">{t('feedback.successTitle')}</h3>
-                    <p className="text-base-content/60 max-w-xs">
-                      {t('feedback.successText')}
-                    </p>
-                    <button 
-                      onClick={handleClose}
-                      className="btn btn-primary w-full mt-4"
-                    >
-                      {t('feedback.close')}
-                    </button>
+              {isSuccess ? (
+                <div className="flex flex-col items-center justify-center py-8 text-center space-y-4">
+                  <div className="w-16 h-16 rounded-full bg-success/10 flex items-center justify-center text-success mb-2">
+                    <CheckCircle2 className="w-8 h-8" />
                   </div>
-                ) : (
-                  <div className="space-y-4">
-                    
-                    {/* Type Selection */}
-                    <div className="flex flex-col gap-1.5">
-                      <label className="text-sm font-medium text-base-content/60 ml-1">{t('feedback.typeLabel')}</label>
-                      <div className="grid grid-cols-3 gap-2">
-                         <button
-                           type="button"
-                           onClick={() => setType('bug')}
-                           className={`btn btn-sm border-0 ${type === 'bug' ? 'bg-error/20 text-error hover:bg-error/30' : 'bg-base-200 text-base-content/60 hover:bg-base-300 hover:text-base-content'}`}
-                         >
-                           {t('feedback.bug')}
-                         </button>
-                         <button
-                           type="button"
-                           onClick={() => setType('idea')}
-                           className={`btn btn-sm border-0 ${type === 'idea' ? 'bg-warning/20 text-warning hover:bg-warning/30' : 'bg-base-200 text-base-content/60 hover:bg-base-300 hover:text-base-content'}`}
-                         >
-                           {t('feedback.idea')}
-                         </button>
-                         <button
-                           type="button"
-                           onClick={() => setType('other')}
-                           className={`btn btn-sm border-0 ${type === 'other' ? 'bg-neutral text-neutral-content hover:bg-neutral/80' :'bg-base-200 text-base-content/60 hover:bg-base-300 hover:text-base-content'}`}
-                         >
-                           {t('feedback.other')}
-                         </button>
-                      </div>
-                    </div>
-
-                    {/* Title */}
-                    <div className="form-control">
-                      <label className="label pt-0 pb-1">
-                        <span className="text-sm font-medium text-base-content/60">{t('feedback.subject')}</span>
-                      </label>
-                      <input 
-                        type="text" 
-                        value={title}
-                        onChange={(e) => setTitle(e.target.value)}
-                        placeholder={t('feedback.subjectPlaceholder')}
-                        className="input input-bordered w-full bg-base-200 border-base-300 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary/20 text-base-content transition-colors"
-                        required
-                        autoFocus
-                        onKeyDown={(e) => e.key === 'Enter' && handleSubmit()}
-                      />
-                    </div>
-
-                    {/* Message */}
-                    <div className="form-control">
-                      <label className="label pt-0 pb-1">
-                        <span className="text-sm font-medium text-base-content/60">{t('feedback.description')}</span>
-                      </label>
-                      <textarea 
-                        value={message}
-                        onChange={(e) => setMessage(e.target.value)}
-                        placeholder={t('feedback.descriptionPlaceholder')}
-                        className="textarea textarea-bordered h-32 w-full bg-base-200 border-base-300 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary/20 text-base-content transition-colors leading-relaxed resize-none"
-                        required
-                      />
-                    </div>
-
-                    {/* Contact (Optional) */}
-                    <div className="form-control">
-                      <label className="label pt-0 pb-1">
-                        <span className="text-sm font-medium text-base-content/60">{t('feedback.contact')}</span>
-                      </label>
-                      <input 
-                        type="text" 
-                        value={contact}
-                        onChange={(e) => setContact(e.target.value)}
-                        placeholder={t('feedback.contactPlaceholder')}
-                        className="input input-bordered w-full bg-base-200 border-base-300 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary/20 text-base-content transition-colors"
-                        onKeyDown={(e) => e.key === 'Enter' && handleSubmit()}
-                      />
-                    </div>
-
-                    {/* Submit Button */}
-                    <div className="pt-2">
-                       <button 
+                  <h3 className="text-xl font-bold text-base-content">
+                    {t('feedback.successTitle')}
+                  </h3>
+                  <p className="text-base-content/60 max-w-xs">{t('feedback.successText')}</p>
+                  <button onClick={handleClose} className="btn btn-primary w-full mt-4">
+                    {t('feedback.close')}
+                  </button>
+                </div>
+              ) : (
+                <div className="space-y-4">
+                  {/* Type Selection */}
+                  <div className="flex flex-col gap-1.5">
+                    <label className="text-sm font-medium text-base-content/60 ml-1">
+                      {t('feedback.typeLabel')}
+                    </label>
+                    <div className="grid grid-cols-3 gap-2">
+                      <button
                         type="button"
-                        onClick={handleSubmit} 
-                        disabled={isSending || !title || !message}
-                        className="btn btn-primary w-full gap-2 font-semibold no-animation"
+                        onClick={() => setType('bug')}
+                        className={`btn btn-sm border-0 ${type === 'bug' ? 'bg-error/20 text-error hover:bg-error/30' : 'bg-base-200 text-base-content/60 hover:bg-base-300 hover:text-base-content'}`}
                       >
-                        {isSending ? (
-                          <>
-                            <Loader2 className="w-5 h-5 animate-spin" />
-                            {t('feedback.sending')}
-                          </>
-                        ) : (
-                          <>
-                            <Send className="w-5 h-5" />
-                            {t('feedback.submit')}
-                          </>
-                        )}
+                        {t('feedback.bug')}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setType('idea')}
+                        className={`btn btn-sm border-0 ${type === 'idea' ? 'bg-warning/20 text-warning hover:bg-warning/30' : 'bg-base-200 text-base-content/60 hover:bg-base-300 hover:text-base-content'}`}
+                      >
+                        {t('feedback.idea')}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setType('other')}
+                        className={`btn btn-sm border-0 ${type === 'other' ? 'bg-neutral text-neutral-content hover:bg-neutral/80' : 'bg-base-200 text-base-content/60 hover:bg-base-300 hover:text-base-content'}`}
+                      >
+                        {t('feedback.other')}
                       </button>
                     </div>
-                    
-                    <p className="text-[10px] text-center text-base-content/50 mt-2">
-                      {t('feedback.footer')}
-                    </p>
-
                   </div>
-               )}
+
+                  {/* Title */}
+                  <div className="form-control">
+                    <label className="label pt-0 pb-1">
+                      <span className="text-sm font-medium text-base-content/60">
+                        {t('feedback.subject')}
+                      </span>
+                    </label>
+                    <input
+                      type="text"
+                      value={title}
+                      onChange={(e) => setTitle(e.target.value)}
+                      placeholder={t('feedback.subjectPlaceholder')}
+                      className="input input-bordered w-full bg-base-200 border-base-300 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary/20 text-base-content transition-colors"
+                      required
+                      autoFocus
+                      onKeyDown={(e) => e.key === 'Enter' && handleSubmit()}
+                    />
+                  </div>
+
+                  {/* Message */}
+                  <div className="form-control">
+                    <label className="label pt-0 pb-1">
+                      <span className="text-sm font-medium text-base-content/60">
+                        {t('feedback.description')}
+                      </span>
+                    </label>
+                    <textarea
+                      value={message}
+                      onChange={(e) => setMessage(e.target.value)}
+                      placeholder={t('feedback.descriptionPlaceholder')}
+                      className="textarea textarea-bordered h-32 w-full bg-base-200 border-base-300 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary/20 text-base-content transition-colors leading-relaxed resize-none"
+                      required
+                    />
+                  </div>
+
+                  {/* Contact (Optional) */}
+                  <div className="form-control">
+                    <label className="label pt-0 pb-1">
+                      <span className="text-sm font-medium text-base-content/60">
+                        {t('feedback.contact')}
+                      </span>
+                    </label>
+                    <input
+                      type="text"
+                      value={contact}
+                      onChange={(e) => setContact(e.target.value)}
+                      placeholder={t('feedback.contactPlaceholder')}
+                      className="input input-bordered w-full bg-base-200 border-base-300 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary/20 text-base-content transition-colors"
+                      onKeyDown={(e) => e.key === 'Enter' && handleSubmit()}
+                    />
+                  </div>
+
+                  {/* Submit Button */}
+                  <div className="pt-2">
+                    <button
+                      type="button"
+                      onClick={handleSubmit}
+                      disabled={isSending || !title || !message}
+                      className="btn btn-primary w-full gap-2 font-semibold no-animation"
+                    >
+                      {isSending ? (
+                        <>
+                          <Loader2 className="w-5 h-5 animate-spin" />
+                          {t('feedback.sending')}
+                        </>
+                      ) : (
+                        <>
+                          <Send className="w-5 h-5" />
+                          {t('feedback.submit')}
+                        </>
+                      )}
+                    </button>
+                  </div>
+
+                  <p className="text-[10px] text-center text-base-content/50 mt-2">
+                    {t('feedback.footer')}
+                  </p>
+                </div>
+              )}
             </div>
           </motion.div>
         </div>

--- a/src/components/Notifications/NotificationDropdown.tsx
+++ b/src/components/Notifications/NotificationDropdown.tsx
@@ -1,6 +1,7 @@
 import { Bell, X } from 'lucide-react';
 import { createPortal } from 'react-dom';
 import { NotificationItem } from './NotificationItem';
+import { openExternal } from '../../mobile/openExternal';
 import { DeadlineAlertItem } from './DeadlineAlertItem';
 import { trackNotificationClick } from '../../services/spolky';
 import { useTranslation } from '../../hooks/useTranslation';
@@ -61,7 +62,12 @@ export function NotificationDropdown({
               onClick={() => {
                 if (n.link) {
                   if (!n.associationId?.startsWith('academic_')) trackNotificationClick(n.id);
-                  window.open(n.link, '_blank');
+                  // openExternal, not window.open: this dropdown portals to a
+                  // full-screen mobile surface too, and on Capacitor
+                  // window.open hands the URL to the system browser. It also
+                  // validates the link — a notification's URL is data from
+                  // outside the app — and adds noopener,noreferrer elsewhere.
+                  void openExternal(n.link);
                   onClose();
                 }
               }}

--- a/src/components/Notifications/NotificationDropdown.tsx
+++ b/src/components/Notifications/NotificationDropdown.tsx
@@ -19,46 +19,74 @@ interface NotificationDropdownProps {
   deadlineAlerts: DeadlineAlert[];
 }
 
-export function NotificationDropdown({ notifications, loading, onClose, onVisible, dropdownRef, deadlineAlerts }: NotificationDropdownProps) {
+export function NotificationDropdown({
+  notifications,
+  loading,
+  onClose,
+  onVisible,
+  dropdownRef,
+  deadlineAlerts,
+}: NotificationDropdownProps) {
   const { t } = useTranslation();
   const isMobile = useIsMobile();
-  const hasStudyJamContent = useAppStore(s => s.studyJamSuggestions.length > 0 || s.studyJamMatch !== null);
+  const hasStudyJamContent = useAppStore(
+    (s) => s.studyJamSuggestions.length > 0 || s.studyJamMatch !== null
+  );
   const hasContent = notifications.length > 0 || hasStudyJamContent || deadlineAlerts.length > 0;
 
   const notificationList = (
     <>
       {deadlineAlerts.length > 0 && (
         <div className="divide-y divide-base-300">
-          {deadlineAlerts.map(alert => (
+          {deadlineAlerts.map((alert) => (
             <DeadlineAlertItem key={alert.id} alert={alert} />
           ))}
         </div>
       )}
       <StudyJamSuggestions onClose={onClose} />
-      {(loading && !notifications.length) ? <div className="p-4 text-center text-base-content/60">{t('notifications.loading')}</div> :
-       (!hasContent) ? <div className="p-8 text-center text-base-content/60"><Bell size={48} className="mx-auto mb-2 opacity-40" /><p>{t('notifications.empty')}</p></div> :
+      {loading && !notifications.length ? (
+        <div className="p-4 text-center text-base-content/60">{t('notifications.loading')}</div>
+      ) : !hasContent ? (
+        <div className="p-8 text-center text-base-content/60">
+          <Bell size={48} className="mx-auto mb-2 opacity-40" />
+          <p>{t('notifications.empty')}</p>
+        </div>
+      ) : (
         <div className="divide-y divide-base-300">
           {notifications.map((n) => (
-            <NotificationItem key={n.id} notification={n} onVisible={() => onVisible(n.id)}
+            <NotificationItem
+              key={n.id}
+              notification={n}
+              onVisible={() => onVisible(n.id)}
               onClick={() => {
                 if (n.link) {
                   if (!n.associationId?.startsWith('academic_')) trackNotificationClick(n.id);
                   window.open(n.link, '_blank');
                   onClose();
                 }
-              }} />
+              }}
+            />
           ))}
         </div>
-      }
+      )}
     </>
   );
 
   if (isMobile) {
     return createPortal(
-      <div ref={dropdownRef} className="fixed inset-0 z-50 bg-base-100 flex flex-col">
+      <div
+        ref={dropdownRef}
+        className="fixed inset-0 z-50 bg-base-100 flex flex-col"
+        // Full-screen and top-anchored: at targetSdk 36 the WebView draws under
+        // the status bar and camera cutout, so this surface must inset itself.
+        // --safe-top is 0 off-device, making this a no-op on desktop.
+        style={{ paddingTop: 'var(--safe-top, 0px)' }}
+      >
         <div className="flex items-center justify-between px-4 py-3 border-b border-base-300">
           <h3 className="font-semibold text-lg text-base-content">{t('notifications.title')}</h3>
-          <button onClick={onClose} className="p-1 hover:bg-base-300 rounded"><X size={20} /></button>
+          <button onClick={onClose} className="p-1 hover:bg-base-300 rounded">
+            <X size={20} />
+          </button>
         </div>
         <div className="flex-1 overflow-y-auto">{notificationList}</div>
       </div>,
@@ -67,10 +95,15 @@ export function NotificationDropdown({ notifications, loading, onClose, onVisibl
   }
 
   return (
-    <div ref={dropdownRef} className="absolute right-0 top-12 z-50 w-96 bg-base-100 border border-base-300 rounded-lg shadow-xl max-h-[320px] overflow-hidden flex flex-col">
+    <div
+      ref={dropdownRef}
+      className="absolute right-0 top-12 z-50 w-96 bg-base-100 border border-base-300 rounded-lg shadow-xl max-h-[320px] overflow-hidden flex flex-col"
+    >
       <div className="flex items-center justify-between px-4 py-3 border-b border-base-300">
         <h3 className="font-semibold text-lg text-base-content">{t('notifications.title')}</h3>
-        <button onClick={onClose} className="p-1 hover:bg-base-300 rounded"><X size={16} /></button>
+        <button onClick={onClose} className="p-1 hover:bg-base-300 rounded">
+          <X size={16} />
+        </button>
       </div>
       <div className="flex-1 overflow-y-auto">{notificationList}</div>
     </div>

--- a/src/components/SubjectFileDrawer/ClassmatesTab.tsx
+++ b/src/components/SubjectFileDrawer/ClassmatesTab.tsx
@@ -10,133 +10,147 @@ import { PersonPhoto } from '../ui/PersonPhoto';
 import type { Classmate } from '../../types/classmates';
 
 interface ClassmatesTabProps {
-    courseCode: string;
+  /** Off for the phone sheet, which pins its own IS MENDELU footer. */
+  showIsBacklink?: boolean;
+  courseCode: string;
 }
 
-export function ClassmatesTab({ courseCode }: ClassmatesTabProps) {
-    const { t, language } = useTranslation();
-    const [searchQuery, setSearchQuery] = useState('');
-    const [selected, setSelected] = useState<Classmate | null>(null);
-    const { classmates, isLoading, error } = useClassmates(courseCode);
-    const subjectInfo = useAppStore(s => courseCode ? s.subjects?.data[courseCode] : undefined);
-    const studium = useAppStore(s => s.studiumId);
-    const obdobi = useAppStore(s => s.obdobiId);
+export function ClassmatesTab({ courseCode, showIsBacklink = true }: ClassmatesTabProps) {
+  const { t, language } = useTranslation();
+  const [searchQuery, setSearchQuery] = useState('');
+  const [selected, setSelected] = useState<Classmate | null>(null);
+  const { classmates, isLoading, error } = useClassmates(courseCode);
+  const subjectInfo = useAppStore((s) => (courseCode ? s.subjects?.data[courseCode] : undefined));
+  const studium = useAppStore((s) => s.studiumId);
+  const obdobi = useAppStore((s) => s.obdobiId);
 
-    const lang = language === 'cz' ? 'cz' : 'en';
-    const subjectId = subjectInfo?.subjectId;
-    const classmatesUrl = studium && obdobi
-        ? (subjectId
-            ? `https://is.mendelu.cz/auth/student/spoluzaci.pl?predmet=${subjectId};;studium=${studium};obdobi=${obdobi};lang=${lang}`
-            : `https://is.mendelu.cz/auth/student/spoluzaci.pl?studium=${studium};obdobi=${obdobi};lang=${lang}`)
-        : null;
+  const lang = language === 'cz' ? 'cz' : 'en';
+  const subjectId = subjectInfo?.subjectId;
+  const classmatesUrl =
+    studium && obdobi
+      ? subjectId
+        ? `https://is.mendelu.cz/auth/student/spoluzaci.pl?predmet=${subjectId};;studium=${studium};obdobi=${obdobi};lang=${lang}`
+        : `https://is.mendelu.cz/auth/student/spoluzaci.pl?studium=${studium};obdobi=${obdobi};lang=${lang}`
+      : null;
 
-    const translate = (key: string, fallback: string) => {
-        const result = t(key);
-        return result === key ? fallback : result;
-    };
+  const translate = (key: string, fallback: string) => {
+    const result = t(key);
+    return result === key ? fallback : result;
+  };
 
-    const filteredClassmates = useMemo(() => {
-        const list = classmates ?? [];
-        if (!searchQuery) return list;
-        const q = searchQuery.toLowerCase();
-        return list.filter(c =>
-            c.name.toLowerCase().includes(q) ||
-            c.personId.toString().includes(q)
-        );
-    }, [classmates, searchQuery]);
-
-    const renderBody = () => {
-        if (isLoading) {
-            return <ClassmatesListSkeleton message={translate('classmates.loadingSeminar', 'Načítám spolužáky z cvičení...')} />;
-        }
-        if (error && filteredClassmates.length === 0) {
-            return (
-                <div className="flex flex-col items-center justify-center py-20 text-base-content/40">
-                    <Users size={48} className="mb-4 opacity-20" />
-                    <p>{translate('classmates.loadFailed', 'Nepodařilo se načíst spolužáky')}</p>
-                </div>
-            );
-        }
-        if (filteredClassmates.length === 0) {
-            return (
-                <div className="flex flex-col items-center justify-center py-20 text-base-content/40">
-                    <Users size={48} className="mb-4 opacity-20" />
-                    <p>{translate('classmates.noneFound', 'Žádní spolužáci nenalezeni')}</p>
-                </div>
-            );
-        }
-        return (
-            <div className="grid grid-cols-1 gap-3">
-                {filteredClassmates.map((student) => (
-                    <div
-                        key={student.personId}
-                        role="button"
-                        tabIndex={0}
-                        onClick={() => setSelected(student)}
-                        onKeyDown={e => {
-                            if (e.key === 'Enter' || e.key === ' ') {
-                                e.preventDefault();
-                                setSelected(student);
-                            }
-                        }}
-                        className="flex items-center justify-between p-3 rounded-xl border border-base-200 bg-base-100 hover:border-primary/20 hover:shadow-sm transition-all group cursor-pointer text-left"
-                    >
-                        <div className="flex items-center gap-4 group/profile flex-1">
-                            <div className="avatar">
-                                <div className="w-14 h-14 rounded-full ring-1 ring-base-200 ring-offset-base-100 ring-offset-2 group-hover/profile:ring-primary/40 transition-all">
-                                    <PersonPhoto
-                                        personId={student.personId}
-                                        alt={student.name}
-                                        className="w-full h-full object-cover scale-[1.05]"
-                                        fallback={
-                                            <div className="bg-neutral text-neutral-content w-full h-full flex items-center justify-center">
-                                                <User size={24} strokeWidth={1.5} />
-                                            </div>
-                                        }
-                                    />
-                                </div>
-                            </div>
-                            <div className="flex flex-col">
-                                <div className="flex items-center gap-2">
-                                    <span className="font-bold text-base-content leading-tight">{student.name}</span>
-                                    {student.studyInfo && (
-                                        <>
-                                            <span className="text-base-content/20">•</span>
-                                            <span className="text-xs text-base-content/60 line-clamp-1 max-w-[150px] md:max-w-[250px] mt-0.5" title={student.studyInfo}>
-                                                {student.studyInfo}
-                                            </span>
-                                        </>
-                                    )}
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                ))}
-            </div>
-        );
-    };
-
-    return (
-        <div className="flex flex-col h-full bg-base-100">
-            <div className="flex items-center gap-4 px-6 py-4 border-b border-base-300">
-                <div className="relative flex-1">
-                    <input
-                        type="text"
-                        placeholder={translate('classmates.search', 'Vyhledat...')}
-                        className="input input-sm input-bordered w-full h-10 pl-9 rounded-lg bg-base-100 focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20"
-                        value={searchQuery}
-                        onChange={(e) => setSearchQuery(e.target.value)}
-                    />
-                    <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-base-content/40 pointer-events-none z-10" />
-                </div>
-            </div>
-            {isLoading ? renderBody() : (
-                <div className="flex-1 overflow-y-auto p-4">
-                    {renderBody()}
-                    {classmatesUrl && <ISBacklink href={classmatesUrl} />}
-                </div>
-            )}
-            <ClassmatePersonDrawer classmate={selected} onClose={() => setSelected(null)} />
-        </div>
+  const filteredClassmates = useMemo(() => {
+    const list = classmates ?? [];
+    if (!searchQuery) return list;
+    const q = searchQuery.toLowerCase();
+    return list.filter(
+      (c) => c.name.toLowerCase().includes(q) || c.personId.toString().includes(q)
     );
+  }, [classmates, searchQuery]);
+
+  const renderBody = () => {
+    if (isLoading) {
+      return (
+        <ClassmatesListSkeleton
+          message={translate('classmates.loadingSeminar', 'Načítám spolužáky z cvičení...')}
+        />
+      );
+    }
+    if (error && filteredClassmates.length === 0) {
+      return (
+        <div className="flex flex-col items-center justify-center py-20 text-base-content/40">
+          <Users size={48} className="mb-4 opacity-20" />
+          <p>{translate('classmates.loadFailed', 'Nepodařilo se načíst spolužáky')}</p>
+        </div>
+      );
+    }
+    if (filteredClassmates.length === 0) {
+      return (
+        <div className="flex flex-col items-center justify-center py-20 text-base-content/40">
+          <Users size={48} className="mb-4 opacity-20" />
+          <p>{translate('classmates.noneFound', 'Žádní spolužáci nenalezeni')}</p>
+        </div>
+      );
+    }
+    return (
+      <div className="grid grid-cols-1 gap-3">
+        {filteredClassmates.map((student) => (
+          <div
+            key={student.personId}
+            role="button"
+            tabIndex={0}
+            onClick={() => setSelected(student)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                setSelected(student);
+              }
+            }}
+            className="flex items-center justify-between p-3 rounded-xl border border-base-200 bg-base-100 hover:border-primary/20 hover:shadow-sm transition-all group cursor-pointer text-left"
+          >
+            <div className="flex items-center gap-4 group/profile flex-1">
+              <div className="avatar">
+                <div className="w-14 h-14 rounded-full ring-1 ring-base-200 ring-offset-base-100 ring-offset-2 group-hover/profile:ring-primary/40 transition-all">
+                  <PersonPhoto
+                    personId={student.personId}
+                    alt={student.name}
+                    className="w-full h-full object-cover scale-[1.05]"
+                    fallback={
+                      <div className="bg-neutral text-neutral-content w-full h-full flex items-center justify-center">
+                        <User size={24} strokeWidth={1.5} />
+                      </div>
+                    }
+                  />
+                </div>
+              </div>
+              <div className="flex flex-col">
+                <div className="flex items-center gap-2">
+                  <span className="font-bold text-base-content leading-tight">{student.name}</span>
+                  {student.studyInfo && (
+                    <>
+                      <span className="text-base-content/20">•</span>
+                      <span
+                        className="text-xs text-base-content/60 line-clamp-1 max-w-[150px] md:max-w-[250px] mt-0.5"
+                        title={student.studyInfo}
+                      >
+                        {student.studyInfo}
+                      </span>
+                    </>
+                  )}
+                </div>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  };
+
+  return (
+    <div className="flex flex-col h-full bg-base-100">
+      <div className="flex items-center gap-4 px-6 py-4 border-b border-base-300">
+        <div className="relative flex-1">
+          <input
+            type="text"
+            placeholder={translate('classmates.search', 'Vyhledat...')}
+            className="input input-sm input-bordered w-full h-10 pl-9 rounded-lg bg-base-100 focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+          />
+          <Search
+            size={16}
+            className="absolute left-3 top-1/2 -translate-y-1/2 text-base-content/40 pointer-events-none z-10"
+          />
+        </div>
+      </div>
+      {isLoading ? (
+        renderBody()
+      ) : (
+        <div className="flex-1 overflow-y-auto p-4">
+          {renderBody()}
+          {classmatesUrl && showIsBacklink && <ISBacklink href={classmatesUrl} />}
+        </div>
+      )}
+      <ClassmatePersonDrawer classmate={selected} onClose={() => setSelected(null)} />
+    </div>
+  );
 }

--- a/src/components/SubjectFileDrawer/DrawerTabBody.tsx
+++ b/src/components/SubjectFileDrawer/DrawerTabBody.tsx
@@ -147,7 +147,8 @@ export function DrawerTabBody({
     );
   if (tab === 'classmates')
     return <ClassmatesTab courseCode={lesson?.courseCode || ''} showIsBacklink={showIsBacklink} />;
-  if (tab === 'zaznamnik') return <ZaznamnikTab courseCode={lesson?.courseCode || ''} />;
+  if (tab === 'zaznamnik')
+    return <ZaznamnikTab courseCode={lesson?.courseCode || ''} showIsBacklink={showIsBacklink} />;
 
   return (
     <SuccessRateTab

--- a/src/components/SubjectFileDrawer/DrawerTabBody.tsx
+++ b/src/components/SubjectFileDrawer/DrawerTabBody.tsx
@@ -36,6 +36,13 @@ interface DrawerTabBodyProps {
   lastVisitedAt?: number | null;
   /** Forwarded to FileList — off for the phone drawer. */
   selectable?: boolean;
+  /**
+   * Whether the tab bodies render their own trailing 'IS MENDELU' link.
+   * Off for the phone sheet, which pins its own 'Otevrit v IS MENDELU'
+   * footer — showing both put two identical-looking links to the same
+   * place in every tab.
+   */
+  showIsBacklink?: boolean;
 }
 
 /**
@@ -65,6 +72,7 @@ export function DrawerTabBody({
   folderUrl,
   lastVisitedAt,
   selectable,
+  showIsBacklink = true,
 }: DrawerTabBodyProps) {
   const { t, language } = useTranslation();
 
@@ -94,7 +102,7 @@ export function DrawerTabBody({
                 ? t('course.footer.searchOnlyInSchedule')
                 : t('course.footer.noFilesAvailable')}
             </p>
-            {folderUrl && (
+            {folderUrl && showIsBacklink && (
               <ISBacklink
                 href={
                   folderUrl.includes('?')
@@ -120,6 +128,7 @@ export function DrawerTabBody({
             folderUrl={folderUrl}
             lastVisitedAt={lastVisitedAt}
             selectable={selectable}
+            showIsBacklink={showIsBacklink}
           />
         )}
       </>
@@ -129,17 +138,20 @@ export function DrawerTabBody({
   if (tab === 'syllabus')
     return (
       <SyllabusTab
+        showIsBacklink={showIsBacklink}
         courseCode={lesson?.courseCode || ''}
         courseId={resolvedCourseId}
         courseName={lesson?.courseName ?? ''}
         prefetchedResult={syllabusResult}
       />
     );
-  if (tab === 'classmates') return <ClassmatesTab courseCode={lesson?.courseCode || ''} />;
+  if (tab === 'classmates')
+    return <ClassmatesTab courseCode={lesson?.courseCode || ''} showIsBacklink={showIsBacklink} />;
   if (tab === 'zaznamnik') return <ZaznamnikTab courseCode={lesson?.courseCode || ''} />;
 
   return (
     <SuccessRateTab
+      showIsBacklink={showIsBacklink}
       courseCode={lesson?.courseCode || ''}
       facultyCode={(lesson as { facultyCode?: string } | null)?.facultyCode}
     />

--- a/src/components/SubjectFileDrawer/FileList.tsx
+++ b/src/components/SubjectFileDrawer/FileList.tsx
@@ -37,6 +37,7 @@ export function FileList({
   folderUrl,
   lastVisitedAt,
   selectable = true,
+  showIsBacklink = true,
 }: FileListProps) {
   const { t, language } = useTranslation();
   const { noteKeys } = useDocumentNoteKeys(courseCode);
@@ -99,7 +100,7 @@ export function FileList({
           </div>
         </div>
       ))}
-      {folderUrl && (
+      {folderUrl && showIsBacklink && (
         <ISBacklink
           href={
             folderUrl.includes('?')

--- a/src/components/SubjectFileDrawer/SyllabusTab.tsx
+++ b/src/components/SubjectFileDrawer/SyllabusTab.tsx
@@ -9,32 +9,54 @@ import { useTranslation } from '../../hooks/useTranslation';
 import { ISBacklink } from './ISBacklink';
 
 interface SyllabusTabProps {
-    courseCode: string;
-    courseId?: string;
-    courseName?: string;
-    prefetchedResult?: { syllabus: SyllabusRequirements | null; isLoading: boolean };
+  /** Off for the phone sheet, which pins its own IS MENDELU footer. */
+  showIsBacklink?: boolean;
+  courseCode: string;
+  courseId?: string;
+  courseName?: string;
+  prefetchedResult?: { syllabus: SyllabusRequirements | null; isLoading: boolean };
 }
 
-export function SyllabusTab({ courseCode, courseId, courseName, prefetchedResult }: SyllabusTabProps) {
-    const hookRes = useSyllabus(courseCode, courseId, courseName);
-    const { syllabus, isLoading } = prefetchedResult || hookRes;
-    const { params } = useUserParams();
-    const { t, language } = useTranslation();
+export function SyllabusTab({
+  courseCode,
+  courseId,
+  courseName,
+  prefetchedResult,
+  showIsBacklink = true,
+}: SyllabusTabProps) {
+  const hookRes = useSyllabus(courseCode, courseId, courseName);
+  const { syllabus, isLoading } = prefetchedResult || hookRes;
+  const { params } = useUserParams();
+  const { t, language } = useTranslation();
 
-    const lang = language === 'cz' ? 'cz' : 'en';
-    const syllabusUrl = courseId 
-        ? `https://is.mendelu.cz/auth/katalog/syllabus.pl?predmet=${courseId};lang=${lang}` 
-        : null;
+  const lang = language === 'cz' ? 'cz' : 'en';
+  const syllabusUrl = courseId
+    ? `https://is.mendelu.cz/auth/katalog/syllabus.pl?predmet=${courseId};lang=${lang}`
+    : null;
 
-    if (isLoading) return <div className="flex flex-col items-center justify-center h-full p-8 animate-pulse"><div className="w-12 h-12 bg-base-300 rounded mb-4" /><div className="h-4 bg-base-300 rounded w-1/2 mb-2" /></div>;
-    if (!syllabus || (!syllabus.requirementsText && !syllabus.requirementsTable.length)) return <div className="flex flex-col items-center justify-center h-full p-6 opacity-40 text-center"><BookOpen className="w-12 h-12 mb-3" /><p className="text-sm">{t('syllabus.noData')}</p></div>;
-
+  if (isLoading)
     return (
-        <div className="h-full overflow-y-auto bg-base-100 p-4 space-y-4 text-[13px]">
-            <SubjectTimeline courseCode={courseCode} />
-            {syllabus.requirementsText && <RequirementsSection text={syllabus.requirementsText} />}
-            {syllabus.requirementsTable.length > 0 && <GradingTable table={syllabus.requirementsTable} studyForm={params?.studyForm || 'prez'} />}
-            {syllabusUrl && <ISBacklink href={syllabusUrl} />}
-        </div>
+      <div className="flex flex-col items-center justify-center h-full p-8 animate-pulse">
+        <div className="w-12 h-12 bg-base-300 rounded mb-4" />
+        <div className="h-4 bg-base-300 rounded w-1/2 mb-2" />
+      </div>
     );
+  if (!syllabus || (!syllabus.requirementsText && !syllabus.requirementsTable.length))
+    return (
+      <div className="flex flex-col items-center justify-center h-full p-6 opacity-40 text-center">
+        <BookOpen className="w-12 h-12 mb-3" />
+        <p className="text-sm">{t('syllabus.noData')}</p>
+      </div>
+    );
+
+  return (
+    <div className="h-full overflow-y-auto bg-base-100 p-4 space-y-4 text-[13px]">
+      <SubjectTimeline courseCode={courseCode} />
+      {syllabus.requirementsText && <RequirementsSection text={syllabus.requirementsText} />}
+      {syllabus.requirementsTable.length > 0 && (
+        <GradingTable table={syllabus.requirementsTable} studyForm={params?.studyForm || 'prez'} />
+      )}
+      {syllabusUrl && showIsBacklink && <ISBacklink href={syllabusUrl} />}
+    </div>
+  );
 }

--- a/src/components/SubjectFileDrawer/ZaznamnikTab.tsx
+++ b/src/components/SubjectFileDrawer/ZaznamnikTab.tsx
@@ -9,96 +9,119 @@ import { PhArchView } from './Zaznamnik/PhArchView';
 const IS_BASE = 'https://is.mendelu.cz';
 
 interface ZaznamnikTabProps {
-    courseCode: string;
+  courseCode: string;
+  /**
+   * Off on the phone, where the sheet pins a single IS link in its footer.
+   * Defaults to shown so the desktop drawer is untouched — the same contract
+   * every sibling tab uses.
+   */
+  showIsBacklink?: boolean;
 }
 
-export function ZaznamnikTab({ courseCode }: ZaznamnikTabProps) {
-    const { data, isLoading } = useZaznamnik(courseCode);
-    const subjectInfo = useAppStore(s => courseCode ? s.subjects?.data[courseCode] : undefined);
-    const studium = useAppStore(s => s.studiumId);
-    const obdobi = useAppStore(s => s.obdobiId);
-    const { t, language } = useTranslation();
-    const lang = language === 'cz' ? 'cz' : 'en';
-    const subjectId = subjectInfo?.subjectId;
+export function ZaznamnikTab({ courseCode, showIsBacklink = true }: ZaznamnikTabProps) {
+  const { data, isLoading } = useZaznamnik(courseCode);
+  const subjectInfo = useAppStore((s) => (courseCode ? s.subjects?.data[courseCode] : undefined));
+  const studium = useAppStore((s) => s.studiumId);
+  const obdobi = useAppStore((s) => s.obdobiId);
+  const { t, language } = useTranslation();
+  const lang = language === 'cz' ? 'cz' : 'en';
+  const subjectId = subjectInfo?.subjectId;
 
-    const buildUrl = (extra: string) =>
-        `${IS_BASE}/auth/student/list.pl?studium=${studium};obdobi=${obdobi};predmet=${subjectId};${extra};lang=${lang}`;
+  const buildUrl = (extra: string) =>
+    `${IS_BASE}/auth/student/list.pl?studium=${studium};obdobi=${obdobi};predmet=${subjectId};${extra};lang=${lang}`;
 
-    const backlinks = (subjectInfo?.hasPrubezne || subjectInfo?.hasTest) && studium && obdobi && subjectId ? (
-        <div className="flex justify-center gap-2 pt-2 pb-2">
-            {subjectInfo!.hasPrubezne && (
-                <a href={buildUrl('prubezne=1')} target="_blank" rel="noopener noreferrer"
-                    className="btn btn-ghost btn-sm gap-2 text-base-content/50 hover:text-primary normal-case font-bold">
-                    <span>{t('zaznamnik.isContinuous')}</span><ExternalLink size={14} />
-                </a>
-            )}
-            {subjectInfo!.hasTest && (
-                <a href={buildUrl('test=1')} target="_blank" rel="noopener noreferrer"
-                    className="btn btn-ghost btn-sm gap-2 text-base-content/50 hover:text-primary normal-case font-bold">
-                    <span>{t('zaznamnik.isTestResults')}</span><ExternalLink size={14} />
-                </a>
-            )}
-        </div>
+  const backlinks =
+    showIsBacklink &&
+    (subjectInfo?.hasPrubezne || subjectInfo?.hasTest) &&
+    studium &&
+    obdobi &&
+    subjectId ? (
+      <div className="flex justify-center gap-2 pt-2 pb-2">
+        {subjectInfo!.hasPrubezne && (
+          <a
+            href={buildUrl('prubezne=1')}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="btn btn-ghost btn-sm gap-2 text-base-content/50 hover:text-primary normal-case font-bold"
+          >
+            <span>{t('zaznamnik.isContinuous')}</span>
+            <ExternalLink size={14} />
+          </a>
+        )}
+        {subjectInfo!.hasTest && (
+          <a
+            href={buildUrl('test=1')}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="btn btn-ghost btn-sm gap-2 text-base-content/50 hover:text-primary normal-case font-bold"
+          >
+            <span>{t('zaznamnik.isTestResults')}</span>
+            <ExternalLink size={14} />
+          </a>
+        )}
+      </div>
     ) : null;
 
-    if (isLoading) {
-        return (
-            <div className="p-4 space-y-3 animate-pulse">
-                <div className="h-4 bg-base-300 rounded w-1/3" />
-                <div className="h-10 bg-base-300 rounded" />
-                <div className="h-10 bg-base-300 rounded" />
-                <div className="h-4 bg-base-300 rounded w-1/4 mt-4" />
-                <div className="h-10 bg-base-300 rounded" />
-            </div>
-        );
-    }
-
-    if (!data || (!data.ph.sections.length && !data.vt.tests.length)) {
-        const hasFlags = subjectInfo?.hasPrubezne || subjectInfo?.hasTest;
-        return (
-            <div className="flex flex-col h-full">
-                <div className="flex flex-col items-center justify-center flex-1 p-6 opacity-40 text-center">
-                    <ClipboardList className="w-12 h-12 mb-3" />
-                    <p className="text-sm">{hasFlags ? t('zaznamnik.noData') : t('zaznamnik.noAssessment')}</p>
-                </div>
-                {backlinks}
-            </div>
-        );
-    }
-
-    const nonEmptyArches = data.ph.sections.flatMap(s => s.arches.filter(a => !a.empty));
-    const vtTests = data.vt.tests;
-
-    const vtGroups: { name: string; attempts: VtTestAttempt[] }[] = [];
-    for (const test of vtTests) {
-        const existing = vtGroups.find(g => g.name === test.name);
-        if (existing) existing.attempts.push(test);
-        else vtGroups.push({ name: test.name, attempts: [test] });
-    }
-
+  if (isLoading) {
     return (
-        <div className="h-full overflow-y-auto p-4 space-y-5 text-[13px]">
-            <PhArchView sections={data.ph.sections} />
-
-            {vtGroups.length > 0 && (
-                <div className="space-y-2">
-                    <p className="text-[11px] font-bold uppercase tracking-wider text-base-content/40">
-                        {t('zaznamnik.vtSection')} · {vtTests.length}
-                    </p>
-                    {vtGroups.map((group, i) => (
-                        <VtTestGroup key={i} name={group.name} attempts={group.attempts} />
-                    ))}
-                </div>
-            )}
-
-            {nonEmptyArches.length === 0 && vtGroups.length === 0 && (
-                <div className="flex flex-col items-center justify-center h-full p-6 opacity-40 text-center">
-                    <ClipboardList className="w-12 h-12 mb-3" />
-                    <p className="text-sm">{t('zaznamnik.noData')}</p>
-                </div>
-            )}
-
-            {backlinks}
-        </div>
+      <div className="p-4 space-y-3 animate-pulse">
+        <div className="h-4 bg-base-300 rounded w-1/3" />
+        <div className="h-10 bg-base-300 rounded" />
+        <div className="h-10 bg-base-300 rounded" />
+        <div className="h-4 bg-base-300 rounded w-1/4 mt-4" />
+        <div className="h-10 bg-base-300 rounded" />
+      </div>
     );
+  }
+
+  if (!data || (!data.ph.sections.length && !data.vt.tests.length)) {
+    const hasFlags = subjectInfo?.hasPrubezne || subjectInfo?.hasTest;
+    return (
+      <div className="flex flex-col h-full">
+        <div className="flex flex-col items-center justify-center flex-1 p-6 opacity-40 text-center">
+          <ClipboardList className="w-12 h-12 mb-3" />
+          <p className="text-sm">
+            {hasFlags ? t('zaznamnik.noData') : t('zaznamnik.noAssessment')}
+          </p>
+        </div>
+        {backlinks}
+      </div>
+    );
+  }
+
+  const nonEmptyArches = data.ph.sections.flatMap((s) => s.arches.filter((a) => !a.empty));
+  const vtTests = data.vt.tests;
+
+  const vtGroups: { name: string; attempts: VtTestAttempt[] }[] = [];
+  for (const test of vtTests) {
+    const existing = vtGroups.find((g) => g.name === test.name);
+    if (existing) existing.attempts.push(test);
+    else vtGroups.push({ name: test.name, attempts: [test] });
+  }
+
+  return (
+    <div className="h-full overflow-y-auto p-4 space-y-5 text-[13px]">
+      <PhArchView sections={data.ph.sections} />
+
+      {vtGroups.length > 0 && (
+        <div className="space-y-2">
+          <p className="text-[11px] font-bold uppercase tracking-wider text-base-content/40">
+            {t('zaznamnik.vtSection')} · {vtTests.length}
+          </p>
+          {vtGroups.map((group, i) => (
+            <VtTestGroup key={i} name={group.name} attempts={group.attempts} />
+          ))}
+        </div>
+      )}
+
+      {nonEmptyArches.length === 0 && vtGroups.length === 0 && (
+        <div className="flex flex-col items-center justify-center h-full p-6 opacity-40 text-center">
+          <ClipboardList className="w-12 h-12 mb-3" />
+          <p className="text-sm">{t('zaznamnik.noData')}</p>
+        </div>
+      )}
+
+      {backlinks}
+    </div>
+  );
 }

--- a/src/components/SubjectFileDrawer/__tests__/ZaznamnikTab.test.tsx
+++ b/src/components/SubjectFileDrawer/__tests__/ZaznamnikTab.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { ZaznamnikTab } from '../ZaznamnikTab';
+import { useAppStore } from '../../../store/useAppStore';
+
+/**
+ * The phone renders this tab inside a sheet that already pins ONE IS link in its
+ * footer. Every other tab honours `showIsBacklink` for exactly that reason;
+ * záznamník rendered its own pair unconditionally, so the sheet showed a
+ * duplicate link on this tab alone.
+ */
+describe('ZaznamnikTab IS backlinks', () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      studiumId: '123',
+      obdobiId: '456',
+      zaznamnikHydrated: true,
+      subjects: {
+        data: { EBC: { hasPrubezne: true, hasTest: true, subjectId: '789' } },
+      },
+    } as never);
+  });
+
+  afterEach(cleanup);
+
+  it('renders the IS backlinks by default, as the desktop drawer expects', () => {
+    render(<ZaznamnikTab courseCode="EBC" />);
+    expect(screen.getAllByRole('link').length).toBe(2);
+  });
+
+  it('renders none when the host pins its own IS link', () => {
+    render(<ZaznamnikTab courseCode="EBC" showIsBacklink={false} />);
+    expect(screen.queryAllByRole('link')).toHaveLength(0);
+  });
+});

--- a/src/components/SubjectFileDrawer/types.ts
+++ b/src/components/SubjectFileDrawer/types.ts
@@ -48,6 +48,8 @@ export interface FileListProps {
    *  download. The phone drawer has neither, so it turns them off — a
    *  checkbox that only ever selects one row at a time is noise. */
   selectable?: boolean;
+  /** Off for the phone sheet, which pins its own IS MENDELU footer. */
+  showIsBacklink?: boolean;
 }
 
 export interface DragSelectionState {

--- a/src/components/SuccessRateTab.tsx
+++ b/src/components/SuccessRateTab.tsx
@@ -9,52 +9,96 @@ import { TermBreakdown } from './SuccessRate/TermBreakdown';
 import { useTranslation } from '../hooks/useTranslation';
 import { ISBacklink } from './SubjectFileDrawer/ISBacklink';
 
-const COLORS: Record<string, string> = { A: 'var(--color-grade-a)', B: 'var(--color-grade-b)', C: 'var(--color-grade-c)', D: 'var(--color-grade-d)', E: 'var(--color-grade-e)', F: 'var(--color-grade-f)', FN: 'var(--color-grade-fn)' };
+const COLORS: Record<string, string> = {
+  A: 'var(--color-grade-a)',
+  B: 'var(--color-grade-b)',
+  C: 'var(--color-grade-c)',
+  D: 'var(--color-grade-d)',
+  E: 'var(--color-grade-e)',
+  F: 'var(--color-grade-f)',
+  FN: 'var(--color-grade-fn)',
+};
 
-export function SuccessRateTab({ courseCode, facultyCode }: { courseCode: string; facultyCode?: string }) {
-    const { stats: data, loading } = useSuccessRate(courseCode);
-    const [idx, setIdx] = useState(0);
-    const { t } = useTranslation();
+export function SuccessRateTab({
+  courseCode,
+  facultyCode,
+  showIsBacklink = true,
+}: {
+  courseCode: string;
+  facultyCode?: string;
+  /** Off for the phone sheet, which pins its own IS MENDELU footer. */
+  showIsBacklink?: boolean;
+}) {
+  const { stats: data, loading } = useSuccessRate(courseCode);
+  const [idx, setIdx] = useState(0);
+  const { t } = useTranslation();
 
-    if (loading) return <div className="flex items-center justify-center h-full"><span className="loading loading-spinner text-primary" /></div>;
-    if (!data?.stats?.length) return <div className="flex flex-col items-center justify-center h-full pt-16"><AlertTriangle className="w-8 h-8 opacity-40 mb-3" /><p className="text-sm opacity-60">{t('successRate.noData')}</p></div>;
-
-    const allStats = sortSemesters(data.stats);
-    const filtered = pickFacultyStats(allStats, facultyCode);
-    if (filtered.length === 0) return <div className="flex flex-col items-center justify-center h-full pt-16"><AlertTriangle className="w-8 h-8 opacity-40 mb-3" /><p className="text-sm opacity-60">{t('successRate.noData')}</p></div>;
-    const stats = filtered.slice(0, 5), sIdx = Math.min(idx, stats.length - 1), current = stats[sIdx];
-    const isCredit = current.type === 'credit', total = current.totalPass + current.totalFail;
-    const order = isCredit ? ['zap', 'nezap'] : ['A', 'B', 'C', 'D', 'E', 'F', 'FN'];
-    const colors = isCredit ? { zap: 'var(--color-success)', nezap: 'var(--color-error)' } : COLORS;
-
-    // Use "Všechny termíny" aggregate if available, otherwise sum all terms (legacy data)
-    const aggregate = current.terms.find(t => t.term === 'Všechny termíny');
-    const grades = aggregate
-        ? (isCredit && aggregate.creditGrades
-            ? { zap: aggregate.creditGrades.zap, nezap: aggregate.creditGrades.nezap + (aggregate.creditGrades.zapNedost || 0) }
-            : aggregate.grades as unknown as Record<string, number>)
-        : current.terms.reduce((acc: Record<string, number>, tRes) => {
-            if (isCredit && tRes.creditGrades) {
-                acc.zap = (acc.zap || 0) + (tRes.creditGrades.zap || 0);
-                acc.nezap = (acc.nezap || 0) + (tRes.creditGrades.nezap || 0) + (tRes.creditGrades.zapNedost || 0);
-            } else if (tRes.grades) {
-                Object.entries(tRes.grades).forEach(([g, c]) => acc[g] = (acc[g] || 0) + c);
-            }
-            return acc;
-        }, {});
-
-    const max = Math.max(...order.map(g => grades[g] || 0), 1);
-    const individualTerms = current.terms.filter(t => t.term !== 'Všechny termíny');
-
+  if (loading)
     return (
-        <div className="flex flex-col h-full px-4 py-3 select-none font-inter overflow-y-auto">
-            <div className="text-center mb-6 flex items-center justify-center gap-2">
-                <span className="text-xs sm:text-sm opacity-50 font-bold uppercase tracking-wider">{total} {t('successRate.students')} {isCredit ? ` (${t('successRate.credit')})` : ` (${t('successRate.exam')})`}</span>
-            </div>
-            <GradeBarChart grades={grades} order={order} colors={colors} max={max} />
-            {individualTerms.length > 0 && <TermBreakdown terms={individualTerms} isCredit={isCredit} />}
-            <SemesterSelector stats={stats} activeIndex={sIdx} onSelect={setIdx} />
-            {current.sourceUrl && <ISBacklink href={current.sourceUrl} />}
-        </div>
+      <div className="flex items-center justify-center h-full">
+        <span className="loading loading-spinner text-primary" />
+      </div>
     );
+  if (!data?.stats?.length)
+    return (
+      <div className="flex flex-col items-center justify-center h-full pt-16">
+        <AlertTriangle className="w-8 h-8 opacity-40 mb-3" />
+        <p className="text-sm opacity-60">{t('successRate.noData')}</p>
+      </div>
+    );
+
+  const allStats = sortSemesters(data.stats);
+  const filtered = pickFacultyStats(allStats, facultyCode);
+  if (filtered.length === 0)
+    return (
+      <div className="flex flex-col items-center justify-center h-full pt-16">
+        <AlertTriangle className="w-8 h-8 opacity-40 mb-3" />
+        <p className="text-sm opacity-60">{t('successRate.noData')}</p>
+      </div>
+    );
+  const stats = filtered.slice(0, 5),
+    sIdx = Math.min(idx, stats.length - 1),
+    current = stats[sIdx];
+  const isCredit = current.type === 'credit',
+    total = current.totalPass + current.totalFail;
+  const order = isCredit ? ['zap', 'nezap'] : ['A', 'B', 'C', 'D', 'E', 'F', 'FN'];
+  const colors = isCredit ? { zap: 'var(--color-success)', nezap: 'var(--color-error)' } : COLORS;
+
+  // Use "Všechny termíny" aggregate if available, otherwise sum all terms (legacy data)
+  const aggregate = current.terms.find((t) => t.term === 'Všechny termíny');
+  const grades = aggregate
+    ? isCredit && aggregate.creditGrades
+      ? {
+          zap: aggregate.creditGrades.zap,
+          nezap: aggregate.creditGrades.nezap + (aggregate.creditGrades.zapNedost || 0),
+        }
+      : (aggregate.grades as unknown as Record<string, number>)
+    : current.terms.reduce((acc: Record<string, number>, tRes) => {
+        if (isCredit && tRes.creditGrades) {
+          acc.zap = (acc.zap || 0) + (tRes.creditGrades.zap || 0);
+          acc.nezap =
+            (acc.nezap || 0) + (tRes.creditGrades.nezap || 0) + (tRes.creditGrades.zapNedost || 0);
+        } else if (tRes.grades) {
+          Object.entries(tRes.grades).forEach(([g, c]) => (acc[g] = (acc[g] || 0) + c));
+        }
+        return acc;
+      }, {});
+
+  const max = Math.max(...order.map((g) => grades[g] || 0), 1);
+  const individualTerms = current.terms.filter((t) => t.term !== 'Všechny termíny');
+
+  return (
+    <div className="flex flex-col h-full px-4 py-3 select-none font-inter overflow-y-auto">
+      <div className="text-center mb-6 flex items-center justify-center gap-2">
+        <span className="text-xs sm:text-sm opacity-50 font-bold uppercase tracking-wider">
+          {total} {t('successRate.students')}{' '}
+          {isCredit ? ` (${t('successRate.credit')})` : ` (${t('successRate.exam')})`}
+        </span>
+      </div>
+      <GradeBarChart grades={grades} order={order} colors={colors} max={max} />
+      {individualTerms.length > 0 && <TermBreakdown terms={individualTerms} isCredit={isCredit} />}
+      <SemesterSelector stats={stats} activeIndex={sIdx} onSelect={setIdx} />
+      {current.sourceUrl && showIsBacklink && <ISBacklink href={current.sourceUrl} />}
+    </div>
+  );
 }

--- a/src/components/__tests__/dropdownExternalLinks.test.tsx
+++ b/src/components/__tests__/dropdownExternalLinks.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { createRef } from 'react';
+import { EventsDropdown } from '../Events/EventsDropdown';
+import { NotificationDropdown } from '../Notifications/NotificationDropdown';
+import type { MendeluEvent } from '../../types/events';
+import type { SpolekNotification } from '../../services/spolky';
+
+/**
+ * Both dropdowns render on the phone (they portal to a full-screen surface under
+ * `useIsMobile`), so on Capacitor a raw `window.open` hands the URL to the SYSTEM
+ * browser — which holds none of the app's IS session. `openExternal` is the
+ * established answer: it validates the URL, routes into the in-app browser on
+ * Capacitor, and off Capacitor opens with `noopener,noreferrer` so the opened
+ * page never keeps a handle on `window.opener`.
+ */
+const openExternal = vi.hoisted(() => vi.fn());
+vi.mock('../../mobile/openExternal', () => ({ openExternal }));
+vi.mock('../../services/spolky', async (orig) => ({
+  ...(await orig<Record<string, unknown>>()),
+  trackNotificationClick: vi.fn(),
+}));
+vi.mock('../StudyJams/StudyJamSuggestions', () => ({ StudyJamSuggestions: () => null }));
+// Stubbed, not exercised: its real load is an async IDB read that resolves after
+// this test tears down, and the resulting setState lands on an unmounted tree —
+// an unhandled error that fails the whole file regardless of assertions.
+vi.mock('../../hooks/useEventsFacultySettings', () => ({
+  useEventsFacultySettings: () => ({ isSubscribed: () => true, toggleFaculty: vi.fn() }),
+}));
+
+const event: MendeluEvent = {
+  title: 'Den otevřených dveří',
+  url: 'https://mendelu.cz/den-otevrenych-dveri',
+  date: '12. 9.',
+  endDate: null,
+  time: null,
+  location: null,
+  imageUrl: null,
+  organizerKey: 'pef',
+};
+
+const notification: SpolekNotification = {
+  id: 'n1',
+  associationId: 'supef',
+  title: 'Zápis do kroužků',
+  body: 'Otevřeno do pátku',
+  link: 'https://supef.cz/zapis',
+  createdAt: '2026-08-01T00:00:00Z',
+  expiresAt: '2026-12-01T00:00:00Z',
+  priority: 'normal',
+};
+
+describe('dropdown external links', () => {
+  beforeEach(() => {
+    openExternal.mockClear();
+    window.open = vi.fn();
+  });
+
+  afterEach(cleanup);
+
+  it('opens an event through openExternal, not the system browser', () => {
+    render(
+      <EventsDropdown
+        events={[event]}
+        loading={false}
+        onClose={() => {}}
+        dropdownRef={createRef<HTMLDivElement>()}
+      />
+    );
+    fireEvent.click(screen.getByText(event.title));
+    expect(openExternal).toHaveBeenCalledWith(event.url);
+    expect(window.open).not.toHaveBeenCalled();
+  });
+
+  it('opens a notification link through openExternal, not the system browser', () => {
+    render(
+      <NotificationDropdown
+        notifications={[notification]}
+        loading={false}
+        onClose={() => {}}
+        onVisible={() => {}}
+        dropdownRef={createRef<HTMLDivElement>()}
+        deadlineAlerts={[]}
+      />
+    );
+    fireEvent.click(screen.getByText(notification.title));
+    expect(openExternal).toHaveBeenCalledWith(notification.link);
+    expect(window.open).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/mobile/MobileApp.tsx
+++ b/src/components/mobile/MobileApp.tsx
@@ -30,7 +30,29 @@ export function MobileApp() {
       data-testid="mobile-app"
       className="relative flex h-screen w-full flex-col overflow-hidden bg-base-200 text-base-content"
     >
-      <Toaster position="top-center" />
+      {/* Offset by the safe-area inset: a top-center toast otherwise lands on
+          top of the status bar under targetSdk 36's forced edge-to-edge, with
+          the clock showing through the "Saved to Downloads" confirmation.
+          `mobileOffset` is the one that matters and `offset` alone is a no-op
+          here — sonner 2.x switches to mobileOffset below a 600px viewport, and
+          this device is 411px wide. Both are set so the toast is inset whichever
+          branch sonner takes. The 16px sides/bottom are sonner's own mobile
+          defaults, restated because passing an object replaces them. */}
+      <Toaster
+        position="top-center"
+        offset={{
+          top: 'calc(1.5rem + var(--safe-top, 0px))',
+          right: '24px',
+          left: '24px',
+          bottom: '24px',
+        }}
+        mobileOffset={{
+          top: 'calc(1rem + var(--safe-top, 0px))',
+          right: '16px',
+          left: '16px',
+          bottom: '16px',
+        }}
+      />
       {tab === 'calendar' && <CalendarScreen />}
       {tab === 'exams' && <ExamsScreen />}
       {tab === 'subjects' && <SubjectsScreen />}

--- a/src/components/mobile/primitives/Sheet.tsx
+++ b/src/components/mobile/primitives/Sheet.tsx
@@ -1,4 +1,5 @@
-import type { ReactNode } from 'react';
+import { useRef, useState, type PointerEvent as ReactPointerEvent, type ReactNode } from 'react';
+import { dragOwnsGesture, shouldDismiss } from './sheetDrag';
 
 export interface SheetProps {
   /** `full` pins below the status area and scrolls; `content` hugs the bottom. */
@@ -11,7 +12,8 @@ export interface SheetProps {
 
 /**
  * The one bottom-sheet container. Nine sheets share this exact behaviour:
- * backdrop fade, slide-up, tap-outside-to-close, and one of two heights.
+ * backdrop fade, slide-up, tap-outside-to-close, drag-down-to-close, and one of
+ * two heights.
  */
 export function Sheet({ size, onClose, children, elevated }: SheetProps) {
   // Tailwind's default z-index scale stops at 50 — z-60/z-61 are not real
@@ -22,6 +24,39 @@ export function Sheet({ size, onClose, children, elevated }: SheetProps) {
   const panelZ = elevated ? 'z-[61]' : 'z-[51]';
   const panelPosition = size === 'full' ? 'top-[70px] bottom-0' : 'bottom-0 max-h-[85dvh]';
 
+  const panelRef = useRef<HTMLDivElement>(null);
+  const start = useRef<{ y: number; t: number } | null>(null);
+  const [dragY, setDragY] = useState(0);
+
+  const onPointerDown = (e: ReactPointerEvent<HTMLDivElement>) => {
+    // Only a gesture the content does not want. dragOwnsGesture returns false
+    // while any scroller under the finger is scrolled past its top, so reading
+    // a long list never costs the student their place.
+    if (!dragOwnsGesture(e.target as Element, panelRef.current)) return;
+    start.current = { y: e.clientY, t: e.timeStamp };
+  };
+
+  const onPointerMove = (e: ReactPointerEvent<HTMLDivElement>) => {
+    if (!start.current) return;
+    const dy = e.clientY - start.current.y;
+    // Clamped at 0: the sheet is bottom-anchored, so upward drag has nowhere to
+    // travel and rubber-banding it would only suggest it does.
+    setDragY(dy > 0 ? dy : 0);
+  };
+
+  const onPointerUp = (e: ReactPointerEvent<HTMLDivElement>) => {
+    const from = start.current;
+    start.current = null;
+    if (!from) return;
+    if (shouldDismiss(e.clientY - from.y, e.timeStamp - from.t)) {
+      onClose();
+      return;
+    }
+    setDragY(0);
+  };
+
+  const dragging = dragY > 0;
+
   return (
     <>
       <div
@@ -30,8 +65,25 @@ export function Sheet({ size, onClose, children, elevated }: SheetProps) {
         className={`absolute inset-0 bg-black/50 animate-[fadeIn_0.2s_ease-out] ${backdropZ}`}
       />
       <div
+        ref={panelRef}
         data-testid="sheet-panel"
-        className={`absolute inset-x-0 ${panelPosition} ${panelZ} flex flex-col overflow-hidden rounded-t-[20px] bg-base-100 shadow-drawer animate-[sheetUp_0.3s_ease-out]`}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        onPointerCancel={onPointerUp}
+        // The entry animation is dropped the moment a drag starts: it animates
+        // the same transform this does, and leaving both on makes the sheet
+        // fight the finger.
+        className={`absolute inset-x-0 ${panelPosition} ${panelZ} flex flex-col overflow-hidden rounded-t-[20px] bg-base-100 shadow-drawer ${
+          dragging ? '' : 'animate-[sheetUp_0.3s_ease-out]'
+        }`}
+        style={
+          dragging
+            ? { transform: `translateY(${dragY}px)` }
+            : // No transition while idle, so releasing below the threshold snaps
+              // back under this rule rather than lingering mid-screen.
+              { transition: 'transform 0.2s ease-out' }
+        }
       >
         {children}
       </div>

--- a/src/components/mobile/primitives/Sheet.tsx
+++ b/src/components/mobile/primitives/Sheet.tsx
@@ -55,6 +55,16 @@ export function Sheet({ size, onClose, children, elevated }: SheetProps) {
     setDragY(0);
   };
 
+  // Not onPointerUp: a cancel is the BROWSER taking the gesture over (a pan it
+  // decided to own, a system edge swipe), not the student letting go. Running
+  // the dismiss decision on it closes the sheet mid-drag — a 30px cancel inside
+  // 50ms reads as a dismissing flick by velocity alone. A cancelled drag has no
+  // outcome but "put it back".
+  const onPointerCancel = () => {
+    start.current = null;
+    setDragY(0);
+  };
+
   const dragging = dragY > 0;
 
   return (
@@ -70,7 +80,7 @@ export function Sheet({ size, onClose, children, elevated }: SheetProps) {
         onPointerDown={onPointerDown}
         onPointerMove={onPointerMove}
         onPointerUp={onPointerUp}
-        onPointerCancel={onPointerUp}
+        onPointerCancel={onPointerCancel}
         // The entry animation is dropped the moment a drag starts: it animates
         // the same transform this does, and leaving both on makes the sheet
         // fight the finger.

--- a/src/components/mobile/primitives/SheetHeader.tsx
+++ b/src/components/mobile/primitives/SheetHeader.tsx
@@ -12,13 +12,13 @@ export interface SheetHeaderProps {
 export function SheetHeader({ title, subtitle, eyebrow, onClose }: SheetHeaderProps) {
   const { t } = useTranslation();
   return (
-    // touchAction 'none' is what makes the drag pill below more than decoration.
-    // Sheet owns the pointer handlers and these events bubble up to it, but with
-    // the default 'auto' the browser claims the gesture as a pan partway through
-    // and fires pointercancel — measured on device, the drag was cut off after
-    // ~20px of a 350px swipe, so it never met the dismiss threshold. Scoped to
-    // the header so the content below keeps scrolling normally.
-    <div className="flex-shrink-0" style={{ touchAction: 'none' }}>
+    // touch-none is what makes the drag pill below more than decoration. Sheet
+    // owns the pointer handlers and these events bubble up to it, but with the
+    // default touch-action the browser claims the gesture as a pan partway
+    // through and fires pointercancel — measured on device, the drag was cut off
+    // after ~20px of a 350px swipe, so it never met the dismiss threshold.
+    // Scoped to the header so the content below keeps scrolling normally.
+    <div className="flex-shrink-0 touch-none">
       <div className="mx-auto mt-2 mb-1 h-1 w-9 rounded-full bg-base-300" />
       <div className="flex items-start gap-3 px-4 pb-3 pt-2">
         <div className="flex min-w-0 flex-1 flex-col gap-0.5">

--- a/src/components/mobile/primitives/SheetHeader.tsx
+++ b/src/components/mobile/primitives/SheetHeader.tsx
@@ -12,7 +12,13 @@ export interface SheetHeaderProps {
 export function SheetHeader({ title, subtitle, eyebrow, onClose }: SheetHeaderProps) {
   const { t } = useTranslation();
   return (
-    <div className="flex-shrink-0">
+    // touchAction 'none' is what makes the drag pill below more than decoration.
+    // Sheet owns the pointer handlers and these events bubble up to it, but with
+    // the default 'auto' the browser claims the gesture as a pan partway through
+    // and fires pointercancel — measured on device, the drag was cut off after
+    // ~20px of a 350px swipe, so it never met the dismiss threshold. Scoped to
+    // the header so the content below keeps scrolling normally.
+    <div className="flex-shrink-0" style={{ touchAction: 'none' }}>
       <div className="mx-auto mt-2 mb-1 h-1 w-9 rounded-full bg-base-300" />
       <div className="flex items-start gap-3 px-4 pb-3 pt-2">
         <div className="flex min-w-0 flex-1 flex-col gap-0.5">

--- a/src/components/mobile/primitives/__tests__/Sheet.test.tsx
+++ b/src/components/mobile/primitives/__tests__/Sheet.test.tsx
@@ -48,4 +48,45 @@ describe('Sheet', () => {
     );
     expect(screen.getByTestId('sheet-panel').className).not.toContain('top-[70px]');
   });
+
+  /**
+   * Drag-to-dismiss, driven through the panel's pointer handlers. jsdom has no
+   * gesture model, so this asserts the decision rather than the animation: a
+   * long downward drag must call onClose.
+   */
+  it('closes on a long downward drag', () => {
+    const onClose = vi.fn();
+    render(
+      <Sheet size="full" onClose={onClose}>
+        x
+      </Sheet>
+    );
+    const panel = screen.getByTestId('sheet-panel');
+    fireEvent.pointerDown(panel, { clientY: 100, timeStamp: 0 });
+    fireEvent.pointerMove(panel, { clientY: 300, timeStamp: 200 });
+    fireEvent.pointerUp(panel, { clientY: 300, timeStamp: 200 });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  // The distance-vs-velocity rules live in sheetDrag.test.ts, not here: jsdom
+  // stamps its own event timeStamps and ignores the ones fireEvent is given, so
+  // every drag reads as an instant flick and a "slow drag" cannot be expressed.
+
+  /**
+   * An upward drag on a bottom-anchored sheet has nowhere to travel, and must
+   * never be mistaken for a dismissal.
+   */
+  it('ignores an upward drag', () => {
+    const onClose = vi.fn();
+    render(
+      <Sheet size="full" onClose={onClose}>
+        x
+      </Sheet>
+    );
+    const panel = screen.getByTestId('sheet-panel');
+    fireEvent.pointerDown(panel, { clientY: 400, timeStamp: 0 });
+    fireEvent.pointerMove(panel, { clientY: 100, timeStamp: 200 });
+    fireEvent.pointerUp(panel, { clientY: 100, timeStamp: 200 });
+    expect(onClose).not.toHaveBeenCalled();
+  });
 });

--- a/src/components/mobile/primitives/__tests__/Sheet.test.tsx
+++ b/src/components/mobile/primitives/__tests__/Sheet.test.tsx
@@ -73,6 +73,41 @@ describe('Sheet', () => {
   // every drag reads as an instant flick and a "slow drag" cannot be expressed.
 
   /**
+   * A cancelled gesture is not a completed one. The browser fires pointercancel
+   * when it takes the gesture over (a pan, a system edge swipe), and the student
+   * never lifted a finger to say "close" — reusing the pointerup handler there
+   * would dismiss the sheet out from under them mid-drag.
+   */
+  it('does not close when the browser cancels the drag', () => {
+    const onClose = vi.fn();
+    render(
+      <Sheet size="full" onClose={onClose}>
+        x
+      </Sheet>
+    );
+    const panel = screen.getByTestId('sheet-panel');
+    fireEvent.pointerDown(panel, { clientY: 100, timeStamp: 0 });
+    fireEvent.pointerMove(panel, { clientY: 300, timeStamp: 200 });
+    fireEvent.pointerCancel(panel, { clientY: 300, timeStamp: 200 });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  /** And the panel must settle back, not stay parked where the finger left it. */
+  it('resets the drag offset after a cancelled gesture', () => {
+    render(
+      <Sheet size="full" onClose={() => {}}>
+        x
+      </Sheet>
+    );
+    const panel = screen.getByTestId('sheet-panel');
+    fireEvent.pointerDown(panel, { clientY: 100, timeStamp: 0 });
+    fireEvent.pointerMove(panel, { clientY: 300, timeStamp: 200 });
+    expect(panel.style.transform).toBe('translateY(200px)');
+    fireEvent.pointerCancel(panel, { clientY: 300, timeStamp: 200 });
+    expect(panel.style.transform).toBe('');
+  });
+
+  /**
    * An upward drag on a bottom-anchored sheet has nowhere to travel, and must
    * never be mistaken for a dismissal.
    */

--- a/src/components/mobile/primitives/__tests__/SheetHeader.test.tsx
+++ b/src/components/mobile/primitives/__tests__/SheetHeader.test.tsx
@@ -24,6 +24,6 @@ describe('SheetHeader', () => {
   it('opts the header out of browser touch panning so the sheet can be dragged', () => {
     const { container } = render(<SheetHeader title="Internet věcí" />);
     const header = container.firstElementChild as HTMLElement;
-    expect(header.style.touchAction).toBe('none');
+    expect(header.className).toContain('touch-none');
   });
 });

--- a/src/components/mobile/primitives/__tests__/SheetHeader.test.tsx
+++ b/src/components/mobile/primitives/__tests__/SheetHeader.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { SheetHeader } from '../SheetHeader';
+
+vi.mock('../../../../hooks/useTranslation', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+describe('SheetHeader', () => {
+  it('renders the title block', () => {
+    render(<SheetHeader title="Internet věcí" eyebrow="EBC-IV" subtitle="Ing. Gallus" />);
+    expect(screen.getByText('Internet věcí')).toBeInTheDocument();
+    expect(screen.getByText('EBC-IV')).toBeInTheDocument();
+  });
+
+  /**
+   * Load-bearing and easy to delete by accident. With the default touch-action
+   * the browser claims a downward drag as a pan and fires pointercancel partway
+   * through — measured on an Android device, a 350px swipe reached Sheet's
+   * handler as ~20px, well under the dismiss threshold, so the drag pill this
+   * component renders was pure decoration. Scoped to the header on purpose:
+   * putting it on the panel would disable scrolling in the content below.
+   */
+  it('opts the header out of browser touch panning so the sheet can be dragged', () => {
+    const { container } = render(<SheetHeader title="Internet věcí" />);
+    const header = container.firstElementChild as HTMLElement;
+    expect(header.style.touchAction).toBe('none');
+  });
+});

--- a/src/components/mobile/primitives/__tests__/sheetDrag.test.ts
+++ b/src/components/mobile/primitives/__tests__/sheetDrag.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { shouldDismiss, dragOwnsGesture, DISMISS_DISTANCE_PX } from '../sheetDrag';
+
+describe('shouldDismiss', () => {
+  it('closes on a long drag regardless of speed', () => {
+    expect(shouldDismiss(DISMISS_DISTANCE_PX, 5000)).toBe(true);
+  });
+
+  it('closes on a short fast flick', () => {
+    expect(shouldDismiss(40, 50)).toBe(true);
+  });
+
+  it('springs back on a short slow drag', () => {
+    expect(shouldDismiss(40, 2000)).toBe(false);
+  });
+
+  // The sheet is anchored to the bottom edge; dragging up has nowhere to go and
+  // must never be read as a dismissal.
+  it.each([-120, -1, 0])('ignores upward travel (%i)', (dy) => {
+    expect(shouldDismiss(dy, 100)).toBe(false);
+  });
+
+  it('does not divide by a zero timestamp delta', () => {
+    expect(shouldDismiss(10, 0)).toBe(false);
+  });
+});
+
+describe('dragOwnsGesture', () => {
+  const build = (opts: { overflowY: string; scrollTop: number; scrollable: boolean }) => {
+    const panel = document.createElement('div');
+    const scroller = document.createElement('div');
+    const child = document.createElement('span');
+    scroller.style.overflowY = opts.overflowY;
+    Object.defineProperty(scroller, 'scrollTop', { value: opts.scrollTop, writable: true });
+    Object.defineProperty(scroller, 'scrollHeight', { value: opts.scrollable ? 2000 : 100 });
+    Object.defineProperty(scroller, 'clientHeight', { value: 100 });
+    scroller.appendChild(child);
+    panel.appendChild(scroller);
+    document.body.appendChild(panel);
+    return { panel, child };
+  };
+
+  /**
+   * The case that matters most: a student reading halfway down a long file list
+   * swipes down to scroll back up. That must scroll, not close the sheet.
+   */
+  it('yields to a scroller that is not at the top', () => {
+    const { panel, child } = build({ overflowY: 'auto', scrollTop: 488, scrollable: true });
+    expect(dragOwnsGesture(child, panel)).toBe(false);
+  });
+
+  it('takes the gesture once the scroller is back at the top', () => {
+    const { panel, child } = build({ overflowY: 'auto', scrollTop: 0, scrollable: true });
+    expect(dragOwnsGesture(child, panel)).toBe(true);
+  });
+
+  // Overflowing content inside a non-scrolling parent is not a scroller. Reading
+  // it as one would silently disable dismissal on ordinary sheets.
+  it('ignores a tall element that cannot actually scroll', () => {
+    const { panel, child } = build({ overflowY: 'visible', scrollTop: 0, scrollable: true });
+    expect(dragOwnsGesture(child, panel)).toBe(true);
+  });
+
+  it('takes the gesture when there is no scroller at all', () => {
+    const panel = document.createElement('div');
+    const child = document.createElement('span');
+    panel.appendChild(child);
+    expect(dragOwnsGesture(child, panel)).toBe(true);
+  });
+});

--- a/src/components/mobile/primitives/sheetDrag.ts
+++ b/src/components/mobile/primitives/sheetDrag.ts
@@ -1,0 +1,51 @@
+/**
+ * The drag-to-dismiss decision for mobile bottom sheets, kept pure so the rules
+ * are testable without a touchscreen.
+ *
+ * The nine mobile sheets render through `Sheet`, which had a backdrop, a
+ * slide-up animation and tap-outside-to-close — but no drag handling at all.
+ * Swiping a sheet down did nothing, which reads as "the app is frozen" rather
+ * than "this gesture is unimplemented".
+ */
+
+/** Past this much downward travel the sheet closes regardless of speed. */
+export const DISMISS_DISTANCE_PX = 96;
+
+/** A short, fast flick should close too — this is the px/ms that counts as one. */
+export const DISMISS_VELOCITY_PX_PER_MS = 0.5;
+
+export function shouldDismiss(dy: number, dtMs: number): boolean {
+  // Upward and sideways drags never dismiss; the sheet is anchored at the bottom.
+  if (dy <= 0) return false;
+  if (dy >= DISMISS_DISTANCE_PX) return true;
+  return dtMs > 0 && dy / dtMs >= DISMISS_VELOCITY_PX_PER_MS;
+}
+
+/**
+ * Whether a downward drag starting on `target` should move the SHEET rather
+ * than scroll the content under the finger.
+ *
+ * Scrolling wins whenever the content can still scroll up, so a student reading
+ * halfway down a 20-file list never loses the sheet by swiping down. Only at the
+ * very top of the scroll does the same gesture become a dismiss — the behaviour
+ * every native sheet has.
+ *
+ * `stopAt` bounds the walk to the sheet panel so an ancestor outside it can
+ * never veto the gesture.
+ */
+export function dragOwnsGesture(target: Element | null, stopAt: Element | null): boolean {
+  let node: Element | null = target;
+  while (node && node !== stopAt?.parentElement) {
+    if (isScrollable(node) && node.scrollTop > 0) return false;
+    node = node.parentElement;
+  }
+  return true;
+}
+
+function isScrollable(el: Element): boolean {
+  // scrollHeight > clientHeight alone is not enough: a tall element inside a
+  // non-scrolling parent reports that too, and treating it as a scroller would
+  // silently disable dismissal on sheets whose content merely overflows.
+  const overflowY = getComputedStyle(el).overflowY;
+  return (overflowY === 'auto' || overflowY === 'scroll') && el.scrollHeight > el.clientHeight;
+}

--- a/src/components/mobile/screens/CalendarScreen.tsx
+++ b/src/components/mobile/screens/CalendarScreen.tsx
@@ -98,15 +98,23 @@ export function CalendarScreen() {
 
   return (
     <div data-testid="calendar-screen" className="flex flex-1 flex-col overflow-hidden">
+      {/* The date IS the title now. It was the eyebrow under a "Ahoj, {name}"
+          greeting that told the student nothing they did not already know. */}
       <ScreenHeader
-        eyebrow={formatHeaderDate(new Date(`${selectedIso}T00:00:00`), locale)}
-        title={
-          fullName
-            ? t('mobile.calendar.greeting', { name: fullName.split(' ')[0] ?? '' })
-            : t('mobile.calendar.greetingNoName')
-        }
+        title={formatHeaderDate(new Date(`${selectedIso}T00:00:00`), locale)}
         action={
           <div className="flex items-center gap-2">
+            {/* Vývěska joins the other two header actions. As a lone pill between
+                the alerts and the day chips it read as misplaced and cost a row
+                of vertical space for one tap target. */}
+            <button
+              type="button"
+              onClick={openBulletin}
+              aria-label={t('bulletin.expand')}
+              className="flex h-10 w-10 items-center justify-center rounded-full border border-base-300 bg-base-100"
+            >
+              <Pin size={18} className="text-primary" />
+            </button>
             <button
               type="button"
               onClick={() => pushSheet({ kind: 'notifications' })}
@@ -153,15 +161,6 @@ export function CalendarScreen() {
         </div>
       )}
 
-      <button
-        type="button"
-        onClick={openBulletin}
-        aria-label={t('bulletin.expand')}
-        className="mx-4 mt-3 flex flex-shrink-0 items-center gap-1.5 self-start rounded-lg border border-base-300 bg-base-100/60 px-3 py-1.5"
-      >
-        <Pin size={14} className="text-primary" />
-        <span className="text-sm font-semibold text-base-content">{t('bulletin.title')}</span>
-      </button>
       <MobileBulletinOverlay
         isOpen={bulletinExpanded}
         onClose={() => {

--- a/src/components/mobile/screens/__tests__/CalendarScreen.test.tsx
+++ b/src/components/mobile/screens/__tests__/CalendarScreen.test.tsx
@@ -62,24 +62,25 @@ describe('CalendarScreen', () => {
     expect(screen.getByTestId('agenda-gap')).toBeInTheDocument();
   });
 
-  it('falls back to a name-less greeting and a User icon avatar when fullName is absent', () => {
+  // The greeting was dropped as redundant — it told the student their own name.
+  // The date, previously the small eyebrow above it, is the title now.
+  it('shows no greeting, and a User icon avatar when fullName is absent', () => {
     useAppStore.setState({
       schedule: { data: [], status: 'success', weekStart: null } as never,
       fullName: null,
     });
     render(<CalendarScreen />);
-    expect(screen.getByText('Ahoj')).toBeInTheDocument();
-    expect(screen.queryByText(/Ahoj,/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/^Ahoj/)).not.toBeInTheDocument();
     expect(screen.getByLabelText('Profil').querySelector('svg')).toBeInTheDocument();
   });
 
-  it('renders the named greeting and initials when fullName is present', () => {
+  it('still derives avatar initials from fullName', () => {
     useAppStore.setState({
       schedule: { data: [], status: 'success', weekStart: null } as never,
       fullName: 'Jana Nováková',
     });
     render(<CalendarScreen />);
-    expect(screen.getByText('Ahoj, Jana')).toBeInTheDocument();
+    expect(screen.queryByText(/^Ahoj/)).not.toBeInTheDocument();
     expect(screen.getByLabelText('Profil')).toHaveTextContent('JN');
   });
 

--- a/src/components/mobile/screens/__tests__/CalendarScreen.test.tsx
+++ b/src/components/mobile/screens/__tests__/CalendarScreen.test.tsx
@@ -71,6 +71,9 @@ describe('CalendarScreen', () => {
     });
     render(<CalendarScreen />);
     expect(screen.queryByText(/^Ahoj/)).not.toBeInTheDocument();
+    // Asserted, not merely absent: "no greeting" also passes on a blank title.
+    // The selected day is 2026-04-20 and the header is capitalised.
+    expect(screen.getByText('Pondělí 20. dubna')).toBeInTheDocument();
     expect(screen.getByLabelText('Profil').querySelector('svg')).toBeInTheDocument();
   });
 
@@ -81,6 +84,7 @@ describe('CalendarScreen', () => {
     });
     render(<CalendarScreen />);
     expect(screen.queryByText(/^Ahoj/)).not.toBeInTheDocument();
+    expect(screen.getByText('Pondělí 20. dubna')).toBeInTheDocument();
     expect(screen.getByLabelText('Profil')).toHaveTextContent('JN');
   });
 

--- a/src/components/mobile/screens/__tests__/MapScreen.test.tsx
+++ b/src/components/mobile/screens/__tests__/MapScreen.test.tsx
@@ -64,7 +64,8 @@ describe('MapScreen', () => {
     expect(useAppStore.getState().mapSheetState).toBe('expanded');
     expect(screen.getByRole('tablist')).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: 'Akce' })).toBeInTheDocument();
-    expect(screen.getByRole('tab', { name: 'Knihovna' })).toBeInTheDocument();
+    // Library study-room reservation is hidden on mobile.
+    expect(screen.queryByRole('tab', { name: 'Knihovna' })).not.toBeInTheDocument();
   });
 
   it('the map canvas stays mounted through the peek/expanded transition', () => {
@@ -76,12 +77,16 @@ describe('MapScreen', () => {
     expect(screen.getByTestId('mock-map-canvas')).toBeInTheDocument();
   });
 
-  it('clicking the Knihovna tab switches mapTab and swaps the tab body', () => {
-    useAppStore.setState({ mapSheetState: 'expanded' });
+  /**
+   * mapTab persists, so a student who last used Knihovna on desktop would come
+   * back to a tab this sheet no longer renders — and, before the fallback, to an
+   * empty body with no tab to click. Akce is what they get instead.
+   */
+  it('falls back to Akce when a persisted Knihovna tab is no longer offered', () => {
+    useAppStore.setState({ mapSheetState: 'expanded', mapTab: 'knihovna' });
     render(<MapScreen />);
-    fireEvent.click(screen.getByRole('tab', { name: 'Knihovna' }));
-    expect(useAppStore.getState().mapTab).toBe('knihovna');
-    expect(screen.getByText('Studovny knihovny')).toBeInTheDocument();
+    expect(screen.queryByText('Studovny knihovny')).not.toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Akce' })).toHaveAttribute('aria-selected', 'true');
   });
 
   it('typing in the search bar updates mapSearchQuery', () => {

--- a/src/components/mobile/screens/__tests__/StudentScreen.test.tsx
+++ b/src/components/mobile/screens/__tests__/StudentScreen.test.tsx
@@ -39,16 +39,18 @@ describe('StudentScreen', () => {
       'true'
     );
     expect(screen.getByRole('tab', { name: 'Lidé' })).toHaveAttribute('aria-selected', 'false');
-    expect(screen.getByText('Eduroam')).toBeInTheDocument();
+    // Eduroam is deliberately absent: one-time device setup belongs in settings,
+    // not among the everyday shortcuts. It lives in ProfileSheet now.
+    expect(screen.queryByText('Eduroam')).not.toBeInTheDocument();
     expect(screen.getByText('Dokumenty')).toBeInTheDocument();
     expect(screen.getByText('Erasmus')).toBeInTheDocument();
     expect(screen.getByText('ISKAM')).toBeInTheDocument();
   });
 
-  it('pushes an eduroam sheet when the Eduroam shortcut is tapped', () => {
+  it('pushes a docs sheet when the Dokumenty shortcut is tapped', () => {
     render(<StudentScreen />);
-    fireEvent.click(screen.getByText('Eduroam'));
-    expect(useAppStore.getState().mobileSheets).toEqual([{ kind: 'eduroam' }]);
+    fireEvent.click(screen.getByText('Dokumenty'));
+    expect(useAppStore.getState().mobileSheets).toEqual([{ kind: 'docs' }]);
   });
 
   it('renders the ISKAM shortcut as a real link, not a sheet trigger', () => {

--- a/src/components/mobile/screens/calendar/ScreenHeader.tsx
+++ b/src/components/mobile/screens/calendar/ScreenHeader.tsx
@@ -12,7 +12,14 @@ export interface ScreenHeaderProps {
 /** The shared screen title block: small eyebrow above a display-face title. */
 export function ScreenHeader({ eyebrow, title, action }: ScreenHeaderProps) {
   return (
-    <div className="flex flex-shrink-0 items-end justify-between gap-3 px-5 pb-1 pt-5">
+    // paddingTop carries --safe-top because this is the topmost element on every
+    // mobile screen and targetSdk 36 forces edge-to-edge: without it the eyebrow
+    // renders *underneath* the status bar and camera cutout (measured 48px on a
+    // 1080x2392 device). A flat pt-5 was the bug.
+    <div
+      className="flex flex-shrink-0 items-end justify-between gap-3 px-5 pb-1"
+      style={{ paddingTop: 'calc(1.25rem + var(--safe-top, 0px))' }}
+    >
       {/* min-w-0 + truncate keeps the eyebrow on one line: a long one
                 ("B-OI prez - ZS 2025/2026") wrapped at 320px and pushed the
                 title out of line with the action button beside it. */}

--- a/src/components/mobile/screens/map/MapSheet.tsx
+++ b/src/components/mobile/screens/map/MapSheet.tsx
@@ -5,7 +5,6 @@ import type { MapSheetTab } from '../../../../store/types';
 import buildingsJson from '../../../../data/map/buildings.json';
 import type { BuildingsMeta } from '../../../../types/campusMap';
 import { MapEventsSection } from '../../../CampusMap/MapEventsSection';
-import { MapLibrarySection } from '../../../CampusMap/MapLibrarySection';
 import { BuildingRoomList } from './BuildingRoomList';
 
 const META = buildingsJson as BuildingsMeta;
@@ -42,7 +41,11 @@ export function MapSheet() {
   // deselected (exitToCampus) — fall back to Akce instead of rendering
   // nothing, mirroring how MapSidePanel's `active` override handles its own
   // mode/tab mismatch.
-  const activeTab: MapSheetTab = tab === 'budova' && !showBudova ? 'akce' : tab;
+  // 'knihovna' joins that fallback: the library study-room tab is hidden on
+  // mobile, and a persisted selection of it would otherwise leave the sheet
+  // rendering nothing with no tab to click back to.
+  const activeTab: MapSheetTab =
+    (tab === 'budova' && !showBudova) || tab === 'knihovna' ? 'akce' : tab;
   const toggle = () => setSheetState(expanded ? 'peek' : 'expanded');
 
   const buildingName =
@@ -98,12 +101,11 @@ export function MapSheet() {
         <>
           <div role="tablist" className="mx-4 flex flex-shrink-0 gap-1 rounded-lg bg-base-200 p-1">
             {tabBtn('akce', t('mobile.map.tabEvents'))}
-            {tabBtn('knihovna', t('mobile.map.tabLibrary'))}
+            {/* Library study-room reservation is hidden on mobile. */}
             {showBudova && tabBtn('budova', t('mobile.map.tabBuilding', { name: buildingName }))}
           </div>
           <div className="flex-1 overflow-y-auto pb-24 pt-2">
             {activeTab === 'akce' && <MapEventsSection />}
-            {activeTab === 'knihovna' && <MapLibrarySection flush />}
             {activeTab === 'budova' && activeBuildingId !== null && (
               <BuildingRoomList buildingId={activeBuildingId} />
             )}

--- a/src/components/mobile/screens/student/ShortcutGrid.tsx
+++ b/src/components/mobile/screens/student/ShortcutGrid.tsx
@@ -1,4 +1,4 @@
-import { Wifi, FileText, GraduationCap, UtensilsCrossed } from 'lucide-react';
+import { FileText, GraduationCap, UtensilsCrossed } from 'lucide-react';
 import { useTranslation } from '../../../../hooks/useTranslation';
 
 export type ShortcutSheetKind = 'eduroam' | 'docs' | 'erasmus';
@@ -23,15 +23,9 @@ export function ShortcutGrid({ onOpenSheet }: ShortcutGridProps) {
 
   return (
     <div className="grid grid-cols-2 gap-2.5 px-4 pb-1 pt-0.5">
-      <button type="button" onClick={() => onOpenSheet('eduroam')} className={cardClassName}>
-        <Wifi size={20} className="text-primary" />
-        <span>
-          <span className="block text-md font-semibold">{t('mobile.student.eduroam')}</span>
-          <span className="block text-2sm text-base-content/60">
-            {t('mobile.student.eduroamSub')}
-          </span>
-        </span>
-      </button>
+      {/* eduroam moved to the settings sheet: it is one-time device setup, not
+          an everyday shortcut. `ShortcutSheetKind` keeps its 'eduroam' member —
+          SheetHost still renders that sheet, it is just opened from settings. */}
       <button type="button" onClick={() => onOpenSheet('docs')} className={cardClassName}>
         <FileText size={20} className="text-primary" />
         <span>

--- a/src/components/mobile/sheets/ErasmusSheet.tsx
+++ b/src/components/mobile/sheets/ErasmusSheet.tsx
@@ -29,7 +29,11 @@ export function ErasmusSheet({ onClose }: ErasmusSheetProps) {
     <Sheet size="full" onClose={onClose}>
       <SheetHeader title={t('mobile.student.erasmus')} onClose={onClose} />
       <div className="flex flex-1 flex-col overflow-hidden">
-        <ErasmusPanel onOpenSubject={openSubject} onSearchSubject={() => {}} />
+        <ErasmusPanel
+          onOpenSubject={openSubject}
+          onSearchSubject={() => {}}
+          showLearningAgreement={false}
+        />
       </div>
     </Sheet>
   );

--- a/src/components/mobile/sheets/ProfileSheet.tsx
+++ b/src/components/mobile/sheets/ProfileSheet.tsx
@@ -5,7 +5,7 @@ import {
   Moon,
   Languages,
   Calendar,
-  HardDrive,
+  Wifi,
   MessageSquarePlus,
   LogOut,
   ChevronRight,
@@ -15,7 +15,6 @@ import { Sheet } from '../primitives/Sheet';
 import { useAppStore } from '../../../store/useAppStore';
 import { useTheme } from '../../../hooks/useTheme';
 import { useOutlookSync } from '../../../hooks/data/useOutlookSync';
-import { useDriveBackup } from '../../../hooks/data/useDriveBackup';
 import { useSpolkySettings } from '../../../hooks/useSpolkySettings';
 import { useStudyPlan } from '../../../hooks/useStudyPlan';
 import { useTranslation } from '../../../hooks/useTranslation';
@@ -39,8 +38,8 @@ function initials(name: string): string {
 }
 
 /**
- * Full-size settings sheet: theme, language, Outlook/Drive sync, hidden
- * items, society map filters, feedback and logout. Reuses desktop's
+ * Full-size settings sheet: theme, language, Outlook sync, eduroam setup,
+ * hidden items, society map filters, feedback and logout. Reuses desktop's
  * `SpolkySection` / `HiddenItemsSection` / `FeedbackModal` wholesale rather
  * than rebuilding them — only the row layout around them is phone-specific.
  *
@@ -60,21 +59,13 @@ export function ProfileSheet({ onClose }: ProfileSheetProps) {
     isLoading: outlookLoading,
     toggle: toggleOutlook,
   } = useOutlookSync();
-  const {
-    connected: driveConnected,
-    busy: driveBusy,
-    connect: driveConnect,
-    disconnect: driveDisconnect,
-  } = useDriveBackup();
   const { isSubscribed, toggleAssociation } = useSpolkySettings();
+  const pushSheet = useAppStore((s) => s.pushSheet);
   const plan = useStudyPlan();
   const [spolkyOpen, setSpolkyOpen] = useState(false);
   const [feedbackOpen, setFeedbackOpen] = useState(false);
 
   const name = fullName ?? '';
-  const toggleDrive = () => {
-    void (driveConnected ? driveDisconnect() : driveConnect());
-  };
 
   return (
     <Sheet size="full" onClose={onClose}>
@@ -155,22 +146,29 @@ export function ProfileSheet({ onClose }: ProfileSheetProps) {
             onChange={toggleOutlook}
           />
         </label>
-        <label className="flex items-center gap-3 px-4 py-2.5">
-          <HardDrive size={16} className="flex-shrink-0 text-base-content/50" />
+        {/* Google Drive backup is deliberately absent on mobile. It is
+            non-functional there on every axis (issue #168), so the toggle only
+            ever promised something the app could not deliver. The desktop
+            sidebar keeps it. */}
+
+        {/* eduroam lives here rather than on the Student hub: it is a one-time
+            device setup, which is what a settings screen is for, and it was
+            competing for attention with everyday shortcuts. One tap, same
+            sheet — SheetHost stacks it above this one. */}
+        <button
+          type="button"
+          onClick={() => pushSheet({ kind: 'eduroam' })}
+          className="flex w-full items-center gap-3 px-4 py-2.5 text-left"
+        >
+          <Wifi size={16} className="flex-shrink-0 text-base-content/50" />
           <div className="flex min-w-0 flex-1 flex-col">
-            <span className="text-md font-medium">{t('drive.title')}</span>
+            <span className="text-md font-medium">{t('mobile.student.eduroam')}</span>
             <span className="truncate text-xs text-base-content/60">
-              {driveConnected ? t('drive.connected') : t('drive.connectHint')}
+              {t('mobile.student.eduroamSub')}
             </span>
           </div>
-          <input
-            type="checkbox"
-            className="toggle toggle-primary toggle-sm"
-            checked={driveConnected ?? false}
-            disabled={driveBusy}
-            onChange={toggleDrive}
-          />
-        </label>
+          <ChevronRight size={16} className="flex-shrink-0 text-base-content/40" />
+        </button>
 
         <HiddenItemsSection />
 

--- a/src/components/mobile/sheets/SubjectDrawerSheet.tsx
+++ b/src/components/mobile/sheets/SubjectDrawerSheet.tsx
@@ -142,6 +142,10 @@ export function SubjectDrawerSheet({ sheet, onClose }: SubjectDrawerSheetProps) 
           syllabusResult={syllabusResult}
           folderUrl={subjectInfo?.folderUrl}
           selectable={false}
+          // The pinned 'Otevrit v IS MENDELU' footer below is this sheet's single
+          // IS link. Left on, every tab also rendered its own 'IS MENDELU' at the
+          // end of its content — two identical-looking links to the same place.
+          showIsBacklink={false}
         />
       </div>
       {openInIsHref && (

--- a/src/components/mobile/sheets/__tests__/ProfileSheet.test.tsx
+++ b/src/components/mobile/sheets/__tests__/ProfileSheet.test.tsx
@@ -76,10 +76,21 @@ describe('ProfileSheet', () => {
     expect(outlookToggle).toHaveBeenCalledTimes(1);
   });
 
-  it('calls the Drive hook connect', () => {
+  /**
+   * Drive backup is non-functional on mobile on every axis (issue #168), so the
+   * toggle only ever promised something the app could not deliver. Pinned as an
+   * absence rather than deleted, so restoring it is a deliberate act.
+   */
+  it('offers no Google Drive backup toggle', () => {
     render(<ProfileSheet onClose={vi.fn()} />);
-    fireEvent.click(screen.getByRole('checkbox', { name: /Záloha na Google Disk/i }));
-    expect(driveConnect).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('checkbox', { name: /Záloha na Google Disk/i })).toBeNull();
+    expect(driveConnect).not.toHaveBeenCalled();
+  });
+
+  it('opens the eduroam sheet from settings in one tap', () => {
+    render(<ProfileSheet onClose={vi.fn()} />);
+    fireEvent.click(screen.getByText('Eduroam'));
+    expect(useAppStore.getState().mobileSheets).toEqual([{ kind: 'eduroam' }]);
   });
 
   it('shows a hidden event and restores it, removing it from the hidden list', () => {

--- a/src/hooks/ui/__tests__/openNativeFile.test.ts
+++ b/src/hooks/ui/__tests__/openNativeFile.test.ts
@@ -1,0 +1,81 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { toast } from 'sonner';
+import { openNativeFile } from '../openNativeFile';
+import { openIsFileNatively } from '../../../mobile/openIsFile';
+
+vi.mock('../../../mobile/openIsFile', () => ({
+  openIsFileNatively: vi.fn(async () => ({ usedFallback: false, delivered: 'downloads' })),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn(), info: vi.fn() },
+}));
+
+vi.mock('../../../utils/reportError', () => ({ logError: vi.fn() }));
+
+const t = (key: string) => key;
+
+describe('openNativeFile success feedback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  /**
+   * The regression this pins: on Android the ONLY sign a download succeeded was
+   * a system notification, and POST_NOTIFICATIONS is a runtime grant the app
+   * never asked for. Measured on device: the file saved (577500 bytes into
+   * content://media/external/downloads/...) while the student saw nothing at
+   * all. Feedback must not depend on a permission that can be denied.
+   */
+  it('confirms a Downloads delivery with a toast', async () => {
+    vi.mocked(openIsFileNatively).mockResolvedValue({
+      usedFallback: false,
+      delivered: 'downloads',
+    });
+
+    await openNativeFile('slozka.pl?download=1', 'Test.open', t);
+
+    expect(toast.success).toHaveBeenCalledWith('course.file.savedToDownloads');
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  /**
+   * iOS hands the file to the share sheet, which is itself the confirmation.
+   * A toast on top of it would be noise about something the student can see.
+   */
+  it('stays silent for a share-sheet delivery', async () => {
+    vi.mocked(openIsFileNatively).mockResolvedValue({
+      usedFallback: false,
+      delivered: 'share',
+    });
+
+    await openNativeFile('slozka.pl?download=1', 'Test.open', t);
+
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  it('still reports a failure and never claims success', async () => {
+    vi.mocked(openIsFileNatively).mockRejectedValue(new Error('IS did not return a file'));
+
+    await openNativeFile('slozka.pl?download=1', 'Test.open', t);
+
+    expect(toast.error).toHaveBeenCalledWith('course.file.openFailed');
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  /**
+   * A lapsed session already raised the recovery prompt with the token the
+   * request used, so this path must stay quiet — and must certainly not
+   * announce a download that did not happen.
+   */
+  it('stays silent on a lapsed session', async () => {
+    const err = new Error('HTTP 401') as Error & { sessionExpired?: boolean };
+    err.sessionExpired = true;
+    vi.mocked(openIsFileNatively).mockRejectedValue(err);
+
+    await openNativeFile('slozka.pl?download=1', 'Test.open', t);
+
+    expect(toast.error).not.toHaveBeenCalled();
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/ui/__tests__/useFileActions.native.test.ts
+++ b/src/hooks/ui/__tests__/useFileActions.native.test.ts
@@ -8,7 +8,7 @@ import { promptSessionRecovery } from '../../../mobile/sessionRecovery';
 
 vi.mock('../../../mobile/openIsFile', () => ({
   isNativeHost: vi.fn(() => true),
-  openIsFileNatively: vi.fn(async () => ({ usedFallback: false })),
+  openIsFileNatively: vi.fn(async () => ({ usedFallback: false, delivered: 'downloads' })),
 }));
 
 vi.mock('sonner', () => ({
@@ -33,7 +33,10 @@ describe('useFileActions on Capacitor', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(isNativeHost).mockReturnValue(true);
-    vi.mocked(openIsFileNatively).mockResolvedValue({ usedFallback: false });
+    vi.mocked(openIsFileNatively).mockResolvedValue({
+      usedFallback: false,
+      delivered: 'downloads',
+    });
     global.fetch = vi.fn();
   });
 

--- a/src/hooks/ui/openNativeFile.ts
+++ b/src/hooks/ui/openNativeFile.ts
@@ -24,7 +24,13 @@ export async function openNativeFile(
   t: (key: string) => string
 ): Promise<void> {
   try {
-    await openIsFileNatively(fullUrl);
+    const { delivered } = await openIsFileNatively(fullUrl);
+    // Android saves into Downloads and posts a notification — but
+    // POST_NOTIFICATIONS is a runtime grant, and a student who declined it (or
+    // was never asked, which was the case) got NO signal at all while the file
+    // saved perfectly. Confirmation must not ride on a droppable permission.
+    // iOS is deliberately silent: its share sheet is already the confirmation.
+    if (delivered === 'downloads') toast.success(t('course.file.savedToDownloads'));
   } catch (e) {
     logError(context, e);
     // A lapsed session returns silently here on purpose: `fetchIsBinary`

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -388,7 +388,8 @@
       "updatedJustNow": "Aktualizováno právě teď"
     },
     "file": {
-      "openFailed": "Soubor se nepodařilo otevřít."
+      "openFailed": "Soubor se nepodařilo otevřít.",
+      "savedToDownloads": "Uloženo do Stažených souborů"
     },
     "documentNote": {
       "add": "Přidat poznámku...",
@@ -1115,8 +1116,6 @@
       "student": "Student"
     },
     "calendar": {
-      "greeting": "Ahoj, {name}",
-      "greetingNoName": "Ahoj",
       "nowRunning": "Teď běží",
       "endsIn": "konec za {minutes} min",
       "next": "Pak: {title}",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -388,7 +388,8 @@
       "updatedJustNow": "Updated just now"
     },
     "file": {
-      "openFailed": "Couldn't open the file."
+      "openFailed": "Couldn't open the file.",
+      "savedToDownloads": "Saved to Downloads"
     },
     "documentNote": {
       "add": "Add note...",
@@ -1115,8 +1116,6 @@
       "student": "Student"
     },
     "calendar": {
-      "greeting": "Hi, {name}",
-      "greetingNoName": "Hi",
       "nowRunning": "On now",
       "endsIn": "ends in {minutes} min",
       "next": "Next: {title}",

--- a/src/mobile/__tests__/backButton.test.ts
+++ b/src/mobile/__tests__/backButton.test.ts
@@ -25,4 +25,43 @@ describe('handleBackPress', () => {
     expect(handleBackPress({ sheetCount: -1, popSheet })).toBe('exit');
     expect(popSheet).not.toHaveBeenCalled();
   });
+
+  /**
+   * The vývěska overlay is NOT a sheet — it lives in its own `bulletinExpanded`
+   * store flag and portals to document.body. So with it open the stack was
+   * still empty, back returned 'exit', and reading the noticeboard and pressing
+   * back quit the app.
+   */
+  it('closes the bulletin overlay rather than exiting', () => {
+    const popSheet = vi.fn();
+    const closeBulletin = vi.fn();
+    expect(handleBackPress({ sheetCount: 0, popSheet, bulletinOpen: true, closeBulletin })).toBe(
+      'popped'
+    );
+    expect(closeBulletin).toHaveBeenCalledOnce();
+    expect(popSheet).not.toHaveBeenCalled();
+  });
+
+  /**
+   * A sheet opened on top of the bulletin must unwind first — it is drawn above
+   * it, so closing what is underneath would be invisible to the student.
+   */
+  it('pops a sheet before the bulletin when both are open', () => {
+    const popSheet = vi.fn();
+    const closeBulletin = vi.fn();
+    expect(handleBackPress({ sheetCount: 1, popSheet, bulletinOpen: true, closeBulletin })).toBe(
+      'popped'
+    );
+    expect(popSheet).toHaveBeenCalledOnce();
+    expect(closeBulletin).not.toHaveBeenCalled();
+  });
+
+  it('still exits when the bulletin is closed', () => {
+    const popSheet = vi.fn();
+    const closeBulletin = vi.fn();
+    expect(handleBackPress({ sheetCount: 0, popSheet, bulletinOpen: false, closeBulletin })).toBe(
+      'exit'
+    );
+    expect(closeBulletin).not.toHaveBeenCalled();
+  });
 });

--- a/src/mobile/backButton.ts
+++ b/src/mobile/backButton.ts
@@ -1,6 +1,14 @@
 export interface BackPressState {
   sheetCount: number;
   popSheet(): void;
+  /**
+   * The vývěska overlay, which is NOT part of the sheet stack: it has its own
+   * `bulletinExpanded` store flag and portals to document.body. Without it here
+   * the stack reads as empty and back quits the app out from under a student
+   * reading the noticeboard.
+   */
+  bulletinOpen?: boolean;
+  closeBulletin?(): void;
 }
 
 export type BackPressResult = 'popped' | 'exit';
@@ -13,9 +21,20 @@ export type BackPressResult = 'popped' | 'exit';
  * Pure on purpose: the @capacitor/app listener is a two-line adapter over this,
  * which keeps the decision testable without a device.
  */
-export function handleBackPress({ sheetCount, popSheet }: BackPressState): BackPressResult {
+export function handleBackPress({
+  sheetCount,
+  popSheet,
+  bulletinOpen,
+  closeBulletin,
+}: BackPressState): BackPressResult {
+  // Sheets first: one opened on top of the bulletin is drawn above it, so
+  // closing the overlay underneath would look like nothing happened.
   if (sheetCount > 0) {
     popSheet();
+    return 'popped';
+  }
+  if (bulletinOpen && closeBulletin) {
+    closeBulletin();
     return 'popped';
   }
   return 'exit';

--- a/src/mobile/openIsFile.ts
+++ b/src/mobile/openIsFile.ts
@@ -3,7 +3,7 @@ import { getPlatform } from '../platform';
 import { loadStoredToken } from '../platform/tokenStore';
 import { fetchIsBinary, blobToBase64 } from '../api/capacitorBinary';
 import { toDirectDownloadUrl } from '../api/isDocumentUrl';
-import { deliverFile } from './deliverFile';
+import { deliverFile, type DeliveryKind } from './deliverFile';
 
 interface DownloadsPlugin {
   save(o: {
@@ -11,6 +11,7 @@ interface DownloadsPlugin {
     base64: string;
     mime: string;
   }): Promise<{ uri: string; bytes: number }>;
+  requestNotificationPermission(): Promise<{ granted: boolean }>;
 }
 
 /** Android-only native plugin: writes into Downloads and posts a notification.
@@ -54,7 +55,7 @@ export async function openIsFileNatively(
   url: string,
   filenameOverride?: string,
   fallbackUrl?: string
-): Promise<{ usedFallback: boolean }> {
+): Promise<{ usedFallback: boolean; delivered: DeliveryKind }> {
   const token = await loadStoredToken();
   const { Capacitor, CapacitorHttp, CapacitorCookies } = await import('@capacitor/core');
   const platform = Capacitor.getPlatform() as 'ios' | 'android' | 'web';
@@ -87,13 +88,23 @@ export async function openIsFileNatively(
   }
 
   const base64 = await blobToBase64(result.blob);
-  await deliverFile(
+  // The delivery kind is returned rather than discarded: it is what tells the
+  // caller whether the student has already SEEN confirmation (iOS share sheet)
+  // or needs to be told (Android, where the file lands silently in Downloads).
+  const delivered = await deliverFile(
     chooseFilename(filenameOverride, result.filename),
     base64,
     result.blob.type || 'application/pdf',
     {
       platform: Capacitor.getPlatform() as 'ios' | 'android' | 'web',
-      saveToDownloads: (o) => Downloads.save(o),
+      saveToDownloads: async (o) => {
+        // Asked for here, at the moment the student requested a file, and never
+        // awaited: the notification is a convenience (tap to open), so a denied
+        // or slow permission dialog must not delay or fail the save. The toast
+        // in openNativeFile is what actually tells them it worked.
+        void Downloads.requestNotificationPermission().catch(() => {});
+        return Downloads.save(o);
+      },
       shareFile: async (o) => {
         // iOS has no Downloads folder: write to Documents, then offer the file to
         // the Files/share sheet, which is that platform's native save flow.
@@ -114,5 +125,5 @@ export async function openIsFileNatively(
     }
   );
 
-  return { usedFallback };
+  return { usedFallback, delivered };
 }


### PR DESCRIPTION
First real Android handset pass on the Capacitor app (A001, 1080x2392, dpr 2.625).

**Sync itself held up.** Cold start → login → **115 requests, all HTTP 200, zero telemetry**, covering all four Task 4 endpoint families (`student/list.pl` prubezne+test, `odevzdavarny.pl`, `studijni_povinnosti.pl`, `wifi/certifikat.pl`) plus 4 POSTs. The "silently CORS-blocked on Capacitor" class is confirmed dead on hardware.

Seven defects found and fixed. Two were not what they looked like.

## Root causes

**Downloads "did nothing" — they always worked.** The file saved fine (577,500 B verified into `content://media/external/downloads/…`). The only feedback was a system notification, and `POST_NOTIFICATIONS` is a runtime grant **nothing in the codebase ever requested**. Success now raises an in-app toast that no permission can suppress, and the permission is requested from the download path. Device now reports `granted=true`.

**Every file badge read "FILE" — IS changed their markup, and this hits the extension too.** A live fetch of `slozka.pl` contains **zero** `img[sysid]` elements; icons are now `<span class="uf-icon" data-sysid="mime-pdf">`. Fixed against that real sample, per CLAUDE.md's parser rule. Two traps: the selector must prefer `mime-` (the read-status icon comes first in DOM order), but must still report other icons — the parser identifies IS's view-info link by its `prohlizeni-info` icon, and a mime-only selector let that link through as a **phantom attachment beside every real file**. Only an attachment count catches it.

**Safe-area.** `targetSdk 36` forces edge-to-edge. `--safe-top` resolved correctly at 48px all along — nothing read it. Swept `ScreenHeader`, the bulletin overlay, both dropdowns and the toast. sonner needed **`mobileOffset`, not `offset`** (it switches below a 600px viewport, so `offset` alone was a silent no-op).

**Sheets could not be swiped closed.** The drag pill was decoration. Pointer handlers alone weren't enough — instrumenting the event stream showed the browser claiming the drag as a pan and firing `pointercancel` after ~20px of a 350px swipe. `touch-action: none`, scoped to the header so content still scrolls.

**Back quit the app from vývěska** because that overlay is not a sheet — own store flag, portals to body, so the stack read empty. `enableOnBackInvokedCallback` is also now set (the documented targetSdk 36 fix).

## Scope changes

Greeting dropped and the date promoted to the calendar title; vývěska moved into the header; Drive sync and library booking hidden on mobile; Erasmus Learning Agreement behind a defaulted prop (desktop untouched); eduroam moved into settings as a one-tap row; feedback rendered as a bottom sheet; duplicate per-tab IS link removed in favour of the sheet's pinned one.

## Verified on device

| Check | Result |
|---|---|
| File type badges | PDF / DOCX / ZIP — no "FILE" |
| IS links per tab | exactly 1, on all 5 tabs |
| Download feedback | toast at `top: 64px` (16 + 48 safe-top) |
| Calendar header | date title clear of the clock |
| Vývěska header | `padding-top: 48px`, title at y=65 |
| Back on vývěska | closes overlay, app stays |
| Swipe-to-close | panel 1 → 0; content still scrolls to 490px |
| Feedback | flex-end, 20px top radius, flush, full width |
| Map tabs | Akce + Budova only — no Knihovna |
| Settings | eduroam row present, no Drive toggle |
| eduroam sheet | opens from settings, password renders, **no telemetry** |

## Still owed

- **The predictive-back gesture needs a human thumb.** `adb` cannot inject a system gesture, and `keyevent 4` exercises the legacy path that worked all along. Decisive test: **open vývěska and swipe back** — if the noticeboard closes and the app stays, this and the bulletin fix are confirmed together.
- **eduroam cert download deliberately not tapped** — it can generate a certificate and rotate a 366-day credential. Assert the bytes start `0x30 0x82` when checking by hand.
- Search and external-links-in-app remain unverified.
- `MobileSearchOverlay` still lacks its inset, blocked by pre-existing lint debt in the same file.
- Other parsers may share the `sysid` break.

## Gates

1,937 tests pass (12 new), typecheck, eslint + prettier on changed files, nuia ratchet. The large `parser.ts` diff is prettier reformatting a legacy 4-space file for the changed-files gate — logic and column constants untouched, confirmed by tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Android notification permission handling when saving files to Downloads, with success feedback after delivery.
  * Added swipe-down dismissal for mobile sheets.
  * Improved mobile safe-area support across headers, overlays, dropdowns, and notifications.
  * Added optional hiding of Learning Agreement and IS MENDELU backlinks.
  * Added direct Eduroam access in profile settings.
  * Updated calendar headers to show the selected date and repositioned bulletin actions.

* **Bug Fixes**
  * Back navigation now closes open sheets and bulletins before exiting.
  * Removed unavailable mobile library and Eduroam shortcuts.
  * Improved document attachment type detection.
  * Improved handling of external links from event and notification menus.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->