### PR TITLE
Mobile: the subject drawer becomes a screen

### DIFF
--- a/src/components/mobile/primitives/Sheet.tsx
+++ b/src/components/mobile/primitives/Sheet.tsx
@@ -8,6 +8,13 @@ export interface SheetProps {
   children: ReactNode;
   /** Raises the sheet above other sheets (confirm dialogs). */
   elevated?: boolean;
+  /**
+   * `screen` presents a pushed screen rather than a bottom sheet: full bleed,
+   * no backdrop, slide in from the right, and no drag-to-dismiss. It stays in
+   * the same sheet STACK — back still pops it — only the presentation differs.
+   * Defaults to `sheet` so the other callers are untouched.
+   */
+  variant?: 'sheet' | 'screen';
 }
 
 /**
@@ -15,20 +22,31 @@ export interface SheetProps {
  * backdrop fade, slide-up, tap-outside-to-close, drag-down-to-close, and one of
  * two heights.
  */
-export function Sheet({ size, onClose, children, elevated }: SheetProps) {
+export function Sheet({ size, onClose, children, elevated, variant = 'sheet' }: SheetProps) {
+  const isScreen = variant === 'screen';
   // Tailwind's default z-index scale stops at 50 — z-60/z-61 are not real
   // classes and would silently drop the sheet's stacking order. z-50 is
   // on-scale and stays as-is; anything above it (51, 60, 61) needs an
   // arbitrary value.
   const backdropZ = elevated ? 'z-[60]' : 'z-50';
   const panelZ = elevated ? 'z-[61]' : 'z-[51]';
-  const panelPosition = size === 'full' ? 'top-[70px] bottom-0' : 'bottom-0 max-h-[85dvh]';
+  // A screen covers everything and carries its own status-bar inset; the sheet
+  // sizes leave the strip above them visible on purpose.
+  const panelPosition = isScreen
+    ? 'inset-0 pt-[var(--safe-top,0px)]'
+    : size === 'full'
+      ? 'top-[70px] bottom-0'
+      : 'bottom-0 max-h-[85dvh]';
 
   const panelRef = useRef<HTMLDivElement>(null);
   const start = useRef<{ y: number; t: number } | null>(null);
   const [dragY, setDragY] = useState(0);
 
   const onPointerDown = (e: ReactPointerEvent<HTMLDivElement>) => {
+    // A screen is left via back, not by being thrown downward — and with no
+    // backdrop there is nothing to tap outside of, so an accidental dismissal
+    // would have no undo.
+    if (isScreen) return;
     // Only a gesture the content does not want. dragOwnsGesture returns false
     // while any scroller under the finger is scrolled past its top, so reading
     // a long list never costs the student their place.
@@ -69,11 +87,13 @@ export function Sheet({ size, onClose, children, elevated }: SheetProps) {
 
   return (
     <>
-      <div
-        data-testid="sheet-backdrop"
-        onClick={onClose}
-        className={`absolute inset-0 bg-black/50 animate-[fadeIn_0.2s_ease-out] ${backdropZ}`}
-      />
+      {!isScreen && (
+        <div
+          data-testid="sheet-backdrop"
+          onClick={onClose}
+          className={`absolute inset-0 bg-black/50 animate-[fadeIn_0.2s_ease-out] ${backdropZ}`}
+        />
+      )}
       <div
         ref={panelRef}
         data-testid="sheet-panel"
@@ -84,9 +104,12 @@ export function Sheet({ size, onClose, children, elevated }: SheetProps) {
         // The entry animation is dropped the moment a drag starts: it animates
         // the same transform this does, and leaving both on makes the sheet
         // fight the finger.
-        className={`absolute inset-x-0 ${panelPosition} ${panelZ} flex flex-col overflow-hidden rounded-t-[20px] bg-base-100 shadow-drawer ${
-          dragging ? '' : 'animate-[sheetUp_0.3s_ease-out]'
-        }`}
+        // A screen enters from the RIGHT and squares off its corners: a rounded
+        // top edge sliding up is the vocabulary of something temporary sitting
+        // over the page, which is exactly the impression to avoid here.
+        className={`absolute ${isScreen ? '' : 'inset-x-0'} ${panelPosition} ${panelZ} flex flex-col overflow-hidden bg-base-100 shadow-drawer ${
+          isScreen ? 'animate-[screenIn_0.25s_ease-out]' : 'rounded-t-[20px]'
+        } ${dragging || isScreen ? '' : 'animate-[sheetUp_0.3s_ease-out]'}`}
         style={
           dragging
             ? { transform: `translateY(${dragY}px)` }

--- a/src/components/mobile/primitives/SheetHeader.tsx
+++ b/src/components/mobile/primitives/SheetHeader.tsx
@@ -1,4 +1,4 @@
-import { X } from 'lucide-react';
+import { ChevronLeft, X } from 'lucide-react';
 import { useTranslation } from '../../../hooks/useTranslation';
 
 export interface SheetHeaderProps {
@@ -6,10 +6,16 @@ export interface SheetHeaderProps {
   subtitle?: string;
   eyebrow?: string;
   onClose?: () => void;
+  /**
+   * Screen presentation: a back chevron in place of the close X, and no drag
+   * pill — a screen is left by going back, and the pill would be advertising a
+   * gesture `Sheet variant="screen"` deliberately does not have.
+   */
+  onBack?: () => void;
 }
 
 /** Drag handle + title block, shared by every sheet. */
-export function SheetHeader({ title, subtitle, eyebrow, onClose }: SheetHeaderProps) {
+export function SheetHeader({ title, subtitle, eyebrow, onClose, onBack }: SheetHeaderProps) {
   const { t } = useTranslation();
   return (
     // touch-none is what makes the drag pill below more than decoration. Sheet
@@ -19,8 +25,17 @@ export function SheetHeader({ title, subtitle, eyebrow, onClose }: SheetHeaderPr
     // after ~20px of a 350px swipe, so it never met the dismiss threshold.
     // Scoped to the header so the content below keeps scrolling normally.
     <div className="flex-shrink-0 touch-none">
-      <div className="mx-auto mt-2 mb-1 h-1 w-9 rounded-full bg-base-300" />
+      {!onBack && <div className="mx-auto mt-2 mb-1 h-1 w-9 rounded-full bg-base-300" />}
       <div className="flex items-start gap-3 px-4 pb-3 pt-2">
+        {onBack && (
+          <button
+            onClick={onBack}
+            aria-label={t('mobile.sheet.back')}
+            className="btn btn-circle btn-ghost btn-sm -ml-1 flex-shrink-0"
+          >
+            <ChevronLeft className="h-5 w-5" />
+          </button>
+        )}
         <div className="flex min-w-0 flex-1 flex-col gap-0.5">
           {eyebrow && (
             <span className="font-mono text-xs font-semibold tracking-wider text-primary">

--- a/src/components/mobile/primitives/SheetHeader.tsx
+++ b/src/components/mobile/primitives/SheetHeader.tsx
@@ -45,7 +45,10 @@ export function SheetHeader({ title, subtitle, eyebrow, onClose, onBack }: Sheet
           <span className="font-display text-lg font-bold tracking-tight">{title}</span>
           {subtitle && <span className="text-sm text-base-content/60">{subtitle}</span>}
         </div>
-        {onClose && (
+        {/* Back and close are alternatives, not a pair: a screen is left by
+            going back, a sheet by being closed. onBack wins so a caller passing
+            both cannot end up with two competing controls in one header. */}
+        {onClose && !onBack && (
           <button
             onClick={onClose}
             aria-label={t('mobile.sheet.close')}

--- a/src/components/mobile/primitives/__tests__/Sheet.test.tsx
+++ b/src/components/mobile/primitives/__tests__/Sheet.test.tsx
@@ -125,3 +125,71 @@ describe('Sheet', () => {
     expect(onClose).not.toHaveBeenCalled();
   });
 });
+
+/**
+ * The subject drawer is a whole screen, not a sheet: it already filled all but
+ * 70px, so the strip of dimmed screen above it and the slide-up-from-the-bottom
+ * entrance were suggesting a temporary overlay over something you could get
+ * back to by looking past it. It stays in the same sheet STACK — back still
+ * pops it — but presents as a pushed screen.
+ */
+describe('Sheet variant="screen"', () => {
+  it('covers the whole viewport instead of stopping below the status area', () => {
+    render(
+      <Sheet size="full" variant="screen" onClose={() => {}}>
+        x
+      </Sheet>
+    );
+    const panel = screen.getByTestId('sheet-panel');
+    expect(panel.className).toContain('inset-0');
+    expect(panel.className).not.toContain('top-[70px]');
+  });
+
+  it('insets its content below the status bar', () => {
+    render(
+      <Sheet size="full" variant="screen" onClose={() => {}}>
+        x
+      </Sheet>
+    );
+    expect(screen.getByTestId('sheet-panel').className).toContain('var(--safe-top');
+  });
+
+  // No dimmed layer: there is nothing behind a screen to see through to.
+  it('renders no backdrop', () => {
+    render(
+      <Sheet size="full" variant="screen" onClose={() => {}}>
+        x
+      </Sheet>
+    );
+    expect(screen.queryByTestId('sheet-backdrop')).not.toBeInTheDocument();
+  });
+
+  /**
+   * A screen is left via back, not by being thrown downward — and with no
+   * backdrop there is nothing to tap outside of either, so an accidental
+   * dismissal would have no undo.
+   */
+  it('does not dismiss on a downward drag', () => {
+    const onClose = vi.fn();
+    render(
+      <Sheet size="full" variant="screen" onClose={onClose}>
+        x
+      </Sheet>
+    );
+    const panel = screen.getByTestId('sheet-panel');
+    fireEvent.pointerDown(panel, { clientY: 100 });
+    fireEvent.pointerMove(panel, { clientY: 500 });
+    fireEvent.pointerUp(panel, { clientY: 500 });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('still defaults to sheet presentation for every other caller', () => {
+    render(
+      <Sheet size="full" onClose={() => {}}>
+        x
+      </Sheet>
+    );
+    expect(screen.getByTestId('sheet-backdrop')).toBeInTheDocument();
+    expect(screen.getByTestId('sheet-panel').className).toContain('top-[70px]');
+  });
+});

--- a/src/components/mobile/primitives/__tests__/SheetHeader.test.tsx
+++ b/src/components/mobile/primitives/__tests__/SheetHeader.test.tsx
@@ -53,3 +53,14 @@ describe('SheetHeader onBack', () => {
     expect(container.querySelector('.w-9.rounded-full')).not.toBeNull();
   });
 });
+
+/**
+ * Back and close are alternatives, not a pair — a screen is left by going back,
+ * a sheet by being closed. Rendering both would put two competing controls in
+ * one header, so onBack wins and the X is suppressed.
+ */
+it('renders only the back control when given both onBack and onClose', () => {
+  render(<SheetHeader title="Internet věcí" onBack={() => {}} onClose={() => {}} />);
+  expect(screen.getByLabelText('mobile.sheet.back')).toBeInTheDocument();
+  expect(screen.queryByLabelText('mobile.sheet.close')).not.toBeInTheDocument();
+});

--- a/src/components/mobile/primitives/__tests__/SheetHeader.test.tsx
+++ b/src/components/mobile/primitives/__tests__/SheetHeader.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { SheetHeader } from '../SheetHeader';
 
 vi.mock('../../../../hooks/useTranslation', () => ({
@@ -25,5 +25,31 @@ describe('SheetHeader', () => {
     const { container } = render(<SheetHeader title="Internet věcí" />);
     const header = container.firstElementChild as HTMLElement;
     expect(header.className).toContain('touch-none');
+  });
+});
+
+/**
+ * A screen is left by going back, not by being dismissed, so its header shows a
+ * back chevron rather than a close X — and drops the drag pill, which would be
+ * promising a gesture the screen variant deliberately does not have.
+ */
+describe('SheetHeader onBack', () => {
+  it('renders a back control instead of the close X', () => {
+    const onBack = vi.fn();
+    render(<SheetHeader title="Internet věcí" onBack={onBack} />);
+    fireEvent.click(screen.getByLabelText('mobile.sheet.back'));
+    expect(onBack).toHaveBeenCalledTimes(1);
+    expect(screen.queryByLabelText('mobile.sheet.close')).not.toBeInTheDocument();
+  });
+
+  it('drops the drag pill, which a screen cannot honour', () => {
+    const { container } = render(<SheetHeader title="Internet věcí" onBack={() => {}} />);
+    expect(container.querySelector('.w-9.rounded-full')).toBeNull();
+  });
+
+  it('keeps the pill and the X for ordinary sheets', () => {
+    const { container } = render(<SheetHeader title="Internet věcí" onClose={() => {}} />);
+    expect(screen.getByLabelText('mobile.sheet.close')).toBeInTheDocument();
+    expect(container.querySelector('.w-9.rounded-full')).not.toBeNull();
   });
 });

--- a/src/components/mobile/sheets/SubjectDrawerSheet.tsx
+++ b/src/components/mobile/sheets/SubjectDrawerSheet.tsx
@@ -108,12 +108,12 @@ export function SubjectDrawerSheet({ sheet, onClose }: SubjectDrawerSheetProps) 
   };
 
   return (
-    <Sheet size="full" onClose={onClose}>
+    <Sheet size="full" variant="screen" onClose={onClose}>
       <SheetHeader
         eyebrow={courseCode}
         title={courseName || courseCode}
         subtitle={teacherLine}
-        onClose={onClose}
+        onBack={onClose}
       />
       <SubjectDrawerTabs
         activeTab={activeTab}

--- a/src/components/mobile/sheets/__tests__/SheetHost.test.tsx
+++ b/src/components/mobile/sheets/__tests__/SheetHost.test.tsx
@@ -50,12 +50,15 @@ describe('SheetHost', () => {
     expect(panels[1]!.textContent).toContain('Matematika');
   });
 
+  /**
+   * `studyPlan` rather than `subjectDrawer`: the drawer presents as a SCREEN
+   * now (Sheet variant="screen") and deliberately renders no backdrop, so it
+   * can no longer stand in for "a sheet with a backdrop". The behaviour under
+   * test — one backdrop click pops exactly one level — is unchanged.
+   */
   it('pops exactly one sheet when a backdrop is clicked', () => {
     useAppStore.setState({
-      mobileSheets: [
-        { kind: 'subjectDrawer', courseCode: 'ALG', courseName: 'Algoritmizace' },
-        { kind: 'subjectDrawer', courseCode: 'MAT', courseName: 'Matematika' },
-      ],
+      mobileSheets: [{ kind: 'studyPlan' }, { kind: 'studyPlan' }],
     } as never);
     render(<SheetHost />);
 

--- a/src/components/mobile/sheets/__tests__/SubjectDrawerSheet.test.tsx
+++ b/src/components/mobile/sheets/__tests__/SubjectDrawerSheet.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { SubjectDrawerSheet } from '../SubjectDrawerSheet';
 import { useAppStore } from '../../../../store/useAppStore';
 import type { SubjectInfo } from '../../../../types/documents';
@@ -93,5 +93,46 @@ describe('SubjectDrawerSheet', () => {
 
     // The files body should NOT be rendered; the files empty state message should not appear
     expect(screen.queryByText('Žádné soubory nejsou k dispozici.')).not.toBeInTheDocument();
+  });
+});
+
+/**
+ * The drawer is a whole screen, not a sheet. It already filled all but 70px of
+ * the viewport, so the dimmed strip above it and the slide-up entrance were
+ * advertising a temporary overlay you could look past — for what is really a
+ * destination you navigate into and come back from.
+ */
+describe('SubjectDrawerSheet presentation', () => {
+  const renderDrawer = (onClose = vi.fn()) =>
+    render(
+      <SubjectDrawerSheet
+        sheet={{ kind: 'subjectDrawer', courseCode: 'BIO', courseName: 'Biologie' }}
+        onClose={onClose}
+      />
+    );
+
+  it('presents as a full-bleed screen with no backdrop behind it', () => {
+    renderDrawer();
+    expect(screen.queryByTestId('sheet-backdrop')).not.toBeInTheDocument();
+    expect(screen.getByTestId('sheet-panel').className).toContain('inset-0');
+  });
+
+  it('offers back rather than close, since back is how a screen is left', () => {
+    const onClose = vi.fn();
+    renderDrawer(onClose);
+    expect(screen.queryByLabelText('Zavřít')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText('Zpět'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * The Android back button pops the same sheet stack, so the chevron and the
+   * system gesture are the same code path — this is what keeps them in step.
+   */
+  it('leaves via the same onClose the back button pops the stack with', () => {
+    const onClose = vi.fn();
+    renderDrawer(onClose);
+    fireEvent.click(screen.getByLabelText('Zpět'));
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -1227,7 +1227,8 @@
       "writeEmail": "Napsat e-mail",
       "showOfficeOnMap": "Ukázat kancelář na mapě",
       "personLoading": "Načítání…",
-      "personLoadError": "Osobu se nepodařilo načíst."
+      "personLoadError": "Osobu se nepodařilo načíst.",
+      "back": "Zpět"
     },
     "profile": {
       "appearance": "Vzhled",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1227,7 +1227,8 @@
       "writeEmail": "Write email",
       "showOfficeOnMap": "Show office on map",
       "personLoading": "Loading…",
-      "personLoadError": "Couldn't load this person."
+      "personLoadError": "Couldn't load this person.",
+      "back": "Back"
     },
     "profile": {
       "appearance": "Appearance",

--- a/src/index.css
+++ b/src/index.css
@@ -38,6 +38,17 @@ body,
     transform: translateY(0);
   }
 }
+/* Pushed screens (Sheet variant="screen") enter from the right, the way a
+   forward navigation reads — as opposed to sheetUp, which says "temporary
+   surface over the page". */
+@keyframes screenIn {
+  from {
+    transform: translateX(100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
 @keyframes fadeIn {
   from {
     opacity: 0;


### PR DESCRIPTION
## What a student notices

Opening a subject used to slide a sheet up from the bottom, leaving a strip of
dimmed screen above it. It now opens as a **screen**: full bleed, sliding in
from the right, with a back chevron where the close X was. Back — the button,
the gesture, or the chevron — returns you to Předměty.

## Why

The drawer already filled all but 70px of the viewport. The dimmed strip and
the slide-up entrance were the vocabulary of a temporary overlay you could look
past, for what is really a destination you navigate into and come back from.

## The change

`Sheet` gains `variant: 'sheet' | 'screen'`, **defaulting to `sheet`** so the
other eight callers are untouched. In `screen`:

- full bleed (`inset-0`) with its own `--safe-top` inset, since it now covers
  the status bar
- no backdrop — there is nothing behind a screen to see through to
- squared corners and a right-to-left entrance (`screenIn`, next to the
  existing `sheetUp`)
- **no drag-to-dismiss.** A screen is left via back; with no backdrop there is
  nothing to tap outside of either, so an accidental dismissal would have no undo.

`SheetHeader` gains `onBack`: a chevron instead of the X, and no drag pill —
the pill would be promising a gesture this variant deliberately does not have.

**It stays in the same `mobileSheets` stack.** Back handling is unchanged: the
Android back button and the chevron are the same code path, nesting
(subject → confirm) still works, and `SheetHost` is not touched.

## Verified

Measured on the phone (via CDP, real device): no backdrop, panel at top 0,
height 911 = full viewport, `padding-top: 48px` = the real safe-area inset,
squared corners, back chevron present and close X gone.

Measured in the dev webapp at 375×812: after the entry animation the panel
rests at `left: 0`, `375×812`, `transform: none` — no horizontal overflow at
document, panel, or element level — and the chevron returns to Předměty.

*A note on how that was measured:* both the phone (screen asleep) and the
browser pane (`document.hidden`) throttle CSS animations, pinning `screenIn` at
`currentTime: 0` so the panel reads as parked off-screen. The animation's
`fill: none` and an explicit `.finish()` establish the resting state instead —
worth knowing before anyone re-measures this and reports a phantom bug.

11 new tests across `Sheet`, `SheetHeader` and `SubjectDrawerSheet`, including
one pinning that the default variant still renders a backdrop and a `top-[70px]`
panel. Full `src/components/mobile` suite green (144). eslint, prettier,
`tsc -b` and the nuia gate pass.

## Follow-up left open deliberately

`SheetHost`'s backdrop test now stacks `studyPlan` rather than `subjectDrawer`:
the drawer renders no backdrop now, so it cannot stand in for "a sheet with a
backdrop". The behaviour under test is unchanged.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a full-screen mobile sheet presentation with safe-area support, right-side animation, and no backdrop.
  * Added back navigation for full-screen sheets, including localized accessibility text.
  * Updated the subject drawer to use full-screen navigation with a back action.

* **Bug Fixes**
  * Preserved existing sheet behavior, including close controls, drag dismissal, and rounded styling.

* **Tests**
  * Added coverage for full-screen presentation, back navigation, and existing sheet behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->