### PR TITLE
eduroam on Android: one tap, configured by the OS

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -61,4 +61,9 @@
     <!-- Runtime-requested on Android 13+; without it the download notification
          is silently dropped (the file still saves). -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <!-- eduroam setup (EduroamPlugin). Both are normal permissions — granted at
+         install, no runtime prompt. The network itself is saved by Android's own
+         dialog via ACTION_WIFI_ADD_NETWORKS, not by us. -->
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
 </manifest>

--- a/android/app/src/main/java/cz/reis/app/EduroamPlugin.java
+++ b/android/app/src/main/java/cz/reis/app/EduroamPlugin.java
@@ -19,10 +19,12 @@ import com.getcapacitor.annotation.CapacitorPlugin;
 
 import java.io.ByteArrayInputStream;
 import java.security.KeyStore;
+import java.security.KeyStoreException;
 import java.security.PrivateKey;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
+import java.util.Enumeration;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -101,7 +103,7 @@ public class EduroamPlugin extends Plugin {
                 call.reject("FAILED at stage=keystore: the PKCS#12 contains no entries");
                 return;
             }
-            String alias = ks.aliases().nextElement();
+            String alias = keyEntryAlias(ks);
             PrivateKey key = (PrivateKey) ks.getKey(alias, pass);
             X509Certificate clientCert = (X509Certificate) ks.getCertificate(alias);
             if (key == null || clientCert == null) {
@@ -170,6 +172,30 @@ public class EduroamPlugin extends Plugin {
             call.reject("FAILED at stage=" + stage + ": "
                     + e.getClass().getSimpleName() + ": " + e.getMessage(), e);
         }
+    }
+
+    /**
+     * The alias holding the private key. PKCS#12 entry order is unspecified, so
+     * the first alias is not necessarily the key entry: a bundle that ships its
+     * issuing chain as separate certificate-only entries can enumerate one of
+     * those first, and keying off it would reject material that is perfectly
+     * valid. Falls back to the first alias when no entry claims to be a key
+     * entry — the caller already null-checks the key and certificate, so a
+     * provider that mislabels its entries fails no worse than before.
+     */
+    private static String keyEntryAlias(KeyStore ks) throws KeyStoreException {
+        String first = null;
+        Enumeration<String> aliases = ks.aliases();
+        while (aliases.hasMoreElements()) {
+            String alias = aliases.nextElement();
+            if (ks.isKeyEntry(alias)) {
+                return alias;
+            }
+            if (first == null) {
+                first = alias;
+            }
+        }
+        return first;
     }
 
     /**

--- a/android/app/src/main/java/cz/reis/app/EduroamPlugin.java
+++ b/android/app/src/main/java/cz/reis/app/EduroamPlugin.java
@@ -1,0 +1,216 @@
+package cz.reis.app;
+
+import android.content.Intent;
+import android.net.wifi.WifiEnterpriseConfig;
+import android.net.wifi.WifiNetworkSuggestion;
+import android.os.Build;
+import android.os.Bundle;
+import android.provider.Settings;
+import android.util.Base64;
+
+import androidx.activity.result.ActivityResult;
+
+import com.getcapacitor.JSObject;
+import com.getcapacitor.Plugin;
+import com.getcapacitor.PluginCall;
+import com.getcapacitor.PluginMethod;
+import com.getcapacitor.annotation.ActivityCallback;
+import com.getcapacitor.annotation.CapacitorPlugin;
+
+import java.io.ByteArrayInputStream;
+import java.security.KeyStore;
+import java.security.PrivateKey;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Configures MENDELU's eduroam as a real saved Wi-Fi network, from the student's
+ * own IS certificate. Two taps: the button in reIS, then Save in Android's own
+ * dialog.
+ *
+ * Ported from the throwaway spike's EduroamProbePlugin, which verified on API 35
+ * with real MENDELU cert material that this path accepts an EAP-TLS config backed
+ * by a SELF-SIGNED root — the one assumption worth proving before building on it.
+ *
+ * Java rather than Kotlin on purpose: the Capacitor app module has no Kotlin
+ * Gradle plugin, and DownloadsPlugin is Java for the same reason.
+ *
+ * Why not geteduroam: it re-resolves the signing institution against the eduroam
+ * discovery catalogue, MENDELU is not in it, and the failed lookup disables a
+ * config that was already working. This path has no discovery step at all.
+ *
+ * Why not WifiManager.addNetworkSuggestions: that API is built for carrier
+ * offload. Its networks are invisible in the Wi-Fi list, a declined prompt
+ * revokes CHANGE_WIFI_STATE, and tapping Disconnect blacklists the network for
+ * 24 hours. ACTION_WIFI_ADD_NETWORKS produces a network the student owns.
+ */
+@CapacitorPlugin(name = "Eduroam")
+public class EduroamPlugin extends Plugin {
+
+    private static final String SSID = "eduroam";
+
+    /**
+     * MENDELU's own Android guide says `mendelu.cz`, and that is what this must
+     * be — NOT the `aleph.mendelu.cz` the iOS profile pins. setDomainSuffixMatch
+     * does label-wise suffix matching against SubjectAltName dNSName entries,
+     * which is stricter and differently scoped than Apple's TLSTrustedServerNames.
+     * The shorter suffix still matches aleph.mendelu.cz and survives a RADIUS
+     * rename. Security is anchored by the private MENDELU root, not by hostname
+     * granularity.
+     */
+    private static final String DOMAIN_SUFFIX = "mendelu.cz";
+
+    /** CN=... in an RFC 2253 subject, honouring backslash-escaped separators. */
+    private static final Pattern CN = Pattern.compile("CN=((?:\\\\.|[^,])*)");
+
+    @PluginMethod
+    public void configure(PluginCall call) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+            // The JS side gates on this too, but a plugin surface is reachable
+            // from any script in the WebView, so it cannot rely on that.
+            call.reject("ACTION_WIFI_ADD_NETWORKS requires Android 11 (API 30); this device is "
+                    + Build.VERSION.SDK_INT);
+            return;
+        }
+
+        String p12Base64 = call.getString("p12Base64");
+        String passphrase = call.getString("passphrase");
+        String caDerBase64 = call.getString("caDerBase64");
+        if (p12Base64 == null || passphrase == null || caDerBase64 == null) {
+            call.reject("configure requires p12Base64, passphrase and caDerBase64");
+            return;
+        }
+
+        // Reported on every failure. "Rejected" is only actionable if we know
+        // whether the PKCS#12, the CA, the Builder or the system dialog rejected
+        // it — this is the single most useful thing the spike taught.
+        String stage = "decode";
+        try {
+            byte[] p12 = Base64.decode(p12Base64, Base64.DEFAULT);
+            char[] pass = passphrase.toCharArray();
+            byte[] caDer = Base64.decode(caDerBase64, Base64.DEFAULT);
+
+            stage = "keystore";
+            KeyStore ks = KeyStore.getInstance("PKCS12");
+            ks.load(new ByteArrayInputStream(p12), pass);
+            if (!ks.aliases().hasMoreElements()) {
+                call.reject("FAILED at stage=keystore: the PKCS#12 contains no entries");
+                return;
+            }
+            String alias = ks.aliases().nextElement();
+            PrivateKey key = (PrivateKey) ks.getKey(alias, pass);
+            X509Certificate clientCert = (X509Certificate) ks.getCertificate(alias);
+            if (key == null || clientCert == null) {
+                call.reject("FAILED at stage=keystore: no key/certificate pair under " + alias);
+                return;
+            }
+
+            stage = "ca";
+            X509Certificate ca = (X509Certificate) CertificateFactory
+                    .getInstance("X.509")
+                    .generateCertificate(new ByteArrayInputStream(caDer));
+
+            stage = "identity";
+            // Android does NOT derive the EAP identity from the client
+            // certificate — it must be set explicitly, and an empty one is what
+            // greys out CONNECT in the manual flow. But the IS-issued cert's
+            // subject CN already IS `<login>@mendelu.cz`, so read it off the
+            // certificate already in hand rather than asking the student or
+            // making another IS request. An explicit override wins if supplied.
+            String identity = call.getString("identity");
+            if (identity == null || identity.isEmpty()) {
+                identity = subjectCommonName(clientCert);
+            }
+            if (identity == null || identity.isEmpty()) {
+                call.reject("FAILED at stage=identity: no CN on the client certificate and no "
+                        + "identity supplied");
+                return;
+            }
+
+            stage = "enterpriseConfig";
+            WifiEnterpriseConfig enterprise = new WifiEnterpriseConfig();
+            enterprise.setEapMethod(WifiEnterpriseConfig.Eap.TLS);
+            enterprise.setCaCertificate(ca);
+            enterprise.setClientKeyEntry(key, clientCert);
+            enterprise.setDomainSuffixMatch(DOMAIN_SUFFIX);
+            enterprise.setIdentity(identity);
+
+            stage = "suggestionBuilder";
+            // There is NO generic setWifiEnterpriseConfig on this Builder — the
+            // caller must commit to a WPA generation, and MENDELU's eduroam is
+            // WPA2-Enterprise. Deprecated since API 33 but still the only WPA2
+            // path. (A WifiNetworkSuggestion object is used here, but this is
+            // NOT the Suggestion API; the intent below makes it a saved network.)
+            @SuppressWarnings("deprecation")
+            WifiNetworkSuggestion suggestion = new WifiNetworkSuggestion.Builder()
+                    .setSsid(SSID)
+                    .setWpa2EnterpriseConfig(enterprise)
+                    .build();
+
+            stage = "intent";
+            ArrayList<WifiNetworkSuggestion> list = new ArrayList<>();
+            list.add(suggestion);
+            Bundle extras = new Bundle();
+            extras.putParcelableArrayList(Settings.EXTRA_WIFI_NETWORK_LIST, list);
+            Intent intent = new Intent(Settings.ACTION_WIFI_ADD_NETWORKS).putExtras(extras);
+
+            // Diagnostics that cost nothing and explain a later rejection. Both
+            // are certificate subjects, not student data beyond the login the
+            // student is themselves configuring.
+            call.getData().put("_identity", identity);
+            call.getData().put("_caSubject", ca.getSubjectX500Principal().getName());
+
+            stage = "startActivity";
+            startActivityForResult(call, intent, "onAddResult");
+        } catch (Exception e) {
+            call.reject("FAILED at stage=" + stage + ": "
+                    + e.getClass().getSimpleName() + ": " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Pull CN out of an RFC 2253 subject. Android has no javax.naming.ldap, so
+     * this is a regex rather than an LdapName — the MENDELU CN is an email
+     * address with no separators in it, and escaped commas are handled anyway.
+     */
+    static String subjectCommonName(X509Certificate cert) {
+        Matcher m = CN.matcher(cert.getSubjectX500Principal().getName());
+        return m.find() ? m.group(1).replace("\\", "") : null;
+    }
+
+    @ActivityCallback
+    private void onAddResult(PluginCall call, ActivityResult result) {
+        if (call == null) {
+            return;
+        }
+        String perNetwork = "(none)";
+        if (result.getData() != null) {
+            List<Integer> codes = result.getData()
+                    .getIntegerArrayListExtra(Settings.EXTRA_WIFI_NETWORK_RESULT_LIST);
+            if (codes != null) {
+                StringBuilder sb = new StringBuilder();
+                for (Integer c : codes) {
+                    if (sb.length() > 0) {
+                        sb.append(',');
+                    }
+                    sb.append(c);
+                }
+                perNetwork = sb.toString();
+            }
+        }
+        JSObject ret = new JSObject();
+        // resultCode -1 = RESULT_OK, 0 = RESULT_CANCELED. The JS side maps these
+        // to an outcome; see src/mobile/configureEduroam.ts.
+        ret.put("resultCode", result.getResultCode());
+        // per-network 0 = ADD_WIFI_RESULT_SUCCESS, 1 = ADD_OR_UPDATE_FAILED,
+        // 2 = ALREADY_EXISTS.
+        ret.put("perNetwork", perNetwork);
+        ret.put("identity", call.getData().optString("_identity"));
+        ret.put("caSubject", call.getData().optString("_caSubject"));
+        call.resolve(ret);
+    }
+}

--- a/android/app/src/main/java/cz/reis/app/MainActivity.java
+++ b/android/app/src/main/java/cz/reis/app/MainActivity.java
@@ -8,6 +8,7 @@ public class MainActivity extends BridgeActivity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         registerPlugin(DownloadsPlugin.class);
+        registerPlugin(EduroamPlugin.class);
         super.onCreate(savedInstanceState);
     }
 }

--- a/docs/superpowers/plans/2026-08-02-capacitor-remaining-work.md
+++ b/docs/superpowers/plans/2026-08-02-capacitor-remaining-work.md
@@ -448,33 +448,54 @@ and was unaffected.
 reproduced in this repo's test environment at all. Worth knowing before trusting a green
 suite on any header-merging question.
 
-## Task 5 — eduroam native one-tap (#159)
+## Task 5 — eduroam native one-tap (#159) — Android BUILT, unverified on a device
 
-**Nothing exists in the product.** Verified: `android/app/src/main/java/cz/reis/app/`
-holds only `MainActivity.java` and `DownloadsPlugin.java`; the manifest declares no
-`ACCESS_WIFI_STATE` / `CHANGE_WIFI_STATE`; there is no iOS hotspot code or entitlement.
-Only the throwaway spike proved the approach.
+**The Android half is written** (branch `worktree-eduroam-android-native`). What landed:
 
-~~Today the sheet is 100% non-functional and fails at the first network call~~ — **the
-network half is fixed** (Task 3 / PR #181). `fetchEduroamPassword` is no longer a
-CORS-blocked bare `fetch`, so the sheet should stop firing a telemetry report on every
-open and the password should render. **Unconfirmed on a device** — that is the owed check
-in Task 3, and it is the first thing to do here, because everything below assumes the
-cert material actually arrives.
+1. `android/.../EduroamPlugin.java` — a port of the spike's `EduroamProbePlugin`, which
+   verified on API 35 with real MENDELU cert material that `ACTION_WIFI_ADD_NETWORKS`
+   accepts an EAP-TLS config backed by a **self-signed** root. Java, not Kotlin: the app
+   module has no Kotlin Gradle plugin. Registered in `MainActivity`.
+2. `ACCESS_WIFI_STATE` + `CHANGE_WIFI_STATE` in the manifest — both normal permissions,
+   granted at install, no runtime prompt.
+3. `src/mobile/configureEduroam.ts` (pure, 11 tests) + `src/mobile/eduroamNative.ts`
+   (the `registerPlugin` wiring and the capability gate).
+4. `useEduroamSetup` native branch ahead of every file/transfer path; `EduroamSheet`
+   drops to two steps on the phone. Android chosen in a *desktop* browser is untouched
+   and still gets the QR transfer.
 
-What remains is the **native Wi-Fi configuration** — nothing joins a network yet.
+**Two departures from the sketch in #159, both deliberate:**
 
-Task 3 (POST + bytes) is now **done**, so this is unblocked. Then:
+- **The identity is derived in the plugin, not passed from JS.** #159 is right that
+  Android does not derive it (an empty Identity is what greys out CONNECT), but the
+  plugin already opens the PKCS#12 for the private key, and the IS-issued cert's subject
+  CN *is* `<login>@mendelu.cz`. Reading it there avoids both an extra `?get=user-der`
+  request and a second ASN.1 parser in TypeScript. An explicit override still wins.
+- **Unknown and missing result codes fail CLOSED.** Claiming success when the network
+  was not saved sends a student to campus with wi-fi that never connects; the opposite
+  mistake self-corrects, since a retry over a network that did save returns
+  ALREADY_EXISTS, which reads as success.
 
-1. Android plugin `configure({p12Base64, passphrase, caDerBase64, login})` — the spike's
-   `EduroamProbePlugin` is the working reference. **`setWifiEnterpriseConfig()` does not
-   exist**; use `setWpa2EnterpriseConfig`. Min API 30.
-2. Manifest permissions.
-3. `EduroamTarget` gains a `native` branch, bypassing `putTransfer` / QR / `saveAs`
-   entirely — and `EduroamSheet.tsx:88` must stop rendering a QR on the very device being
-   configured (it is a desktop→phone artifact; unscannable here).
+**What is NOT verified, and how to verify it:**
+
+- **The Java has never been compiled.** There is no JDK on the dev machine
+  (`/usr/bin/java` is the macOS stub; no JVMs installed, no Android Studio). Install one
+  (`brew install --cask temurin`) and run
+  `./gradlew :app:compileDebugJavaWithJavac` before trusting any of the above.
+- **Nothing has run on a handset.** The decisive check is on campus: acceptance is not
+  connection — the spike's emulator returned `FAILURE_NETWORK_NOT_FOUND` purely because
+  no eduroam AP was in range. That remains the last real unknown on the Android path.
+- The **API 30 floor** is not gated in JS on purpose. `minSdkVersion` is 24, so Android
+  7–10 devices reach the plugin and get an explicit rejection rather than a silently
+  different flow. **Product decision still open:** leave them on the manual instructions,
+  or raise minSdk.
+
+**Still not started:**
+
 4. iOS `NEHotspotEAPSettings` + entitlement — **still unverified** whether iOS accepts
-   MENDELU's self-signed root.
+   MENDELU's self-signed root. Blocked behind Task 7 (the iOS app has never been built).
+   Note the same QR-pointing-at-itself absurdity exists on the iOS app today: target
+   resolves to `ios`, which takes the transfer path. Pre-existing, not introduced here.
 5. Cert expiry is 366 days and silent; renewal is a POST (an IS write) and must stay
    student-initiated.
 

--- a/docs/superpowers/plans/2026-08-02-capacitor-remaining-work.md
+++ b/docs/superpowers/plans/2026-08-02-capacitor-remaining-work.md
@@ -75,7 +75,8 @@ on the extension is the check that would actually confirm it.
 | Re-login after a lapsed session | **Done**, prompt-first — **unverified on a device** |
 | Secure storage for `UISAuth` (Task 6) | **Not started** — the one hard release gate |
 | iOS app | **Never built** — only the throwaway spike ran there |
-| ISKAM, Drive, native Wi-Fi | **Broken** — see below |
+| Native Wi-Fi (eduroam, Android) | **Done**, device-verified — Task 5 |
+| ISKAM, Drive | **Broken** — see below |
 
 **Everything shipped since PR #181 is unit-tested only.** That is the single largest risk
 in this document, and it compounds: this transport's own record is *four* bugs shipping
@@ -505,6 +506,34 @@ framework auto-installs the key and CA: no cert-install dialog, no Settings danc
 A read-only check of `certifikat.pl` ran FIRST to confirm a certificate already existed
 (issued 21 Jun 2026), so the flow read it and never POSTed `gen=`. **Keep that order** —
 generating rotates a 366-day credential the student may have installed elsewhere.
+
+**Re-running is safe, and that replaces "detection".** Verified on the same handset with
+the network already saved: the system dialog appears again (Android does NOT pre-suppress
+it), the result is `SUCCESS` rather than `ADD_WIFI_RESULT_ALREADY_EXISTS`, and network 73
+is updated **in place** — `cmd wifi list-networks` still shows one `eduroam`, no duplicate.
+
+Two consequences:
+
+- The `already-configured` branch is kept as a defensive mapping (documented API, OEMs
+  vary) but **nothing may depend on it** — it appears unreachable on Android 16.
+- **Certificate expiry needs no special mechanism.** At ~366 days the student taps the
+  same button and the credential is replaced in place. Renewal stays student-initiated
+  because generating is an IS write; the *config* side is already idempotent.
+
+**Detecting an existing eduroam config before setup is not possible, by design.**
+`WifiManager.getConfiguredNetworks()` is deprecated at API 29 and since Android 10
+returns only networks the calling app created. Scan results prove range, not
+configuration. `getConnectionInfo().getSSID()` needs location permission and only answers
+while connected on campus. So do not gate an onboarding prompt on detection — offer it,
+record completion locally, and let idempotency absorb the rest.
+
+**Build trap that cost a broken install.** `android/app/src/main/assets/public` is
+**gitignored**, so a `cap sync`'d web bundle SURVIVES a branch switch while the Java does
+not. Switching to a branch without `EduroamPlugin.java` and rebuilding produced an APK
+with eduroam-aware JavaScript over Java that had no such plugin — Capacitor threw
+"Eduroam plugin is not implemented on android", which the sheet then reported as
+"couldn't prepare the profile". Always re-run `npm run build:capacitor && npx cap sync
+android` after changing branches, and never trust an incremental APK across a switch.
 
 **Still not verified:**
 

--- a/docs/superpowers/plans/2026-08-02-capacitor-remaining-work.md
+++ b/docs/superpowers/plans/2026-08-02-capacitor-remaining-work.md
@@ -476,15 +476,41 @@ suite on any header-merging question.
   mistake self-corrects, since a retry over a network that did save returns
   ALREADY_EXISTS, which reads as success.
 
-**What is NOT verified, and how to verify it:**
+**DEVICE-VERIFIED 2026-08-08** on the A001 handset (Android 16 / API 36), end to end
+against the student's real IS certificate. `./gradlew :app:compileDebugJavaWithJavac`
+succeeds (JDK 21 via `brew install openjdk@21`; the machine had no JVM at all before).
 
-- **The Java has never been compiled.** There is no JDK on the dev machine
-  (`/usr/bin/java` is the macOS stub; no JVMs installed, no Android Studio). Install one
-  (`brew install --cask temurin`) and run
-  `./gradlew :app:compileDebugJavaWithJavac` before trusting any of the above.
-- **Nothing has run on a handset.** The decisive check is on campus: acceptance is not
-  connection — the spike's emulator returned `FAILURE_NETWORK_NOT_FOUND` purely because
-  no eduroam AP was in range. That remains the last real unknown on the Android path.
+The flow: profile → eduroam → one tap → Android's own dialog
+(**"Save this network? / reIS wants to save a network to your phone / eduroam"**,
+activity `com.android.settings.wifi.addappnetworks.AddAppNetworksActivity`) → Save.
+Two taps, exactly as promised.
+
+`dumpsys wifi` afterwards, i.e. Android's record and not the app's claim:
+
+```
+ID: 73 SSID: "eduroam"
+KeyMgmt: WPA_EAP IEEE8021X          (Type 3 + Type 9 → WPA2- and WPA3-Enterprise)
+eap_method: TLS
+identity "xholek1@mendelu.cz"
+domain_suffix_match "mendelu.cz"
+client_cert "keystore://USRCERT_..."
+ca_cert     "keystore://CACERT_..."
+```
+
+**The identity line proves the design call.** It was derived inside the plugin from the
+client cert's subject CN — no `?get=user-der` request, no ASN.1 parser in TypeScript —
+and it produced the exact string EAP-TLS needs. The `keystore://` entries confirm the
+framework auto-installs the key and CA: no cert-install dialog, no Settings dance.
+
+A read-only check of `certifikat.pl` ran FIRST to confirm a certificate already existed
+(issued 21 Jun 2026), so the flow read it and never POSTed `gen=`. **Keep that order** —
+generating rotates a 366-day credential the student may have installed elsewhere.
+
+**Still not verified:**
+
+- **Association on campus.** Acceptance is not connection. The phone had no eduroam AP
+  in range (`cmd wifi list-scan-results` was empty for it), so this still needs the
+  handset on MENDELU grounds. It is now the ONLY unknown on the Android path.
 - The **API 30 floor** is not gated in JS on purpose. `minSdkVersion` is 24, so Android
   7–10 devices reach the plugin and get an explicit rejection rather than a silently
   different flow. **Product decision still open:** leave them on the manual instructions,

--- a/src/components/mobile/sheets/EduroamSheet.tsx
+++ b/src/components/mobile/sheets/EduroamSheet.tsx
@@ -61,10 +61,15 @@ export function EduroamSheet({ onClose }: EduroamSheetProps) {
           <div className="alert alert-error text-base">
             <AlertTriangle className="h-4 w-4 flex-shrink-0" />
             <span>
-              {/* On the native path nothing was prepared or downloaded, so the
-                  profile wording would describe a step that never happened. */}
-              {native && outcome === 'failed'
-                ? t('eduroam.native.failed')
+              {/* On the native path nothing is prepared or downloaded, so the
+                  profile wording would describe a step that never happens —
+                  including when the throw lands before Android is ever reached
+                  (a lapsed IS session, a blip fetching the certificate) and
+                  outcome is therefore still null. */}
+              {native
+                ? outcome === 'failed'
+                  ? t('eduroam.native.failed')
+                  : `${t('eduroam.native.error')}${error ? `: ${error}` : ''}`
                 : `${t('eduroam.error')}${error ? `: ${error}` : ''}`}
             </span>
           </div>

--- a/src/components/mobile/sheets/EduroamSheet.tsx
+++ b/src/components/mobile/sheets/EduroamSheet.tsx
@@ -1,10 +1,11 @@
-import { Download, Loader2, AlertTriangle } from 'lucide-react';
+import { Download, Loader2, AlertTriangle, Wifi, CheckCircle2 } from 'lucide-react';
 import { Sheet } from '../primitives/Sheet';
 import { SheetHeader } from '../primitives/SheetHeader';
 import { PasswordChip } from '../../Eduroam/PasswordChip';
 import { useEduroamSetup, type EduroamTarget } from '../../../hooks/data/useEduroamSetup';
 import { useTranslation } from '../../../hooks/useTranslation';
 import { isMac, isMobile } from '../../../utils/platform';
+import { canConfigureEduroamNatively } from '../../../mobile/eduroamNative';
 
 export interface EduroamSheetProps {
   onClose: () => void;
@@ -27,17 +28,26 @@ function NumberBadge({ n }: { n: number }) {
 }
 
 /**
- * Container sheet for the eduroam flow (prototype lines 535-544): three
- * numbered rows — certificate password, one-tap download for the detected
- * device, and the install/connect hint. All certificate/profile generation
- * logic stays in `useEduroamSetup` (shared with the desktop `EduroamDrawer`)
- * — this sheet only auto-picks the target and lays out the result.
+ * Container sheet for the eduroam flow (prototype lines 535-544): numbered rows
+ * — certificate password, one-tap download for the detected device, and the
+ * install/connect hint. All certificate/profile generation logic stays in
+ * `useEduroamSetup` (shared with the desktop `EduroamDrawer`) — this sheet only
+ * auto-picks the target and lays out the result.
+ *
+ * Inside the Android app the first row disappears: Android saves the network
+ * itself, so nothing is downloaded and no password is ever typed by a human.
+ * Two steps instead of three.
  */
 export function EduroamSheet({ onClose }: EduroamSheetProps) {
   const { t } = useTranslation();
   const target = detectTarget();
-  const { status, password, qrDataUrl, error, run } = useEduroamSetup(target);
+  const { status, password, qrDataUrl, error, outcome, run } = useEduroamSetup(target);
   const working = status === 'working';
+
+  // On the phone itself Android saves the network directly, so there is no
+  // profile to download, no QR to scan, and no password for anyone to type.
+  // That collapses the flow from three steps to two.
+  const native = canConfigureEduroamNatively(target);
 
   return (
     <Sheet size="content" onClose={onClose}>
@@ -51,25 +61,47 @@ export function EduroamSheet({ onClose }: EduroamSheetProps) {
           <div className="alert alert-error text-base">
             <AlertTriangle className="h-4 w-4 flex-shrink-0" />
             <span>
-              {t('eduroam.error')}
-              {error ? `: ${error}` : ''}
+              {/* On the native path nothing was prepared or downloaded, so the
+                  profile wording would describe a step that never happened. */}
+              {native && outcome === 'failed'
+                ? t('eduroam.native.failed')
+                : `${t('eduroam.error')}${error ? `: ${error}` : ''}`}
             </span>
           </div>
         )}
 
-        <div className="flex items-center gap-3">
-          <NumberBadge n={1} />
-          <div className="min-w-0 flex-1">
-            {password ? (
-              <PasswordChip password={password} />
-            ) : (
-              <span className="text-base text-base-content/60">{t('eduroam.pwdLabel')}</span>
-            )}
+        {native && outcome === 'cancelled' && (
+          <div className="alert alert-info text-base">
+            <span>{t('eduroam.native.cancelled')}</span>
           </div>
-        </div>
+        )}
+
+        {status === 'done' &&
+          native &&
+          (outcome === 'saved' || outcome === 'already-configured') && (
+            <div className="alert alert-success text-base">
+              <CheckCircle2 className="h-4 w-4 flex-shrink-0" />
+              <span>
+                {outcome === 'saved' ? t('eduroam.native.saved') : t('eduroam.native.already')}
+              </span>
+            </div>
+          )}
+
+        {!native && (
+          <div className="flex items-center gap-3">
+            <NumberBadge n={1} />
+            <div className="min-w-0 flex-1">
+              {password ? (
+                <PasswordChip password={password} />
+              ) : (
+                <span className="text-base text-base-content/60">{t('eduroam.pwdLabel')}</span>
+              )}
+            </div>
+          </div>
+        )}
 
         <div className="flex items-center gap-3">
-          <NumberBadge n={2} />
+          <NumberBadge n={native ? 1 : 2} />
           <button
             type="button"
             onClick={() => run(target)}
@@ -78,23 +110,37 @@ export function EduroamSheet({ onClose }: EduroamSheetProps) {
           >
             {working ? (
               <Loader2 className="h-4 w-4 animate-spin" />
+            ) : native ? (
+              <Wifi className="h-4 w-4" />
             ) : (
               <Download className="h-4 w-4" />
             )}
-            {working ? t('eduroam.preparing') : t('eduroam.download')}
+            {working
+              ? native
+                ? t('eduroam.native.working')
+                : t('eduroam.preparing')
+              : native
+                ? t('eduroam.native.button')
+                : t('eduroam.download')}
           </button>
         </div>
 
-        {status === 'done' && qrDataUrl && (
+        {/* Never on the native path: the QR is a desktop→phone artifact and
+            would be pointing this device at itself. */}
+        {status === 'done' && qrDataUrl && !native && (
           <div className="ml-9 self-start rounded-box bg-white p-3">
             <img src={qrDataUrl} alt="eduroam QR" width={160} height={160} />
           </div>
         )}
 
         <div className="flex items-center gap-3">
-          <NumberBadge n={3} />
+          <NumberBadge n={native ? 2 : 3} />
           <span className="flex-1 text-sm text-base-content/70">{t('eduroam.connectStep')}</span>
         </div>
+
+        {native && (
+          <p className="ml-9 text-sm text-base-content/60">{t('eduroam.native.privacyNote')}</p>
+        )}
       </div>
     </Sheet>
   );

--- a/src/components/mobile/sheets/__tests__/EduroamSheet.test.tsx
+++ b/src/components/mobile/sheets/__tests__/EduroamSheet.test.tsx
@@ -4,6 +4,7 @@ import { EduroamSheet } from '../EduroamSheet';
 import { useAppStore } from '../../../../store/useAppStore';
 import { useEduroamSetup } from '../../../../hooks/data/useEduroamSetup';
 import { isMac, isMobile } from '../../../../utils/platform';
+import { canConfigureEduroamNatively } from '../../../../mobile/eduroamNative';
 
 vi.mock('../../../../hooks/data/useEduroamSetup', () => ({
   useEduroamSetup: vi.fn(),
@@ -14,11 +15,18 @@ vi.mock('../../../../utils/platform', () => ({
   isMobile: vi.fn(),
 }));
 
+vi.mock('../../../../mobile/eduroamNative', () => ({
+  canConfigureEduroamNatively: vi.fn().mockReturnValue(false),
+}));
+
 const mockedUseEduroamSetup = vi.mocked(useEduroamSetup);
 const mockedIsMac = vi.mocked(isMac);
 const mockedIsMobile = vi.mocked(isMobile);
+const mockedCanConfigureNatively = vi.mocked(canConfigureEduroamNatively);
 
-function baseHookState() {
+type HookState = ReturnType<typeof useEduroamSetup>;
+
+function baseHookState(): HookState {
   return {
     status: 'idle' as const,
     target: 'windows' as const,
@@ -26,10 +34,20 @@ function baseHookState() {
     password: null,
     qrDataUrl: null,
     error: null,
+    outcome: null,
     run: vi.fn(),
     reset: vi.fn(),
     openProfilesSettings: vi.fn(),
   };
+}
+
+/** An Android phone running the Capacitor app, where the OS does the setup. */
+function onPhone(over: Partial<HookState> = {}) {
+  mockedIsMobile.mockReturnValue(true);
+  mockedIsMac.mockReturnValue(false);
+  mockedCanConfigureNatively.mockReturnValue(true);
+  mockedUseEduroamSetup.mockReturnValue({ ...baseHookState(), target: 'android', ...over });
+  useAppStore.setState({ language: 'cz' } as never);
 }
 
 afterEach(() => {
@@ -126,6 +144,74 @@ describe('EduroamSheet', () => {
     render(<EduroamSheet onClose={vi.fn()} />);
 
     expect(screen.getByText(/Session expired/)).toBeInTheDocument();
+  });
+
+  it('drops the password step on the phone — the app opens the certificate itself', () => {
+    // The extraction password only exists so a human can type it into an
+    // install dialog. On this path the plugin opens the PKCS#12 directly, so
+    // showing the password would be handing over a credential for no reason.
+    onPhone({ password: 'abc123' });
+
+    render(<EduroamSheet onClose={vi.fn()} />);
+
+    expect(screen.queryByText('abc123')).not.toBeInTheDocument();
+    expect(screen.getByText('1')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.queryByText('3')).not.toBeInTheDocument();
+  });
+
+  it('offers to set eduroam up, not to download a profile', () => {
+    onPhone();
+
+    render(<EduroamSheet onClose={vi.fn()} />);
+
+    expect(screen.getByText('Nastavit eduroam')).toBeInTheDocument();
+    expect(screen.queryByText('Stáhnout eduroam profil')).not.toBeInTheDocument();
+  });
+
+  it('confirms in plain language once Android has saved the network', () => {
+    onPhone({ status: 'done', outcome: 'saved' });
+
+    render(<EduroamSheet onClose={vi.fn()} />);
+
+    expect(screen.getByText(/eduroam je uložený/)).toBeInTheDocument();
+  });
+
+  it('reads an already-configured network as success, not a problem', () => {
+    onPhone({ status: 'done', outcome: 'already-configured' });
+
+    render(<EduroamSheet onClose={vi.fn()} />);
+
+    expect(screen.getByText(/už na tomto telefonu nastavený je/)).toBeInTheDocument();
+  });
+
+  it('does not scold a student who dismissed the system dialog', () => {
+    onPhone({ status: 'idle', outcome: 'cancelled' });
+
+    render(<EduroamSheet onClose={vi.fn()} />);
+
+    expect(screen.getByText(/Klepni znovu/)).toBeInTheDocument();
+    expect(screen.queryByText('Profil se nepodařilo připravit')).not.toBeInTheDocument();
+    expect(screen.getByText('Nastavit eduroam')).toBeInTheDocument();
+  });
+
+  it('names the real failure when Android refuses the network', () => {
+    // "Couldn't prepare the profile" is the wrong sentence here: no profile is
+    // involved, and nothing was downloaded.
+    onPhone({ status: 'error', outcome: 'failed' });
+
+    render(<EduroamSheet onClose={vi.fn()} />);
+
+    expect(screen.getByText(/Android síť eduroam neuložil/)).toBeInTheDocument();
+  });
+
+  it('never renders a QR on the phone being configured', () => {
+    // A desktop→phone artifact; on this device it points at itself.
+    onPhone({ status: 'done', outcome: 'saved', qrDataUrl: 'data:image/png;base64,zz' });
+
+    render(<EduroamSheet onClose={vi.fn()} />);
+
+    expect(screen.queryByAltText('eduroam QR')).not.toBeInTheDocument();
   });
 
   it('closes via the header close button', () => {

--- a/src/components/mobile/sheets/__tests__/EduroamSheet.test.tsx
+++ b/src/components/mobile/sheets/__tests__/EduroamSheet.test.tsx
@@ -195,6 +195,18 @@ describe('EduroamSheet', () => {
     expect(screen.getByText('Nastavit eduroam')).toBeInTheDocument();
   });
 
+  it('never blames a profile on the native path, whatever failed', () => {
+    // A throw before Android is even reached — a lapsed IS session, a network
+    // blip fetching the certificate — leaves outcome null. The generic copy
+    // ("couldn't prepare the profile") describes a step this path never takes.
+    onPhone({ status: 'error', outcome: null, error: 'Failed to fetch' });
+
+    render(<EduroamSheet onClose={vi.fn()} />);
+
+    expect(screen.queryByText(/Profil se nepodařilo připravit/)).not.toBeInTheDocument();
+    expect(screen.getByText(/Nastavení eduroamu se nepodařilo/)).toBeInTheDocument();
+  });
+
   it('names the real failure when Android refuses the network', () => {
     // "Couldn't prepare the profile" is the wrong sentence here: no profile is
     // involved, and nothing was downloaded.

--- a/src/hooks/data/__tests__/useEduroamSetup.test.ts
+++ b/src/hooks/data/__tests__/useEduroamSetup.test.ts
@@ -33,6 +33,21 @@ vi.mock('../../../services/eduroam/eapConfig', () => ({
   generateEapConfig: vi.fn().mockReturnValue('<eap-config/>'),
 }));
 
+// Only the native wiring is stubbed; configureEduroam itself runs for real, so
+// these tests cover the result-code mapping the student actually sees.
+vi.mock('../../../mobile/eduroamNative', () => ({
+  canConfigureEduroamNatively: vi.fn().mockReturnValue(false),
+  nativeEduroamDeps: { configure: vi.fn() },
+}));
+
+/** Put the hook on the phone, with the plugin answering `perNetwork`. */
+async function onPhone(perNetwork: string, resultCode = -1) {
+  const native = await import('../../../mobile/eduroamNative');
+  vi.mocked(native.canConfigureEduroamNatively).mockReturnValue(true);
+  vi.mocked(native.nativeEduroamDeps.configure).mockResolvedValue({ resultCode, perNetwork });
+  return native;
+}
+
 afterEach(() => {
   vi.clearAllMocks();
 });
@@ -83,5 +98,78 @@ describe('useEduroamSetup', () => {
     expect(result.current.password).toBe('pw123');
     expect(result.current.qrDataUrl).toBeNull();
     expect(saveAs).toHaveBeenCalledWith(expect.any(Blob), 'eduroam-reis.eap-config');
+  });
+
+  it('configures the network natively on the phone, with no QR and no transfer', async () => {
+    const { putTransfer } = await import('../../../api/eduroamTransfer');
+    await onPhone('0');
+    const { result } = renderHook(() => useEduroamSetup());
+
+    await act(async () => {
+      await result.current.run('android');
+    });
+
+    expect(result.current.status).toBe('done');
+    expect(result.current.outcome).toBe('saved');
+    // A QR on the very device being configured is unscannable — it is a
+    // desktop→phone artifact and has no meaning here.
+    expect(result.current.qrDataUrl).toBeNull();
+    expect(putTransfer).not.toHaveBeenCalled();
+  });
+
+  it('treats an eduroam network that already exists as success', async () => {
+    await onPhone('2');
+    const { result } = renderHook(() => useEduroamSetup());
+
+    await act(async () => {
+      await result.current.run('android');
+    });
+
+    expect(result.current.status).toBe('done');
+    expect(result.current.outcome).toBe('already-configured');
+  });
+
+  it('returns to idle when the student dismisses the system dialog', async () => {
+    // RESULT_CANCELED revokes nothing, so the honest state is "not done yet" —
+    // an error banner here would scold someone for changing their mind.
+    await onPhone('(none)', 0);
+    const { result } = renderHook(() => useEduroamSetup());
+
+    await act(async () => {
+      await result.current.run('android');
+    });
+
+    expect(result.current.status).toBe('idle');
+    expect(result.current.outcome).toBe('cancelled');
+    expect(result.current.error).toBeNull();
+  });
+
+  it('surfaces a genuine add failure as an error', async () => {
+    await onPhone('1');
+    const { result } = renderHook(() => useEduroamSetup());
+
+    await act(async () => {
+      await result.current.run('android');
+    });
+
+    expect(result.current.status).toBe('error');
+    expect(result.current.outcome).toBe('failed');
+  });
+
+  it('keeps the QR transfer for Android chosen in a desktop browser', async () => {
+    const { putTransfer } = await import('../../../api/eduroamTransfer');
+    // Stated rather than inherited: clearAllMocks resets calls, not
+    // implementations, so a preceding onPhone() would otherwise leak in here.
+    const native = await import('../../../mobile/eduroamNative');
+    vi.mocked(native.canConfigureEduroamNatively).mockReturnValue(false);
+    const { result } = renderHook(() => useEduroamSetup());
+
+    await act(async () => {
+      await result.current.run('android');
+    });
+
+    expect(putTransfer).toHaveBeenCalled();
+    expect(result.current.qrDataUrl).toBe('data:image/png;base64,zz');
+    expect(result.current.outcome).toBeNull();
   });
 });

--- a/src/hooks/data/useEduroamSetup.ts
+++ b/src/hooks/data/useEduroamSetup.ts
@@ -5,6 +5,8 @@ import { fetchEduroamCertMaterial, fetchEduroamPassword } from '../../api/eduroa
 import { generateEduroamMobileconfig } from '../../services/eduroam/mobileconfig';
 import { generateEapConfig } from '../../services/eduroam/eapConfig';
 import { putTransfer, buildTransferUrl } from '../../api/eduroamTransfer';
+import { configureEduroam, type EduroamConfigOutcome } from '../../mobile/configureEduroam';
+import { canConfigureEduroamNatively, nativeEduroamDeps } from '../../mobile/eduroamNative';
 import { logError } from '../../utils/reportError';
 
 export type EduroamStatus = 'idle' | 'working' | 'done' | 'error';
@@ -30,6 +32,8 @@ export function useEduroamSetup(autoSelectTarget?: EduroamTarget) {
   const [password, setPassword] = useState<string | null>(null);
   const [qrDataUrl, setQrDataUrl] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  /** Native-path only: what Android did with the network. Null on file paths. */
+  const [outcome, setOutcome] = useState<EduroamConfigOutcome | null>(null);
 
   // The .p12 password is NEVER embedded: the macOS path prompts at install, and
   // the iOS transfer path must keep the profile from being a standalone credential.
@@ -38,8 +42,24 @@ export function useEduroamSetup(autoSelectTarget?: EduroamTarget) {
     setError(null);
     setPassword(null);
     setQrDataUrl(null);
+    setOutcome(null);
     try {
-      const { rootCaDer, clientP12, password: extractionPw } = await fetchEduroamCertMaterial();
+      const material = await fetchEduroamCertMaterial();
+      const { rootCaDer, clientP12, password: extractionPw } = material;
+
+      // On the phone itself, Android configures eduroam directly: no profile
+      // file, no transfer, and no QR — a QR here would be pointing the device
+      // at itself. Everything below this branch is desktop→phone delivery.
+      if (canConfigureEduroamNatively(t)) {
+        const result = await configureEduroam(material, nativeEduroamDeps);
+        setOutcome(result);
+        setPassword(extractionPw);
+        // Dismissing Android's dialog is a choice, not a fault: go back to idle
+        // so the button is simply offered again, with no error banner.
+        setStatus(result === 'cancelled' ? 'idle' : result === 'failed' ? 'error' : 'done');
+        return;
+      }
+
       const xml = generateEduroamMobileconfig({ rootCaDer, clientP12 });
 
       if (t === 'ios') {
@@ -84,6 +104,7 @@ export function useEduroamSetup(autoSelectTarget?: EduroamTarget) {
     setError(null);
     setPassword(null);
     setQrDataUrl(null);
+    setOutcome(null);
     // Prefetch the extraction password so the chip can show it before Download.
     // Only populates when a cert already exists; first-time users get it from
     // run(). Never overwrites a value run() may have already set.
@@ -99,6 +120,7 @@ export function useEduroamSetup(autoSelectTarget?: EduroamTarget) {
     setError(null);
     setPassword(null);
     setQrDataUrl(null);
+    setOutcome(null);
   }, []);
 
   // Fires selectTarget exactly once, only when a caller (the sheet) hands us a
@@ -128,6 +150,7 @@ export function useEduroamSetup(autoSelectTarget?: EduroamTarget) {
     password,
     qrDataUrl,
     error,
+    outcome,
     run,
     reset,
     openProfilesSettings,

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -638,6 +638,7 @@
       "already": "eduroam už na tomto telefonu nastavený je.",
       "cancelled": "Nastavení nebylo dokončeno. Klepni znovu.",
       "failed": "Android síť eduroam neuložil. Zkus to prosím znovu.",
+      "error": "Nastavení eduroamu se nepodařilo",
       "privacyNote": "Certifikát z telefonu nikam neodchází — reIS ho předá přímo Androidu, který eduroam uloží jako každou jinou síť, kterou vidíš a můžeš smazat."
     },
     "manual": {

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -631,6 +631,15 @@
     "openSettings": "Otevřít nastavení Profily",
     "privacyNoteLocal": "Vše se generuje ve vašem zařízení a váš soukromý klíč zůstává chráněn heslem, které zadáte jen vy při instalaci.",
     "privacyNoteTransfer": "Vše se generuje ve vašem zařízení a váš soukromý klíč je chráněn heslem, které zadáte jen vy při instalaci. Přenosový odkaz je jednorázový a vyprší během několika minut.",
+    "native": {
+      "button": "Nastavit eduroam",
+      "working": "Otevírám nastavení Androidu…",
+      "saved": "Hotovo — eduroam je uložený. Na fakultě se připojíš automaticky.",
+      "already": "eduroam už na tomto telefonu nastavený je.",
+      "cancelled": "Nastavení nebylo dokončeno. Klepni znovu.",
+      "failed": "Android síť eduroam neuložil. Zkus to prosím znovu.",
+      "privacyNote": "Certifikát z telefonu nikam neodchází — reIS ho předá přímo Androidu, který eduroam uloží jako každou jinou síť, kterou vidíš a můžeš smazat."
+    },
     "manual": {
       "ios": {
         "hint": "Naskenuj QR kód",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -631,6 +631,15 @@
     "openSettings": "Open Profiles settings",
     "privacyNoteLocal": "Everything is generated on your device and your private key stays protected by a password only you enter at install time.",
     "privacyNoteTransfer": "Everything is generated on your device and your private key is protected by a password only you enter at install time. The transfer link is one-time and expires within a few minutes.",
+    "native": {
+      "button": "Set up eduroam",
+      "working": "Opening Android setup…",
+      "saved": "Done — eduroam is saved. You'll connect automatically on campus.",
+      "already": "eduroam is already set up on this phone.",
+      "cancelled": "Setup wasn't finished. Tap again to retry.",
+      "failed": "Android didn't save the eduroam network. Please try again.",
+      "privacyNote": "Your certificate never leaves this phone — reIS hands it straight to Android, which saves eduroam like any other network you can see and delete."
+    },
     "manual": {
       "ios": {
         "hint": "Scan a QR code",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -638,6 +638,7 @@
       "already": "eduroam is already set up on this phone.",
       "cancelled": "Setup wasn't finished. Tap again to retry.",
       "failed": "Android didn't save the eduroam network. Please try again.",
+      "error": "eduroam setup didn't go through",
       "privacyNote": "Your certificate never leaves this phone — reIS hands it straight to Android, which saves eduroam like any other network you can see and delete."
     },
     "manual": {

--- a/src/mobile/__tests__/configureEduroam.test.ts
+++ b/src/mobile/__tests__/configureEduroam.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  configureEduroam,
+  interpretAddResult,
+  RESULT_CANCELED,
+  RESULT_OK,
+  type ConfigureEduroamDeps,
+} from '../configureEduroam';
+
+function material(over: Partial<Parameters<typeof configureEduroam>[0]> = {}) {
+  return {
+    // 0x30 0x82 — the DER SEQUENCE header every real cert and .p12 starts with.
+    clientP12: new Uint8Array([0x30, 0x82, 0x01, 0x02]),
+    rootCaDer: new Uint8Array([0x30, 0x82, 0x03, 0x04]),
+    password: 'hunter2',
+    ...over,
+  };
+}
+
+function deps(over: Partial<ConfigureEduroamDeps> = {}): ConfigureEduroamDeps {
+  return {
+    configure: vi.fn(async () => ({ resultCode: RESULT_OK, perNetwork: '0' })),
+    ...over,
+  };
+}
+
+describe('interpretAddResult', () => {
+  it('reads per-network 0 as saved', () => {
+    expect(interpretAddResult({ resultCode: RESULT_OK, perNetwork: '0' })).toBe('saved');
+  });
+
+  it('treats an existing eduroam network as success, not an error', () => {
+    // ADD_WIFI_RESULT_ALREADY_EXISTS. A student re-running setup has the network
+    // they wanted; saying "failed" would send them hunting for a problem.
+    expect(interpretAddResult({ resultCode: RESULT_OK, perNetwork: '2' })).toBe(
+      'already-configured'
+    );
+  });
+
+  it('reads per-network 1 as a real failure', () => {
+    expect(interpretAddResult({ resultCode: RESULT_OK, perNetwork: '1' })).toBe('failed');
+  });
+
+  it('reports a declined system dialog as cancelled, not failed', () => {
+    // RESULT_CANCELED revokes nothing, so the student can simply be offered the
+    // button again. Reporting an error here would be both wrong and scolding.
+    expect(interpretAddResult({ resultCode: RESULT_CANCELED, perNetwork: '(none)' })).toBe(
+      'cancelled'
+    );
+  });
+
+  it('fails closed when Android returns OK but no per-network code', () => {
+    // Guessing "saved" here would send the student to campus believing eduroam
+    // works. The opposite mistake is self-correcting: a retry that actually
+    // saved comes back ALREADY_EXISTS, which reads as success.
+    expect(interpretAddResult({ resultCode: RESULT_OK, perNetwork: '(none)' })).toBe('failed');
+  });
+
+  it('fails closed on an unrecognised per-network code', () => {
+    expect(interpretAddResult({ resultCode: RESULT_OK, perNetwork: '99' })).toBe('failed');
+  });
+
+  it('reads only the first code — one network is requested, so extras are noise', () => {
+    expect(interpretAddResult({ resultCode: RESULT_OK, perNetwork: '0,1' })).toBe('saved');
+  });
+});
+
+describe('configureEduroam', () => {
+  it('hands the cert material across the bridge as base64', async () => {
+    const d = deps();
+    await configureEduroam(material(), d);
+    expect(d.configure).toHaveBeenCalledWith({
+      p12Base64: 'MIIBAg==',
+      caDerBase64: 'MIIDBA==',
+      passphrase: 'hunter2',
+    });
+  });
+
+  it('returns the interpreted outcome rather than raw Android codes', async () => {
+    const d = deps({ configure: vi.fn(async () => ({ resultCode: RESULT_OK, perNetwork: '2' })) });
+    await expect(configureEduroam(material(), d)).resolves.toBe('already-configured');
+  });
+
+  it('refuses to call native code when IS gave us no extraction password', async () => {
+    // The passphrase is what opens the PKCS#12. Without it the KeyStore load
+    // fails inside the plugin, which surfaces as an opaque native stage error —
+    // so catch it here, where the cause is still legible.
+    const d = deps();
+    await expect(configureEduroam(material({ password: null }), d)).rejects.toThrow(
+      /extraction password/i
+    );
+    expect(d.configure).not.toHaveBeenCalled();
+  });
+
+  it('propagates a native rejection instead of reporting a phantom success', async () => {
+    const d = deps({
+      configure: vi.fn(async () => {
+        throw new Error('FAILED at stage=keystore: IOException: wrong password');
+      }),
+    });
+    await expect(configureEduroam(material(), d)).rejects.toThrow(/stage=keystore/);
+  });
+});

--- a/src/mobile/configureEduroam.ts
+++ b/src/mobile/configureEduroam.ts
@@ -1,0 +1,93 @@
+// JS side of the native eduroam Wi-Fi setup (Android).
+//
+// The student's cert material is fetched in the WebView, which holds the IS
+// session (src/api/eduroam.ts), and crosses the bridge as base64. A .p12 is a
+// few KB, so bridge size is a non-issue.
+//
+// This replaces the geteduroam route on Android, which is structurally broken
+// for MENDELU: geteduroam re-resolves the signing institution against eduroam
+// discovery, MENDELU is not in that catalogue, and the lookup failure disables
+// a config that was already working. The intent path has no discovery step.
+
+import { bytesToBase64 } from '../services/eduroam/base64';
+
+/** Android `Activity.RESULT_OK`. */
+export const RESULT_OK = -1;
+/** Android `Activity.RESULT_CANCELED` — the student dismissed the system dialog. */
+export const RESULT_CANCELED = 0;
+
+// Settings.ADD_WIFI_RESULT_* — the per-network codes inside EXTRA_WIFI_NETWORK_RESULT_LIST.
+const ADD_WIFI_RESULT_SUCCESS = 0;
+const ADD_WIFI_RESULT_ADD_OR_UPDATE_FAILED = 1;
+const ADD_WIFI_RESULT_ALREADY_EXISTS = 2;
+
+export type EduroamConfigOutcome = 'saved' | 'already-configured' | 'failed' | 'cancelled';
+
+/** Raw shape the native plugin resolves with. `perNetwork` is comma-joined ints. */
+export interface NativeAddResult {
+  resultCode: number;
+  perNetwork: string;
+}
+
+export interface ConfigureEduroamDeps {
+  configure(o: {
+    p12Base64: string;
+    caDerBase64: string;
+    passphrase: string;
+  }): Promise<NativeAddResult>;
+}
+
+/** What the caller passes in — the subset of `EduroamCertMaterial` this needs. */
+export interface EduroamNativeInput {
+  clientP12: Uint8Array;
+  rootCaDer: Uint8Array;
+  password: string | null;
+}
+
+/**
+ * Turn Android's two-level result into something the UI can act on.
+ *
+ * Unknown and missing codes deliberately fail CLOSED. Claiming success when the
+ * network was not saved sends a student to campus with wi-fi that never
+ * connects and no reason to suspect setup; the opposite mistake self-corrects,
+ * because a retry over a network that did save returns ALREADY_EXISTS, which
+ * reads as success.
+ */
+export function interpretAddResult(result: NativeAddResult): EduroamConfigOutcome {
+  if (result.resultCode !== RESULT_OK) return 'cancelled';
+
+  // Exactly one network is ever requested, so only the first code is meaningful.
+  const first = Number.parseInt(result.perNetwork.split(',')[0] ?? '', 10);
+  if (first === ADD_WIFI_RESULT_SUCCESS) return 'saved';
+  if (first === ADD_WIFI_RESULT_ALREADY_EXISTS) return 'already-configured';
+  if (first === ADD_WIFI_RESULT_ADD_OR_UPDATE_FAILED) return 'failed';
+  return 'failed';
+}
+
+/**
+ * Hand the cert material to the native plugin and report what Android did.
+ *
+ * The EAP identity is NOT passed from here: the plugin already opens the
+ * PKCS#12 to get the private key, so it reads the subject CN off the client
+ * certificate it is holding — which for the MENDELU cert is exactly
+ * `<login>@mendelu.cz`. Deriving it there costs nothing and avoids both an
+ * extra IS request for the DER and a second ASN.1 parser in TypeScript.
+ */
+export async function configureEduroam(
+  material: EduroamNativeInput,
+  deps: ConfigureEduroamDeps
+): Promise<EduroamConfigOutcome> {
+  if (!material.password) {
+    // Checked here, where the cause is still legible. Inside the plugin this
+    // surfaces as `FAILED at stage=keystore`, which says nothing about IS not
+    // having shown a password on the certificate page.
+    throw new Error('eduroam: IS did not provide the certificate extraction password');
+  }
+
+  const result = await deps.configure({
+    p12Base64: bytesToBase64(material.clientP12),
+    caDerBase64: bytesToBase64(material.rootCaDer),
+    passphrase: material.password,
+  });
+  return interpretAddResult(result);
+}

--- a/src/mobile/eduroamNative.ts
+++ b/src/mobile/eduroamNative.ts
@@ -1,0 +1,35 @@
+import { registerPlugin } from '@capacitor/core';
+import { getPlatform } from '../platform';
+import type { ConfigureEduroamDeps, NativeAddResult } from './configureEduroam';
+
+interface EduroamNativePlugin {
+  configure(o: {
+    p12Base64: string;
+    caDerBase64: string;
+    passphrase: string;
+  }): Promise<NativeAddResult>;
+}
+
+/** Android-only native plugin: saves eduroam via ACTION_WIFI_ADD_NETWORKS. */
+const Eduroam = registerPlugin<EduroamNativePlugin>('Eduroam');
+
+export const nativeEduroamDeps: ConfigureEduroamDeps = {
+  configure: (o) => Eduroam.configure(o),
+};
+
+/**
+ * True when eduroam can be configured by the OS instead of by handing the
+ * student a file.
+ *
+ * `target` already resolves to 'android' only on an Android device, so pairing
+ * it with the Capacitor host is the whole test — reIS in a desktop browser with
+ * the Android tab selected is a desktop→phone transfer and must keep its QR.
+ *
+ * The API 30 floor is NOT checked here. minSdkVersion is 24, so Android 7–10
+ * devices reach this, and the plugin rejects them with an explicit message
+ * rather than this returning a quiet false — a student on an old phone should
+ * see why, not silently get a different flow.
+ */
+export function canConfigureEduroamNatively(target: string): boolean {
+  return target === 'android' && getPlatform().kind === 'capacitor';
+}


### PR DESCRIPTION
Setting up eduroam on Android is currently broken, and the advice reIS gives makes it worse. We tell students to install geteduroam and import a file. The import works — then geteduroam tries to resolve the institution that signed the certificate against the eduroam discovery catalogue, MENDELU is not in that catalogue, and the failed lookup **disables the config that was already working**. There is no fix from our side; discovery is not ours to register in.

This replaces that path inside the Capacitor app. The student taps one row in settings, Android shows its own dialog, they tap Save. Two taps, and the result is a real saved network they can see and delete like any other — `ACTION_WIFI_ADD_NETWORKS` has no discovery step to fail later.

Android chosen in a **desktop** browser is untouched and still gets the QR transfer. Windows still uses geteduroam. iOS is a separate job and not in scope here.

## Verified on a handset

A001, Android 16 / API 36, against a real IS certificate. The full flow ran: profile → eduroam → one tap → `com.android.settings.wifi.addappnetworks.AddAppNetworksActivity` showing *&#34;Save this network? / reIS wants to save a network to your phone / eduroam&#34;* → Save.

Android&#39;s own `dumpsys wifi` afterwards — its record, not the app&#39;s claim:

```
ID: 73 SSID: "eduroam"
KeyMgmt: WPA_EAP IEEE8021X          (WPA2- and WPA3-Enterprise)
eap_method: TLS
identity "xholek1@mendelu.cz"
domain_suffix_match "mendelu.cz"
client_cert "keystore://USRCERT_..."
ca_cert     "keystore://CACERT_..."
```

The certificate was **read, not generated** — `certifikat.pl` was checked first and an existing cert was found, so no `gen=` POST fired. That order matters: generating rotates a 366-day credential the student may have installed on other devices.

**Still unverified: association on campus.** Acceptance is not connection, and no eduroam AP was in range. That is the only remaining unknown on this path.

## Three decisions worth reviewing

**The EAP identity is derived inside the plugin, not passed from JS.** Android does not derive it — an empty Identity is exactly what greys out CONNECT in the manual flow — but the plugin already opens the PKCS#12 for the private key, and the IS certificate&#39;s subject CN *is* `@mendelu.cz`. Reading it there avoids an extra `?get=user-der` request and a second ASN.1 parser in TypeScript. Issue #159&#39;s sketch says to pass `login`; the device output above confirms deriving it produces the right string.

**Unknown and missing result codes fail closed.** If Android returns `RESULT_OK` with no per-network code, the student is told it failed. Claiming success wrongly sends someone to campus with wi-fi that never connects and no reason to suspect setup; the opposite error self-corrects, because tapping the button again over a network that did save is harmless and reports success.

> **Correction, from a second device run** — see [the comment below](https://github.com/reis-mendelu/reis-extension/pull/189#issuecomment-5223367007) for the full detail. This paragraph originally justified the fail-closed choice by saying a retry returns `ALREADY_EXISTS`, which reads as success. That is **not** what Android 16 does: the retry returns `SUCCESS` and updates the existing network in place, with no duplicate entry. The conclusion stands — a retry is harmless and self-correcting — but by a different mechanism than claimed. The `already-configured` branch remains as a defensive mapping of documented API that OEMs may vary on; nothing depends on it, and I am not claiming it is reachable.

**A dismissed dialog returns to idle, not error.** `RESULT_CANCELED` revokes nothing, so the button is simply offered again. The error copy also branches — &#34;couldn&#39;t prepare the profile&#34; describes a step that never happens on this path.

## Notes for the reviewer

- `EduroamPlugin.java` is a port of the throwaway spike&#39;s `EduroamProbePlugin`, which had already verified on API 35 that this path accepts an EAP-TLS config backed by MENDELU&#39;s **self-signed** root. Java rather than Kotlin: the app module has no Kotlin Gradle plugin, same reason `DownloadsPlugin` is Java.
- `setWifiEnterpriseConfig()` does not exist on the Builder — `setWpa2EnterpriseConfig` is the only WPA2 path, deprecated since API 33 and still correct.
- The PKCS#12 alias is selected by `isKeyEntry()` rather than by enumeration order. This is a provider-portability guard, not a fix for an observed failure — the JDK's provider enumerates key entries first regardless of insertion order, so I could not make the old code pick wrong; Android's BouncyCastle makes no such promise.
- The API 30 floor is deliberately **not** gated in JS. `minSdkVersion` is 24, so Android 7–10 devices reach the plugin and get an explicit rejection rather than silently falling into a different flow. Whether to leave them on the manual instructions or raise minSdk is still an open product decision.
- 23 new tests, written before the implementation. Full suite green; typecheck, eslint and prettier on changed files, nuia ratchet all pass.

Closes part of #159 (Android half; iOS still open there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)