### PR TITLE
Mobile: the map sheet can actually be dragged

### DIFF
--- a/src/components/CampusMap/MapEventsSection.tsx
+++ b/src/components/CampusMap/MapEventsSection.tsx
@@ -42,14 +42,13 @@ export function MapEventsSection() {
   // them — rather than a set of toggles. A bordered, tinted pill with a muted
   // resting state says "filter" at a glance and takes far less room.
   const chipBase =
-    'flex h-7 flex-shrink-0 items-center whitespace-nowrap rounded-full border px-2.5 text-xs font-semibold transition-colors';
-  // Tinted from base-content rather than the base-100/200/300 ramp, which
-  // INVERTS between themes: in dark, base-200 (#111827) and base-300 (#0f172a)
-  // are both darker than the base-100 surface these chips sit on, so an idle
-  // chip was a near-black border around a near-black fill — measured at 1.006:1
-  // against its backdrop, the recurring reIS dark-theme bug. An alpha of the
-  // foreground colour reads as a raised pill on any surface, in either theme.
-  const chipIdle = 'border-base-content/15 bg-base-content/5 text-base-content/70';
+    'flex h-7 flex-shrink-0 items-center whitespace-nowrap rounded-full px-2.5 text-xs font-semibold transition-colors';
+  // No border at all: the outline was carrying the shape, and on the dark theme
+  // it could not — base-300 (#0f172a) around a base-200 (#111827) fill is
+  // 1.006:1, invisible, the recurring reIS dark-theme bug. The fill alone says
+  // "chip", and tinting it from base-content rather than the base-100/200/300
+  // ramp (which INVERTS between themes) means it reads on any surface in either.
+  const chipIdle = 'bg-base-content/5 text-base-content/70';
 
   return (
     <div className="flex max-h-[60vh] flex-col">
@@ -58,7 +57,7 @@ export function MapEventsSection() {
             brand colour when active, so the colour legend pays off here */}
         <button
           onClick={() => setFilter('all')}
-          className={`${chipBase} ${filter === 'all' ? 'border-transparent bg-primary text-primary-content' : chipIdle}`}
+          className={`${chipBase} ${filter === 'all' ? 'bg-primary text-primary-content' : chipIdle}`}
         >
           {t('map.allSocieties')}
         </button>
@@ -68,7 +67,7 @@ export function MapEventsSection() {
             <button
               key={s.id}
               onClick={() => setFilter(s.id)}
-              className={`${chipBase} ${active ? 'border-transparent' : chipIdle}`}
+              className={`${chipBase} ${active ? '' : chipIdle}`}
               style={
                 active ? { backgroundColor: s.color, color: readableTextColor(s.color) } : undefined
               }

--- a/src/components/CampusMap/MapEventsSection.tsx
+++ b/src/components/CampusMap/MapEventsSection.tsx
@@ -43,7 +43,13 @@ export function MapEventsSection() {
   // resting state says "filter" at a glance and takes far less room.
   const chipBase =
     'flex h-7 flex-shrink-0 items-center whitespace-nowrap rounded-full border px-2.5 text-xs font-semibold transition-colors';
-  const chipIdle = 'border-base-300 bg-base-200 text-base-content/70';
+  // Tinted from base-content rather than the base-100/200/300 ramp, which
+  // INVERTS between themes: in dark, base-200 (#111827) and base-300 (#0f172a)
+  // are both darker than the base-100 surface these chips sit on, so an idle
+  // chip was a near-black border around a near-black fill — measured at 1.006:1
+  // against its backdrop, the recurring reIS dark-theme bug. An alpha of the
+  // foreground colour reads as a raised pill on any surface, in either theme.
+  const chipIdle = 'border-base-content/15 bg-base-content/5 text-base-content/70';
 
   return (
     <div className="flex max-h-[60vh] flex-col">

--- a/src/components/mobile/primitives/__tests__/sheetDrag.test.ts
+++ b/src/components/mobile/primitives/__tests__/sheetDrag.test.ts
@@ -3,6 +3,7 @@ import {
   shouldDismiss,
   dragOwnsGesture,
   snapDetent,
+  consumesTravel,
   DISMISS_DISTANCE_PX,
   DETENT_DISTANCE_PX,
 } from '../sheetDrag';
@@ -71,6 +72,23 @@ describe('snapDetent', () => {
 
   it('does not divide by a zero timestamp delta', () => {
     expect(snapDetent('peek', -10, 0)).toBe('peek');
+  });
+});
+
+describe('consumesTravel', () => {
+  it('absorbs downward travel only when expanded', () => {
+    expect(consumesTravel('expanded', 20)).toBe(true);
+    expect(consumesTravel('expanded', -20)).toBe(false);
+  });
+
+  it('absorbs upward travel only when at peek', () => {
+    expect(consumesTravel('peek', -20)).toBe(true);
+    expect(consumesTravel('peek', 20)).toBe(false);
+  });
+
+  it('absorbs nothing at rest', () => {
+    expect(consumesTravel('peek', 0)).toBe(false);
+    expect(consumesTravel('expanded', 0)).toBe(false);
   });
 });
 

--- a/src/components/mobile/primitives/__tests__/sheetDrag.test.ts
+++ b/src/components/mobile/primitives/__tests__/sheetDrag.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { shouldDismiss, dragOwnsGesture, DISMISS_DISTANCE_PX } from '../sheetDrag';
+import {
+  shouldDismiss,
+  dragOwnsGesture,
+  snapDetent,
+  DISMISS_DISTANCE_PX,
+  DETENT_DISTANCE_PX,
+} from '../sheetDrag';
 
 describe('shouldDismiss', () => {
   it('closes on a long drag regardless of speed', () => {
@@ -22,6 +28,49 @@ describe('shouldDismiss', () => {
 
   it('does not divide by a zero timestamp delta', () => {
     expect(shouldDismiss(10, 0)).toBe(false);
+  });
+});
+
+/**
+ * The map sheet does not dismiss — it moves between two detents — so it needs a
+ * rule that works in BOTH directions. `shouldDismiss` deliberately ignores
+ * upward travel, which is why it could not be reused as-is.
+ */
+describe('snapDetent', () => {
+  it('expands on a long upward drag from peek', () => {
+    expect(snapDetent('peek', -DETENT_DISTANCE_PX, 5000)).toBe('expanded');
+  });
+
+  it('expands on a short fast upward flick from peek', () => {
+    expect(snapDetent('peek', -40, 50)).toBe('expanded');
+  });
+
+  it('collapses on a long downward drag from expanded', () => {
+    expect(snapDetent('expanded', DETENT_DISTANCE_PX, 5000)).toBe('peek');
+  });
+
+  it('collapses on a short fast downward flick from expanded', () => {
+    expect(snapDetent('expanded', 40, 50)).toBe('peek');
+  });
+
+  it('stays put on a short slow drag in either direction', () => {
+    expect(snapDetent('peek', -40, 2000)).toBe('peek');
+    expect(snapDetent('expanded', 40, 2000)).toBe('expanded');
+  });
+
+  /**
+   * Dragging further into the detent you are already at has nowhere to travel.
+   * Pulling up while expanded must not "re-expand" and, more importantly,
+   * pulling DOWN while at peek must not collapse it out of existence — peek is
+   * the floor.
+   */
+  it('ignores travel that pushes past the detent already held', () => {
+    expect(snapDetent('expanded', -200, 50)).toBe('expanded');
+    expect(snapDetent('peek', 200, 50)).toBe('peek');
+  });
+
+  it('does not divide by a zero timestamp delta', () => {
+    expect(snapDetent('peek', -10, 0)).toBe('peek');
   });
 });
 

--- a/src/components/mobile/primitives/sheetDrag.ts
+++ b/src/components/mobile/primitives/sheetDrag.ts
@@ -21,6 +21,32 @@ export function shouldDismiss(dy: number, dtMs: number): boolean {
   return dtMs > 0 && dy / dtMs >= DISMISS_VELOCITY_PX_PER_MS;
 }
 
+/** Past this much travel the map sheet changes detent regardless of speed. */
+export const DETENT_DISTANCE_PX = 64;
+
+export type Detent = 'peek' | 'expanded';
+
+/**
+ * Where a two-detent sheet lands when the finger lifts.
+ *
+ * The map sheet never closes — it moves between peek and expanded — so it needs
+ * the dismissal rules mirrored to work upward as well. `shouldDismiss` cannot
+ * serve here: it ignores upward travel by design, which is exactly the "I
+ * cannot pull it up" half.
+ *
+ * Travel deeper into the detent already held is ignored rather than clamped
+ * later: peek is the floor, and dragging down from it must not collapse the
+ * sheet out of existence, since the sheet is the only way to reach Akce.
+ */
+export function snapDetent(from: Detent, dy: number, dtMs: number): Detent {
+  // Negative dy is upward, so the direction that can still travel flips.
+  const travel = from === 'peek' ? -dy : dy;
+  if (travel <= 0) return from;
+  const target: Detent = from === 'peek' ? 'expanded' : 'peek';
+  if (travel >= DETENT_DISTANCE_PX) return target;
+  return dtMs > 0 && travel / dtMs >= DISMISS_VELOCITY_PX_PER_MS ? target : from;
+}
+
 /**
  * Whether a downward drag starting on `target` should move the SHEET rather
  * than scroll the content under the finger.

--- a/src/components/mobile/primitives/sheetDrag.ts
+++ b/src/components/mobile/primitives/sheetDrag.ts
@@ -38,6 +38,17 @@ export type Detent = 'peek' | 'expanded';
  * later: peek is the floor, and dragging down from it must not collapse the
  * sheet out of existence, since the sheet is the only way to reach Akce.
  */
+/**
+ * Whether the sheet can absorb travel in this direction from this detent.
+ *
+ * Expanded absorbs downward only, peek upward only — in the other direction it
+ * is already against its stop, and the gesture belongs to whatever is under the
+ * finger (usually the Akce list scrolling).
+ */
+export function consumesTravel(from: Detent, dy: number): boolean {
+  return (from === 'peek' ? -dy : dy) > 0;
+}
+
 export function snapDetent(from: Detent, dy: number, dtMs: number): Detent {
   // Negative dy is upward, so the direction that can still travel flips.
   const travel = from === 'peek' ? -dy : dy;

--- a/src/components/mobile/screens/MapScreen.tsx
+++ b/src/components/mobile/screens/MapScreen.tsx
@@ -54,7 +54,14 @@ export function MapScreen() {
     <div data-testid="map-screen" className="relative isolate flex flex-1 flex-col overflow-hidden">
       <MapCanvas />
       <FloorSwitcher />
-      <div className="relative z-[1000] mx-4 mt-4">
+      {/* marginTop carries --safe-top because this floating bar is the topmost
+          element on the map screen and targetSdk 36 forces edge-to-edge: without
+          it the search sits UNDER the status bar's clock and signal icons. Every
+          other screen inherits this from ScreenHeader, which the map does not
+          use — it floats its own chrome over the canvas instead. A flat mt-4 was
+          the bug, and it looks correct in any desktop browser, where --safe-top
+          resolves to 0. */}
+      <div className="relative z-[1000] mx-4 mt-[calc(1rem_+_var(--safe-top,0px))]">
         <label
           className="flex items-center gap-2.5 rounded-full px-4 py-3 backdrop-blur-md"
           style={{ background: 'rgba(31,41,55,.94)', border: '1px solid rgba(243,244,246,.1)' }}

--- a/src/components/mobile/screens/__tests__/MapScreen.test.tsx
+++ b/src/components/mobile/screens/__tests__/MapScreen.test.tsx
@@ -177,6 +177,37 @@ describe('MapScreen', () => {
 });
 
 /**
+ * targetSdk 36 forces edge-to-edge, so anything anchored to the top of a screen
+ * renders UNDER the status bar (clock, 5G, notification icons) unless it carries
+ * --safe-top. Every other screen gets that through ScreenHeader; the map floats
+ * its own search bar instead and was missing it, so the search sat behind the
+ * clock on a real handset.
+ */
+describe('MapScreen safe-area inset', () => {
+  // Asserted on the CLASS, not an inline style: happy-dom's CSS parser rejects a
+  // calc() containing a var() outright, leaving both el.style.marginTop and the
+  // style attribute empty for a declaration real browsers apply fine. A Tailwind
+  // arbitrary value survives as plain text and matches how the rest of this tree
+  // expresses one-off values (h-[70vh], z-[1000]).
+  const barClass = () =>
+    screen.getByPlaceholderText('Najdi místnost, budovu, akci…').closest('div')?.className ?? '';
+
+  it('insets the floating search bar below the status bar', () => {
+    render(<MapScreen />);
+    expect(barClass()).toContain('var(--safe-top');
+  });
+
+  /**
+   * A flat margin is exactly the bug: it looks right in a desktop browser, where
+   * --safe-top resolves to 0, and fails only on the device.
+   */
+  it('keeps the base spacing on top of the inset', () => {
+    render(<MapScreen />);
+    expect(barClass()).toMatch(/calc\(.*rem/);
+  });
+});
+
+/**
  * The handle was drawn as a drag pill but wired to nothing but onClick, so the
  * sheet could only be tapped open — swiping it did nothing at all, which reads
  * as a frozen app rather than an unimplemented gesture.
@@ -229,6 +260,75 @@ describe('MapSheet drag', () => {
     fireEvent.pointerUp(handle, { clientY: 400, timeStamp: 100 });
     fireEvent.click(handle);
     expect(useAppStore.getState().mapSheetState).toBe('expanded');
+  });
+
+  /**
+   * The handle is a 4px pill at the very top of a 70vh sheet. Reaching it to
+   * collapse means stretching to the top of the screen, so the tab row below it
+   * drags too — the nearest thing to the content you are already looking at.
+   */
+  it('drags from the tab row, not just the handle', () => {
+    useAppStore.setState({ mapSheetState: 'expanded' } as never);
+    render(<MapScreen />);
+    const tabRow = screen.getByRole('tablist');
+    fireEvent.pointerDown(tabRow, { clientY: 300 });
+    fireEvent.pointerMove(tabRow, { clientY: 500 });
+    fireEvent.pointerUp(tabRow, { clientY: 500 });
+    expect(useAppStore.getState().mapSheetState).toBe('peek');
+  });
+
+  /**
+   * The tabs are buttons, so a drag that starts on one ends in a click on it.
+   * Without suppression that click switches tab as a side effect of collapsing.
+   */
+  /**
+   * Needs TWO tabs and a starting tab that is not the one being dragged from,
+   * otherwise the assertion passes whether or not the click is suppressed.
+   */
+  it('does not switch tab when a drag starts on a tab button', () => {
+    useAppStore.setState({
+      mapSheetState: 'expanded',
+      mapTab: 'budova',
+      activeBuildingId: BUILDING_ID,
+      activeFloorId: FLOOR_ID,
+    } as never);
+    render(<MapScreen />);
+    const akce = screen.getByRole('tab', { name: 'Akce' });
+    fireEvent.pointerDown(akce, { clientY: 300 });
+    fireEvent.pointerMove(akce, { clientY: 500 });
+    fireEvent.pointerUp(akce, { clientY: 500 });
+    fireEvent.click(akce);
+    expect(useAppStore.getState().mapSheetState).toBe('peek');
+    expect(useAppStore.getState().mapTab).toBe('budova');
+  });
+
+  it('still switches tab on a plain tap', () => {
+    useAppStore.setState({
+      mapSheetState: 'expanded',
+      mapTab: 'budova',
+      activeBuildingId: BUILDING_ID,
+      activeFloorId: FLOOR_ID,
+    } as never);
+    render(<MapScreen />);
+    const akce = screen.getByRole('tab', { name: 'Akce' });
+    fireEvent.pointerDown(akce, { clientY: 300 });
+    fireEvent.pointerUp(akce, { clientY: 300 });
+    fireEvent.click(akce);
+    // A tap selects the tab and must not collapse the sheet.
+    expect(useAppStore.getState().mapTab).toBe('akce');
+    expect(useAppStore.getState().mapSheetState).toBe('expanded');
+  });
+
+  /**
+   * jsdom has no touch-action, so only the class can be asserted here. It is
+   * load-bearing rather than cosmetic: without it the browser claims the drag as
+   * a pan and fires pointercancel partway through — measured at ~20px of a 350px
+   * swipe when the other sheets hit this.
+   */
+  it('marks the tab row as a drag surface for the browser', () => {
+    useAppStore.setState({ mapSheetState: 'expanded' } as never);
+    render(<MapScreen />);
+    expect(screen.getByRole('tablist').className).toContain('touch-none');
   });
 
   it('still toggles on a plain tap, with no drag in between', () => {

--- a/src/components/mobile/screens/__tests__/MapScreen.test.tsx
+++ b/src/components/mobile/screens/__tests__/MapScreen.test.tsx
@@ -320,6 +320,35 @@ describe('MapSheet drag', () => {
   });
 
   /**
+   * Dragging a sheet down anywhere on it is what every native sheet does — the
+   * handle is an affordance, not the only grab point.
+   */
+  it('collapses when dragged down from the content area', () => {
+    useAppStore.setState({ mapSheetState: 'expanded' } as never);
+    render(<MapScreen />);
+    const body = screen.getByText('Žádné akce');
+    fireEvent.pointerDown(body, { clientY: 300 });
+    fireEvent.pointerMove(body, { clientY: 500 });
+    fireEvent.pointerUp(body, { clientY: 500 });
+    expect(useAppStore.getState().mapSheetState).toBe('peek');
+  });
+
+  /**
+   * The mirror image: while expanded, an UPWARD drag in the content is the
+   * student scrolling the list. The sheet is already at its ceiling, so
+   * absorbing it would freeze the list in place.
+   */
+  it('leaves an upward drag in the content to the list', () => {
+    useAppStore.setState({ mapSheetState: 'expanded' } as never);
+    render(<MapScreen />);
+    const body = screen.getByText('Žádné akce');
+    fireEvent.pointerDown(body, { clientY: 500 });
+    fireEvent.pointerMove(body, { clientY: 300 });
+    fireEvent.pointerUp(body, { clientY: 300 });
+    expect(useAppStore.getState().mapSheetState).toBe('expanded');
+  });
+
+  /**
    * jsdom has no touch-action, so only the class can be asserted here. It is
    * load-bearing rather than cosmetic: without it the browser claims the drag as
    * a pan and fires pointercancel partway through — measured at ~20px of a 350px

--- a/src/components/mobile/screens/__tests__/MapScreen.test.tsx
+++ b/src/components/mobile/screens/__tests__/MapScreen.test.tsx
@@ -175,3 +175,68 @@ describe('MapScreen', () => {
     expect(screen.getByText('Posluchárna')).toBeInTheDocument();
   });
 });
+
+/**
+ * The handle was drawn as a drag pill but wired to nothing but onClick, so the
+ * sheet could only be tapped open — swiping it did nothing at all, which reads
+ * as a frozen app rather than an unimplemented gesture.
+ */
+describe('MapSheet drag', () => {
+  // The distance-vs-velocity rules live in sheetDrag.test.ts, not here: jsdom
+  // stamps its own event timeStamps and ignores the ones fireEvent is given, so
+  // every drag reads as an instant flick and a "slow drag" cannot be expressed.
+  // Same reason Sheet.test.tsx leaves those cases to the pure tests.
+  const drag = (from: number, to: number) => {
+    const handle = screen.getByLabelText(/panel mapy/);
+    fireEvent.pointerDown(handle, { clientY: from });
+    fireEvent.pointerMove(handle, { clientY: to });
+    fireEvent.pointerUp(handle, { clientY: to });
+  };
+
+  it('expands when the handle is dragged up', () => {
+    render(<MapScreen />);
+    drag(600, 400);
+    expect(useAppStore.getState().mapSheetState).toBe('expanded');
+  });
+
+  it('collapses when the handle is dragged down', () => {
+    useAppStore.setState({ mapSheetState: 'expanded' } as never);
+    render(<MapScreen />);
+    drag(300, 500);
+    expect(useAppStore.getState().mapSheetState).toBe('peek');
+  });
+
+  /**
+   * Peek is the floor: this sheet is the only route to Akce, so dragging down
+   * from it must not collapse it away.
+   */
+  it('stays at peek when dragged further down', () => {
+    render(<MapScreen />);
+    drag(400, 600);
+    expect(useAppStore.getState().mapSheetState).toBe('peek');
+  });
+
+  /**
+   * A drag ends in a click as well. Without suppression that click runs the tap
+   * toggle and puts the sheet straight back where the drag just took it from —
+   * the gesture would look like it did nothing, which is the original bug.
+   */
+  it('does not let the drag-ending click undo the snap', () => {
+    render(<MapScreen />);
+    const handle = screen.getByLabelText(/panel mapy/);
+    fireEvent.pointerDown(handle, { clientY: 600, timeStamp: 0 });
+    fireEvent.pointerMove(handle, { clientY: 400, timeStamp: 100 });
+    fireEvent.pointerUp(handle, { clientY: 400, timeStamp: 100 });
+    fireEvent.click(handle);
+    expect(useAppStore.getState().mapSheetState).toBe('expanded');
+  });
+
+  it('still toggles on a plain tap, with no drag in between', () => {
+    render(<MapScreen />);
+    const handle = screen.getByLabelText(/panel mapy/);
+    fireEvent.pointerDown(handle, { clientY: 600, timeStamp: 0 });
+    fireEvent.pointerUp(handle, { clientY: 600, timeStamp: 40 });
+    fireEvent.click(handle);
+    expect(useAppStore.getState().mapSheetState).toBe('expanded');
+  });
+});

--- a/src/components/mobile/screens/map/MapSheet.tsx
+++ b/src/components/mobile/screens/map/MapSheet.tsx
@@ -116,7 +116,15 @@ export function MapSheet() {
       type="button"
       role="tab"
       aria-selected={activeTab === key}
-      onClick={() => setTab(key)}
+      // Same suppression as the handle: a drag that starts on a tab ends in a
+      // click on it, which would switch tab as a side effect of collapsing.
+      onClick={() => {
+        if (dragged.current) {
+          dragged.current = false;
+          return;
+        }
+        setTab(key);
+      }}
       className={`flex-1 whitespace-nowrap rounded-md px-2 py-1.5 text-sm font-semibold ${
         activeTab === key ? 'bg-base-100 text-base-content shadow-sm' : 'text-base-content/60'
       }`}
@@ -170,7 +178,14 @@ export function MapSheet() {
 
       {expanded && (
         <>
-          <div role="tablist" className="mx-4 flex flex-shrink-0 gap-1 rounded-lg bg-base-200 p-1">
+          {/* touch-none here too, not just on the handle: the handle is a 4px
+              pill at the top of a 70vh sheet, so collapsing meant reaching to
+              the top of the screen. The tab row is the nearest grab surface to
+              the content the student is actually looking at. */}
+          <div
+            role="tablist"
+            className="mx-4 flex flex-shrink-0 touch-none gap-1 rounded-lg bg-base-content/5 p-1"
+          >
             {tabBtn('akce', t('mobile.map.tabEvents'))}
             {/* Library study-room reservation is hidden on mobile. */}
             {showBudova && tabBtn('budova', t('mobile.map.tabBuilding', { name: buildingName }))}

--- a/src/components/mobile/screens/map/MapSheet.tsx
+++ b/src/components/mobile/screens/map/MapSheet.tsx
@@ -1,6 +1,6 @@
-import { useRef, useState, type PointerEvent as ReactPointerEvent } from 'react';
+import { useEffect, useRef, useState, type PointerEvent as ReactPointerEvent } from 'react';
 import { ChevronUp } from 'lucide-react';
-import { snapDetent, dragOwnsGesture } from '../../primitives/sheetDrag';
+import { snapDetent, dragOwnsGesture, consumesTravel } from '../../primitives/sheetDrag';
 import { useAppStore } from '../../../../store/useAppStore';
 import { useTranslation } from '../../../../hooks/useTranslation';
 import type { MapSheetTab } from '../../../../store/types';
@@ -82,7 +82,10 @@ export function MapSheet() {
     const from = start.current;
     if (!from) return;
     const dy = e.clientY - from.y;
-    if (dy !== 0) dragged.current = true;
+    // Travel the sheet cannot absorb belongs to the content: at peek a downward
+    // drag has nowhere to go, and while expanded an upward one scrolls the list.
+    if (!consumesTravel(sheetState, dy)) return;
+    dragged.current = true;
     // Clamped to the two detents: peek is the floor because this sheet is the
     // only way to reach Akce, and 70vh is the ceiling it snaps to.
     const max = window.innerHeight * EXPANDED_VH;
@@ -97,6 +100,29 @@ export function MapSheet() {
     if (!from) return;
     setSheetState(snapDetent(sheetState, e.clientY - from.y, e.timeStamp - from.t));
   };
+
+  /**
+   * The whole sheet is a drag surface, not just the handle — dragging a sheet
+   * down anywhere on it is what every native sheet does.
+   *
+   * This needs a NON-PASSIVE touchmove: React attaches touch listeners
+   * passively, so `preventDefault` from onPointerMove is a no-op and the
+   * browser takes the gesture as a pan and fires pointercancel mid-drag. Only
+   * while the sheet is actually absorbing the travel — otherwise this would
+   * block the Akce list from ever scrolling.
+   */
+  useEffect(() => {
+    const panel = panelRef.current;
+    if (!panel) return;
+    const onTouchMove = (e: TouchEvent) => {
+      const from = start.current;
+      const touch = e.touches[0];
+      if (!from || !touch) return;
+      if (consumesTravel(sheetState, touch.clientY - from.y)) e.preventDefault();
+    };
+    panel.addEventListener('touchmove', onTouchMove, { passive: false });
+    return () => panel.removeEventListener('touchmove', onTouchMove);
+  }, [sheetState]);
 
   // A cancel is the BROWSER taking the gesture over, not the student letting
   // go — the only outcome is "put it back". Mirrors Sheet's handling.

--- a/src/components/mobile/screens/map/MapSheet.tsx
+++ b/src/components/mobile/screens/map/MapSheet.tsx
@@ -1,4 +1,6 @@
+import { useRef, useState, type PointerEvent as ReactPointerEvent } from 'react';
 import { ChevronUp } from 'lucide-react';
+import { snapDetent, dragOwnsGesture } from '../../primitives/sheetDrag';
 import { useAppStore } from '../../../../store/useAppStore';
 import { useTranslation } from '../../../../hooks/useTranslation';
 import type { MapSheetTab } from '../../../../store/types';
@@ -8,6 +10,12 @@ import { MapEventsSection } from '../../../CampusMap/MapEventsSection';
 import { BuildingRoomList } from './BuildingRoomList';
 
 const META = buildingsJson as BuildingsMeta;
+
+/** The collapsed height, in px — kept in sync with the `h-[166px]` class below. */
+const PEEK_PX = 166;
+
+/** The expanded height as a fraction of the viewport, matching `h-[70vh]`. */
+const EXPANDED_VH = 0.7;
 
 /**
  * The map screen's bottom sheet: a drag handle that's always visible, then
@@ -46,7 +54,56 @@ export function MapSheet() {
   // rendering nothing with no tab to click back to.
   const activeTab: MapSheetTab =
     (tab === 'budova' && !showBudova) || tab === 'knihovna' ? 'akce' : tab;
-  const toggle = () => setSheetState(expanded ? 'peek' : 'expanded');
+  const panelRef = useRef<HTMLDivElement>(null);
+  const start = useRef<{ y: number; t: number; height: number } | null>(null);
+  const dragged = useRef(false);
+  const [dragHeight, setDragHeight] = useState<number | null>(null);
+
+  // A drag ends in a click too, and letting that click through would toggle the
+  // sheet straight back out of the detent the drag just chose.
+  const toggle = () => {
+    if (dragged.current) {
+      dragged.current = false;
+      return;
+    }
+    setSheetState(expanded ? 'peek' : 'expanded');
+  };
+
+  const onPointerDown = (e: ReactPointerEvent<HTMLDivElement>) => {
+    // Only a gesture the content does not want: while the expanded Akce list is
+    // scrolled down, a downward swipe belongs to the list, not the sheet.
+    if (!dragOwnsGesture(e.target as Element, panelRef.current)) return;
+    const height = panelRef.current?.getBoundingClientRect().height ?? PEEK_PX;
+    start.current = { y: e.clientY, t: e.timeStamp, height };
+    dragged.current = false;
+  };
+
+  const onPointerMove = (e: ReactPointerEvent<HTMLDivElement>) => {
+    const from = start.current;
+    if (!from) return;
+    const dy = e.clientY - from.y;
+    if (dy !== 0) dragged.current = true;
+    // Clamped to the two detents: peek is the floor because this sheet is the
+    // only way to reach Akce, and 70vh is the ceiling it snaps to.
+    const max = window.innerHeight * EXPANDED_VH;
+    const next = from.height - dy;
+    setDragHeight(Math.min(Math.max(next, PEEK_PX), max));
+  };
+
+  const onPointerUp = (e: ReactPointerEvent<HTMLDivElement>) => {
+    const from = start.current;
+    start.current = null;
+    setDragHeight(null);
+    if (!from) return;
+    setSheetState(snapDetent(sheetState, e.clientY - from.y, e.timeStamp - from.t));
+  };
+
+  // A cancel is the BROWSER taking the gesture over, not the student letting
+  // go — the only outcome is "put it back". Mirrors Sheet's handling.
+  const onPointerCancel = () => {
+    start.current = null;
+    setDragHeight(null);
+  };
 
   const buildingName =
     activeBuildingId !== null
@@ -70,16 +127,30 @@ export function MapSheet() {
 
   return (
     <div
+      ref={panelRef}
       data-testid="map-sheet"
-      className={`absolute inset-x-0 bottom-0 z-[1000] flex flex-col overflow-hidden rounded-t-[20px] bg-base-100 shadow-drawer transition-[height] duration-300 ease-out ${
-        expanded ? 'h-[70vh]' : 'h-[166px]'
-      }`}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+      onPointerCancel={onPointerCancel}
+      // The height transition is dropped mid-drag: it animates the same height
+      // the finger is setting, and leaving both on makes the sheet lag behind.
+      className={`absolute inset-x-0 bottom-0 z-[1000] flex flex-col overflow-hidden rounded-t-[20px] bg-base-100 shadow-drawer ${
+        dragHeight === null ? 'transition-[height] duration-300 ease-out' : ''
+      } ${expanded ? 'h-[70vh]' : 'h-[166px]'}`}
+      style={dragHeight === null ? undefined : { height: `${dragHeight}px` }}
     >
       <button
         type="button"
         onClick={toggle}
         aria-label={t(expanded ? 'mobile.map.sheetCollapse' : 'mobile.map.sheetExpand')}
-        className="flex-shrink-0 pb-1 pt-2"
+        // touch-none is what makes the pill below more than decoration. This
+        // div owns the pointer handlers and these events bubble up to it, but
+        // with the default touch-action the browser claims the gesture as a pan
+        // partway through and fires pointercancel — measured on device for the
+        // other sheets, where a 350px swipe was cut off after ~20px. Scoped to
+        // the handle and peek row so the expanded list keeps scrolling.
+        className="flex-shrink-0 touch-none pb-1 pt-2"
       >
         <span className="mx-auto block h-1 w-9 rounded-full bg-base-300" />
       </button>
@@ -88,7 +159,7 @@ export function MapSheet() {
         <button
           type="button"
           onClick={toggle}
-          className="flex flex-shrink-0 items-center justify-between px-5 pb-3.5 pt-0.5 text-left"
+          className="flex flex-shrink-0 touch-none items-center justify-between px-5 pb-3.5 pt-0.5 text-left"
         >
           <span className="text-[13.5px] font-semibold text-base-content">
             {t('mobile.map.peekHint')}


### PR DESCRIPTION
## What a student notices

The map's bottom sheet could only be **tapped** open. Swiping it — up or down —
did nothing: no animation, no movement, no response. Now it follows your finger
between the two heights, and a flick works too. Tapping still works exactly as
before.

## Why it happened

The handle was drawn as a drag pill but wired to nothing except `onClick`
([MapSheet.tsx:78](https://github.com/reis-mendelu/reis-extension/blob/main/src/components/mobile/screens/map/MapSheet.tsx#L78)) —
a decorative `<span>` inside a button. Every other sheet in the app goes through
the shared `Sheet` primitive, which has had follow-the-finger dragging all along.
The map sheet is the one surface that opted out, so the handle was promising a
gesture the code never implemented. `sheetDrag.ts`'s own header comment describes
this exact failure ("reads as *the app is frozen*") — for the sheets that got fixed.

## The change

`snapDetent()` joins `shouldDismiss()` in `sheetDrag.ts`, pure and tested without
a touchscreen. It mirrors the same distance/velocity rules so they work upward
too — `shouldDismiss` ignores upward travel by design, which is precisely the
"cannot pull it up" half. Travel deeper into the detent already held is ignored:
**peek is the floor**, because this sheet is the only route to Akce.

`MapSheet` sets its height from the finger, clamped between 166px and 70vh, and
drops the height transition mid-drag so the sheet doesn't lag behind.

## Two traps, both already paid for elsewhere in this repo

- **`touch-none`.** Without it the browser claims the gesture as a pan and fires
  `pointercancel` partway through — measured at ~20px of a 350px swipe when the
  other sheets hit this. Scoped to the handle and peek row so the expanded list
  still scrolls.
- **The drag-ending click.** A drag finishes with a click, which would run the
  tap toggle and put the sheet straight back where the drag took it from — the
  gesture would appear to do nothing, reproducing the original bug. Suppressed,
  and pinned by a test.

## Verified on the handset

Built, installed and driven on the A001 device, reading real geometry over CDP:

| Gesture | Result |
|---|---|
| Drag handle down (expanded) | 638 → 166 CSS px |
| Drag handle **up** (peek) | 166 → 638, Akce tab revealed |
| Drag **down** at peek | stays 166 — floor holds |
| Tap (expanded) | 638 → 166 |
| Tap (peek) | 166 → 638 |

23 unit tests across `sheetDrag` and `MapScreen`. Full `src/components/mobile`
suite green (145 tests). eslint, prettier, `tsc -b` and the nuia gate pass.

**Not verified on device:** the drag-vs-scroll hand-off, because the Akce list
currently fits without overflowing, so there was no scroller to test against.
That path is `dragOwnsGesture`, unit-tested and already shipping on the other
nine sheets.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)