### PR TITLE
Mobile: back returns to the calendar instead of quitting the app

### DIFF
--- a/capacitor/main.capacitor.ts
+++ b/capacitor/main.capacitor.ts
@@ -13,8 +13,9 @@ import { setSessionExpiredHandler } from '@/services/sessionExpiry';
 import { useAppStore } from '@/store/useAppStore';
 
 /**
- * Android's hardware back unwinds the sheet stack before exiting. Registered
- * before boot so it works even while the login WebView is up.
+ * Android's hardware back unwinds the sheet stack, then the tab, before
+ * exiting. Registered before boot so it works even while the login WebView is
+ * up — no tab exists then, and handleBackPress falls through to exit.
  */
 void CapApp.addListener('backButton', () => {
   const s = useAppStore.getState();
@@ -23,6 +24,8 @@ void CapApp.addListener('backButton', () => {
     popSheet: s.popSheet,
     bulletinOpen: s.bulletinExpanded,
     closeBulletin: () => void s.setBulletinExpanded(false),
+    tab: s.mobileTab,
+    goToCalendar: () => s.setMobileTab('calendar'),
   });
   if (result === 'exit') {
     void CapApp.exitApp();

--- a/src/mobile/__tests__/backButton.test.ts
+++ b/src/mobile/__tests__/backButton.test.ts
@@ -64,4 +64,74 @@ describe('handleBackPress', () => {
     );
     expect(closeBulletin).not.toHaveBeenCalled();
   });
+
+  /**
+   * Calendar is the app's start destination, the way Android expects a bottom
+   * nav to behave: back from any other tab returns there instead of quitting.
+   * Before this, pressing back on Zkoušky/Předměty/Mapa/Student closed the app.
+   */
+  it.each(['exams', 'subjects', 'map', 'student'] as const)(
+    'returns to the calendar from the %s tab instead of exiting',
+    (tab) => {
+      const popSheet = vi.fn();
+      const goToCalendar = vi.fn();
+      expect(handleBackPress({ sheetCount: 0, popSheet, tab, goToCalendar })).toBe('popped');
+      expect(goToCalendar).toHaveBeenCalledOnce();
+    }
+  );
+
+  it('exits from the calendar tab, which is the start destination', () => {
+    const popSheet = vi.fn();
+    const goToCalendar = vi.fn();
+    expect(handleBackPress({ sheetCount: 0, popSheet, tab: 'calendar', goToCalendar })).toBe(
+      'exit'
+    );
+    expect(goToCalendar).not.toHaveBeenCalled();
+  });
+
+  /**
+   * A sheet belongs to the screen that opened it, so it must unwind before the
+   * tab switches out from under it — otherwise one press would both close the
+   * sheet and change screens.
+   */
+  it('pops a sheet before switching tabs', () => {
+    const popSheet = vi.fn();
+    const goToCalendar = vi.fn();
+    expect(handleBackPress({ sheetCount: 1, popSheet, tab: 'subjects', goToCalendar })).toBe(
+      'popped'
+    );
+    expect(popSheet).toHaveBeenCalledOnce();
+    expect(goToCalendar).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The bulletin is a calendar-tab overlay, but ordering it ahead of the tab
+   * step costs nothing and keeps the rule "innermost surface first" intact.
+   */
+  it('closes the bulletin before switching tabs', () => {
+    const popSheet = vi.fn();
+    const closeBulletin = vi.fn();
+    const goToCalendar = vi.fn();
+    expect(
+      handleBackPress({
+        sheetCount: 0,
+        popSheet,
+        bulletinOpen: true,
+        closeBulletin,
+        tab: 'exams',
+        goToCalendar,
+      })
+    ).toBe('popped');
+    expect(closeBulletin).toHaveBeenCalledOnce();
+    expect(goToCalendar).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The pre-tab callers (and the login WebView, which registers this listener
+   * before any tab exists) pass no tab at all — they must still exit.
+   */
+  it('exits when no tab is supplied', () => {
+    const popSheet = vi.fn();
+    expect(handleBackPress({ sheetCount: 0, popSheet })).toBe('exit');
+  });
 });

--- a/src/mobile/backButton.ts
+++ b/src/mobile/backButton.ts
@@ -1,3 +1,5 @@
+import type { MobileTab } from '../store/types';
+
 export interface BackPressState {
   sheetCount: number;
   popSheet(): void;
@@ -9,6 +11,13 @@ export interface BackPressState {
    */
   bulletinOpen?: boolean;
   closeBulletin?(): void;
+  /**
+   * The bottom-nav tab in view. Optional because this listener is registered
+   * before boot, so it also fires while the login WebView is up and no tab
+   * exists yet — that case must still exit.
+   */
+  tab?: MobileTab;
+  goToCalendar?(): void;
 }
 
 export type BackPressResult = 'popped' | 'exit';
@@ -18,6 +27,10 @@ export type BackPressResult = 'popped' | 'exit';
  * The stack genuinely nests (Student → person, Subjects → drawer → confirm), so
  * one press pops exactly one level.
  *
+ * Innermost surface first: sheet → bulletin → tab → exit. Calendar is the start
+ * destination, which is how Android expects a bottom nav to behave — back from
+ * Zkoušky/Předměty/Mapa/Student returns there, and only calendar quits.
+ *
  * Pure on purpose: the @capacitor/app listener is a two-line adapter over this,
  * which keeps the decision testable without a device.
  */
@@ -26,6 +39,8 @@ export function handleBackPress({
   popSheet,
   bulletinOpen,
   closeBulletin,
+  tab,
+  goToCalendar,
 }: BackPressState): BackPressResult {
   // Sheets first: one opened on top of the bulletin is drawn above it, so
   // closing the overlay underneath would look like nothing happened.
@@ -35,6 +50,10 @@ export function handleBackPress({
   }
   if (bulletinOpen && closeBulletin) {
     closeBulletin();
+    return 'popped';
+  }
+  if (tab && tab !== 'calendar' && goToCalendar) {
+    goToCalendar();
     return 'popped';
   }
   return 'exit';


### PR DESCRIPTION
## What a student notices

Before: on Zkoušky, Předměty, Mapa or Student, pressing back **closed the app**.
Now it takes you back to the calendar. Back on the calendar still leaves the app,
as it should.

## Why it happened

`handleBackPress` only knew about two things: the sheet stack and the vývěska
overlay. It had no idea which tab was in view, so every non-calendar tab fell
straight through to `exit`.

## The change

One step added to the chain, innermost surface first:

    sheet → bulletin → tab → exit

Calendar is the start destination, which is how Android expects a bottom nav to
behave. `tab` is optional on `BackPressState` because the listener is registered
*before* boot and also fires while the login WebView is up — no tab exists then,
and that case must still exit.

## Verified on the handset

Built, installed and driven over CDP on the A001 device (not just unit tests):

| From | Back → | App still up |
|---|---|---|
| Zkoušky | Kalendář | yes |
| Předměty | Kalendář | yes |
| Mapa | Kalendář | yes |
| Student | Kalendář | yes |
| Kalendář | *launcher* | no (correct) |

The predictive-back **gesture** was confirmed separately by hand on vývěska, so
both the gesture and the legacy paths are covered.

15 unit tests on `handleBackPress` (4 new tab cases + ordering against sheets and
the bulletin + the no-tab fallback). Full `src/mobile` + `src/store` suites green
(276 tests). eslint, prettier, `tsc -b` and the nuia gate all pass.

## Not in scope

Back does not restore the *previous* tab, only the calendar — matching how the
bottom nav's start destination normally works. An expanded map sheet also still
falls through to the tab step rather than collapsing first; worth deciding
separately.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Android back-button navigation on mobile.
  * Pressing Back from non-calendar tabs now returns to the Calendar.
  * Sheets and bulletin content close before tab navigation occurs.
  * Pressing Back from the Calendar exits the app as expected.

* **Bug Fixes**
  * Improved handling when tab or navigation context is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->