### PR TITLE
Mobile: the IS session token moves to the Android Keystore

### DIFF
--- a/android/app/src/main/java/cz/reis/app/MainActivity.java
+++ b/android/app/src/main/java/cz/reis/app/MainActivity.java
@@ -9,6 +9,7 @@ public class MainActivity extends BridgeActivity {
     public void onCreate(Bundle savedInstanceState) {
         registerPlugin(DownloadsPlugin.class);
         registerPlugin(EduroamPlugin.class);
+        registerPlugin(SecureStorePlugin.class);
         super.onCreate(savedInstanceState);
     }
 }

--- a/android/app/src/main/java/cz/reis/app/SecureStorePlugin.java
+++ b/android/app/src/main/java/cz/reis/app/SecureStorePlugin.java
@@ -1,0 +1,159 @@
+package cz.reis.app;
+
+import android.content.SharedPreferences;
+import android.security.keystore.KeyGenParameterSpec;
+import android.security.keystore.KeyProperties;
+import android.util.Base64;
+
+import com.getcapacitor.JSObject;
+import com.getcapacitor.Plugin;
+import com.getcapacitor.PluginCall;
+import com.getcapacitor.PluginMethod;
+import com.getcapacitor.annotation.CapacitorPlugin;
+
+import java.nio.charset.StandardCharsets;
+import java.security.KeyStore;
+
+import javax.crypto.Cipher;
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+
+/**
+ * Encrypted storage for the IS session token.
+ *
+ * The app persists UISAuth, which authenticates as the student on its own and
+ * never rotates. @capacitor/preferences is SharedPreferences — plaintext — so
+ * anything able to read app storage could act as that student. Here the value
+ * is encrypted with AES-256-GCM under a key generated inside the Android
+ * Keystore: the key is hardware-backed where a TEE/StrongBox exists, cannot be
+ * exported, and never enters the JS heap. Only ciphertext is persisted.
+ *
+ * Written by hand rather than pulled in as a dependency for two reasons: this
+ * sits directly on the credential path, and the obvious library for it —
+ * androidx.security:security-crypto (EncryptedSharedPreferences) — was
+ * deprecated in April 2025.
+ *
+ * setUserAuthenticationRequired is deliberately NOT set: the token is read at
+ * cold start to restore the session, and demanding a device unlock there would
+ * break launch-time sync for a credential the OS already protects at rest.
+ */
+@CapacitorPlugin(name = "SecureStore")
+public class SecureStorePlugin extends Plugin {
+
+    private static final String KEYSTORE = "AndroidKeyStore";
+    private static final String KEY_ALIAS = "reis.securestore.v1";
+    private static final String PREFS = "reis_secure_store";
+    private static final String TRANSFORMATION = "AES/GCM/NoPadding";
+    private static final int GCM_TAG_BITS = 128;
+    private static final int IV_BYTES = 12;
+
+    private SharedPreferences prefs() {
+        return getContext().getSharedPreferences(PREFS, android.content.Context.MODE_PRIVATE);
+    }
+
+    /**
+     * Created on first use and reused thereafter. Generating it inside the
+     * Keystore — rather than generating bytes here and importing them — is what
+     * keeps the key material out of this process entirely.
+     */
+    private SecretKey key() throws Exception {
+        KeyStore ks = KeyStore.getInstance(KEYSTORE);
+        ks.load(null);
+        KeyStore.Entry entry = ks.getEntry(KEY_ALIAS, null);
+        if (entry instanceof KeyStore.SecretKeyEntry) {
+            return ((KeyStore.SecretKeyEntry) entry).getSecretKey();
+        }
+        KeyGenerator gen = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, KEYSTORE);
+        gen.init(
+            new KeyGenParameterSpec.Builder(
+                KEY_ALIAS,
+                KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT
+            )
+                .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                .setKeySize(256)
+                .build()
+        );
+        return gen.generateKey();
+    }
+
+    @PluginMethod
+    public void set(PluginCall call) {
+        String storageKey = call.getString("key");
+        String value = call.getString("value");
+        if (storageKey == null || value == null) {
+            call.reject("key and value are required");
+            return;
+        }
+        try {
+            Cipher cipher = Cipher.getInstance(TRANSFORMATION);
+            cipher.init(Cipher.ENCRYPT_MODE, key());
+            byte[] iv = cipher.getIV();
+            byte[] ct = cipher.doFinal(value.getBytes(StandardCharsets.UTF_8));
+
+            // IV prepended rather than stored beside the ciphertext: one string
+            // cannot go out of sync with itself, and GCM needs a fresh IV per
+            // write — which the Cipher generates for us on every init.
+            byte[] joined = new byte[iv.length + ct.length];
+            System.arraycopy(iv, 0, joined, 0, iv.length);
+            System.arraycopy(ct, 0, joined, iv.length, ct.length);
+
+            prefs().edit().putString(storageKey, Base64.encodeToString(joined, Base64.NO_WRAP)).apply();
+            call.resolve();
+        } catch (Exception e) {
+            call.reject("secure set failed: " + e.getClass().getSimpleName());
+        }
+    }
+
+    /**
+     * Resolves {value: null} for "not stored" AND for "stored but unreadable".
+     *
+     * The Keystore key is invalidated by a device-credential change or a restore
+     * onto new hardware, and decryption then throws for a value that is present
+     * but permanently unrecoverable. Both cases mean the same thing to the app:
+     * no session, present login. Rejecting instead would turn a recoverable
+     * lapse into a boot failure. The dead entry is dropped so the next write
+     * starts clean.
+     */
+    @PluginMethod
+    public void get(PluginCall call) {
+        String storageKey = call.getString("key");
+        if (storageKey == null) {
+            call.reject("key is required");
+            return;
+        }
+        String stored = prefs().getString(storageKey, null);
+        JSObject out = new JSObject();
+        if (stored == null) {
+            out.put("value", null);
+            call.resolve(out);
+            return;
+        }
+        try {
+            byte[] joined = Base64.decode(stored, Base64.NO_WRAP);
+            byte[] iv = new byte[IV_BYTES];
+            System.arraycopy(joined, 0, iv, 0, IV_BYTES);
+
+            Cipher cipher = Cipher.getInstance(TRANSFORMATION);
+            cipher.init(Cipher.DECRYPT_MODE, key(), new GCMParameterSpec(GCM_TAG_BITS, iv));
+            byte[] pt = cipher.doFinal(joined, IV_BYTES, joined.length - IV_BYTES);
+            out.put("value", new String(pt, StandardCharsets.UTF_8));
+        } catch (Exception e) {
+            prefs().edit().remove(storageKey).apply();
+            out.put("value", null);
+        }
+        call.resolve(out);
+    }
+
+    @PluginMethod
+    public void remove(PluginCall call) {
+        String storageKey = call.getString("key");
+        if (storageKey == null) {
+            call.reject("key is required");
+            return;
+        }
+        prefs().edit().remove(storageKey).apply();
+        call.resolve();
+    }
+}

--- a/capacitor/main.capacitor.ts
+++ b/capacitor/main.capacitor.ts
@@ -9,6 +9,7 @@ import { handleBackPress } from '@/mobile/backButton';
 import { installMobileActionHandler } from '@/mobile/actionHandler';
 import { installExternalLinkHandler } from '@/mobile/openExternal';
 import { promptSessionRecovery } from '@/mobile/sessionRecovery';
+import { purgePlaintextToken } from '@/platform/tokenStore';
 import { setSessionExpiredHandler } from '@/services/sessionExpiry';
 import { useAppStore } from '@/store/useAppStore';
 
@@ -33,6 +34,13 @@ void CapApp.addListener('backButton', () => {
 });
 
 async function boot(): Promise<void> {
+  // BEFORE ensureSession, which is what reads the token and decides whether to
+  // present login. Installs from before #172 hold a live UISAuth in plain
+  // Preferences; it is deleted rather than migrated, so the student signs in
+  // once and the plaintext copy is gone by deletion rather than by trusting a
+  // copy step.
+  await purgePlaintextToken();
+
   // Same deps as re-login after a lapse (mobile/sessionRecovery), deliberately
   // shared: ensureSession's cookie-polling contract only holds if onPageLoaded
   // and readCookies come from the same WebView openLogin presented, and two

--- a/docs/superpowers/plans/2026-08-02-capacitor-remaining-work.md
+++ b/docs/superpowers/plans/2026-08-02-capacitor-remaining-work.md
@@ -13,7 +13,7 @@ measurements) and `2026-08-02-capacitor-transport-decision.md` (why Model C).
 
 ## Where it stands
 
-*Updated 2026-08-07 (evening), after the first real Android handset pass.*
+*Updated 2026-08-08, after a UI-polish round (#192–#194) and secure storage (#195).*
 
 **THE DEVICE PASS HAPPENED.** Handset A001, 1080x2392, dpr 2.625. Cold start → login →
 **115 requests, all HTTP 200, zero telemetry**, covering all four Task 4 endpoint families
@@ -64,55 +64,67 @@ on the extension is the check that would actually confirm it.
 |---|---|
 | Shell: boot, login, session restore, back button | **Done**, device-verified on Android |
 | Transport (`CapacitorHttp`, per-platform cookie) | **Done** — GET **and POST**, plus raw bytes |
-| Sync (14 endpoints, ~236 requests) | **Done** via postMessage loopback; the zaznamnik hole is closed — **unverified on a device** |
+| Sync (14 endpoints, ~236 requests) | **Done**, device-verified — 115 requests, all HTTP 200 |
 | File download → Downloads + notification | **Done**, device-verified |
 | Duplicate file listings | **Fixed** (also fixes the extension) |
 | Study documents (Task 1/2) | **Done**, device-verified — PR #179 |
-| eduroam cert fetch (Task 3 + eduroam half of Task 4) | **Merged unverified** — PR #181, see Task 3 |
-| Bare `fetch` sites (Task 4) | **Done** — all migratable rows on `fetchWithAuth`; `serverTime` excluded on purpose. **Unverified on a device** |
-| Search, cvicne testy, odevzdávárny, kontrola | **Done** (Task 4) — **unverified on a device** |
-| External links → in-app browser (Task 8) | **Done** — **unverified on a device** |
-| Re-login after a lapsed session | **Done**, prompt-first — **unverified on a device** |
-| Secure storage for `UISAuth` (Task 6) | **Not started** — the one hard release gate |
-| iOS app | **Never built** — only the throwaway spike ran there |
+| eduroam cert fetch (Task 3 + eduroam half of Task 4) | **Done** — superseded by the native path (#189), proven on hardware |
+| Bare `fetch` sites (Task 4) | **Done**, device-verified — `serverTime` excluded on purpose |
+| Search, cvicne testy, odevzdávárny, kontrola | **Done** — search device-verified (people + subjects, person card fills) |
+| External links → in-app browser (Task 8) | **Done** — ⚠️ still **unverified on a device**, one of two owed checks |
+| Re-login after a lapsed session | **Done**, prompt-first — device-verified via the #172 purge, which forced a real re-login |
+| Secure storage for `UISAuth` (Task 6) | **Done for Android** (#195), device-verified — iOS half owed |
+| iOS app | **Never built** — only the spike ran there. **Now the top remaining item** |
 | Native Wi-Fi (eduroam, Android) | **Done**, device-verified — Task 5 |
 | ISKAM, Drive | **Broken** — see below |
 
-**Everything shipped since PR #181 is unit-tested only.** That is the single largest risk
-in this document, and it compounds: this transport's own record is *four* bugs shipping
-green because the tests stubbed shapes the native layer never produces (Task 3). One
-Android session is now worth more than any further code.
+~~**Everything shipped since PR #181 is unit-tested only.**~~ **Largely closed.** Two
+handset sessions (2026-08-07, 2026-08-08) verified sync, downloads, search, back
+navigation, the map sheet and secure storage on real hardware. The warning that produced
+this line still stands as a rule, though: this transport's record is *four* bugs shipping
+green because the tests stubbed shapes the native layer never produces (Task 3) — and this
+session added a second class, where jsdom cannot express `touch-action` at all, so a
+gesture can pass every test and still be dead on a device.
 
 ## What is still owed
 
-**1. The predictive-back GESTURE — the one thing a human must check.**
-`android:enableOnBackInvokedCallback="true"` is now in the merged manifest, which is the
-documented fix for targetSdk 36. It is NOT confirmed: `adb shell input swipe` only reaches
-the app window, and `input keyevent 4` exercises the legacy path, which worked all along.
-Only a thumb settles it. **The single decisive test: open vývěska and swipe back.** If the
-noticeboard closes and the app stays, both this and the bulletin fix are confirmed at once —
-before, the two failure modes were indistinguishable (the app closed either way).
+*Rewritten 2026-08-08. The five items that stood here are resolved except where noted.*
 
-**2. eduroam, the half that must not be automated.** The sheet opens and the extraction
-password renders. The cert download was deliberately NOT tapped: it can generate a
-certificate and rotate a 366-day credential the student may have installed elsewhere. When
-checking by hand, assert the bytes start `0x30 0x82` — an HTML error page is also non-empty,
-so a length check proves nothing. Native Wi-Fi config (#159) remains unstarted.
+**1. iOS has still never been compiled — this is now the top of the list (#174).**
+With #172 done for Android, iOS is the only thing between this app and a release
+candidate, and it is entirely unmeasured: the inverted cookie delivery has run only in
+the throwaway spike, `deliverFile`'s share-sheet branch has never been seen, and the
+Keychain half of secure storage is deliberately unwritten (Task 6). Everything about it
+is assumption until something compiles.
 
-**3. Search and external links.** `searchService` moved onto the content-script proxy and
-still has no end-to-end coverage (`e2e/tests/search.spec.ts` only asserts the bar renders,
-and CI does not run e2e). External links opening in-app AND authenticated is likewise
-unverified. Both were mid-check when this session ended.
+**2. Two device checks, neither needing new code.** External links must open **in-app and
+authenticated**, not in Chrome. And the map sheet's drag-vs-scroll hand-off is unverified
+because the Akce list currently has no events, so nothing overflows to scroll against —
+that path is `dragOwnsGesture` + `consumesTravel`, both unit-tested.
+
+**3. Lower-severity credentials.** Google OAuth tokens still sit in plain storage (#196,
+found while doing #172). Lower bar than UISAuth was: `drive.file`-scoped, they expire,
+and they are revocable. The Discord webhook still ships in the client bundle (#163/#183).
 
 **4. UI polish backlog.** `MobileSearchOverlay` still lacks its `--safe-top` inset and is
 BLOCKED by pre-existing react-hooks lint debt in the same file (a setState-in-effect error
 on HEAD) — the changed-files CI gate makes that file untouchable until the effect is fixed.
-Other top-anchored surfaces were swept. The bottom nav sits at `bottom-[18px]` against a
-24px `--safe-bottom`.
+The map's floating search bar had the same defect and is fixed (#193); it was the only
+other top-anchored surface that did not inherit the inset from `ScreenHeader`.
 
-**5. Unchanged blockers.** Secure storage for `UISAuth` (#172) is still the one hard release
-gate. iOS has still never been built (#174). Drive on mobile (#168) is now hidden rather
-than fixed. The Discord webhook still ships in the client bundle (#163/#183).
+**5. Unchanged.** Drive on mobile (#168) is hidden rather than fixed. Tablets still get the
+desktop tree (#175). Three unguarded IDB reads can still setState after unmount (#176).
+
+### Resolved since this list was written
+
+- ~~predictive-back gesture~~ **confirmed by thumb.** It exposed a separate defect — back
+  from any non-calendar tab *quit the app*, because `handleBackPress` knew about sheets and
+  the bulletin but never about `mobileTab`. Fixed in #192; the chain is now
+  sheet → bulletin → tab → exit, with calendar as the start destination.
+- ~~eduroam~~ **native Android one-tap merged** (#189) — see Task 5. The cert-bytes check is
+  moot: the native path proved the whole chain on hardware.
+- ~~search~~ **verified on device** — people *and* subjects, live from IS, person card fills.
+- ~~secure storage for UISAuth~~ **done for Android** (#172 / PR #195) — see Task 6.
 
 **6. Other parsers may share the FILE bug.** IS's `img[sysid]` → `span[data-sysid]`
 migration is unlikely to stop at the document server. Audit `grep -rn "sysid" src/` and
@@ -449,7 +461,7 @@ and was unaffected.
 reproduced in this repo's test environment at all. Worth knowing before trusting a green
 suite on any header-merging question.
 
-## Task 5 — eduroam native one-tap (#159) — Android BUILT, unverified on a device
+## Task 5 — eduroam native one-tap (#159) ✅ Android DONE and device-verified (PR #189, `1b5b7fbd`)
 
 **The Android half is written** (branch `worktree-eduroam-android-native`). What landed:
 
@@ -554,24 +566,60 @@ android` after changing branches, and never trust an incremental APK across a sw
 5. Cert expiry is 366 days and silent; renewal is a POST (an IS write) and must stay
    student-initiated.
 
-## Task 6 — Secure storage for `UISAuth`
+## Task 6 — Secure storage for `UISAuth` ✅ DONE for Android (#172, PR #195)
 
-`@capacitor/preferences` is UserDefaults / SharedPreferences, **not** Keychain/Keystore,
-and `UISAuth` is a live credential (`src/platform/tokenStore.ts:8-12` says so). Acceptable
-for a debug build.
+> This was the one item with a security bar rather than a feature bar. **The Android half
+> is closed.** iOS is deliberately unwritten — see below.
 
-> **This is the one item with a security bar rather than a feature bar. It must land
-> before any public release.**
+**The exposure, measured before the fix.** `adb shell run-as cz.reis.app cat
+shared_prefs/CapacitorStorage.xml` returned the live token in plaintext, 56 characters.
 
-## Task 7 — Build and verify on iOS
+**What landed.** `android/.../SecureStorePlugin.java` encrypts with AES-256-GCM under a key
+generated *inside* the Android Keystore — hardware-backed where a TEE/StrongBox exists,
+unexportable, never in the JS heap. Only ciphertext is persisted. Hand-written rather than
+taken as a dependency because it sits on the credential path and because the obvious
+library, `androidx.security:security-crypto` (`EncryptedSharedPreferences`), **was
+deprecated in April 2025** — check this before reaching for it again.
 
-The app has never been built for iOS; only the spike ran there. Everything platform-specific
-should be re-checked, in particular:
+`secureStorage` joins `ReisPlatform` (`src/platform/types.ts`), **required not optional**:
+an optional field would let a host silently lack it and fall back to plaintext, the exact
+failure being prevented.
+
+**The finding worth more than the code.** Three call sites reached
+`storage.get/set/remove(TOKEN_KEY)` directly, and `saveStoredToken` had **no callers at
+all** — the login flow wrote the credential straight to plaintext while the module meant to
+own it sat unused. Swapping only `tokenStore`'s internals would have left login writing
+plaintext and reads coming from the Keystore: a broken session, not a leftover copy.
+`TOKEN_KEY` is now private to `tokenStore`, which is what stops this recurring.
+
+**Device evidence** (the 74-byte figure is the one that proves encryption rather than
+encoding): blob = 46 plaintext + 12 IV + 16 GCM tag = **74 bytes exactly**; entropy
+5.93 bits/byte against a 6.21 ceiling for that sample size; no printable run ≥ 8 chars;
+decrypt round-trips; cold restart restores the session with no login prompt.
+
+**Migration is deletion, not copying.** Boot purges the plaintext copy before
+`ensureSession`, so the student signs in once. A decrypt failure — key invalidated by a
+credential change or a restore onto new hardware — reads as a lapsed session: never a
+crash, never grounds to look in plaintext.
+
+**Still owed: the iOS half.** Keychain via the Security framework, landing with Task 7
+where it can actually be compiled. Calling the plugin on iOS today rejects from the bridge,
+which is the intended behaviour — a missing implementation must fail loudly rather than
+quietly store a credential in the clear.
+
+## Task 7 — Build and verify on iOS ← **the top remaining item**
+
+The app has never been built for iOS; only the spike ran there. With Task 6 closed for
+Android, this is the last thing between the app and a release candidate — and it is
+entirely unmeasured. Everything platform-specific should be re-checked, in particular:
 
 - The **inverted cookie delivery** (iOS needs the explicit header, Android the native jar).
 - **File delivery** — iOS has no Downloads folder, so `deliverFile` deliberately uses the
   share sheet there (`src/mobile/deliverFile.ts`). Verify that is the right feel.
 - Cold-start session restore.
+- **The Keychain half of Task 6** — `SecureStorePlugin` is Android-only by design, and the
+  bridge rejects on iOS rather than falling back to plaintext. Until this is written, an
+  iOS build cannot store a session at all, which is the intended failure.
 
 ## Task 8 — Smaller, known items (two of four done)
 

--- a/src/api/__tests__/authedBytes.test.ts
+++ b/src/api/__tests__/authedBytes.test.ts
@@ -18,6 +18,19 @@ function stub(kind: ReisPlatform['kind']): ReisPlatform {
         bag.delete(k);
       },
     },
+    // Shares the plain bag: these tests exercise the transport, not the
+    // storage guarantee — tokenStore.test.ts owns that.
+    secureStorage: {
+      async get(k) {
+        return bag.get(k);
+      },
+      async set(k, v) {
+        bag.set(k, v);
+      },
+      async remove(k) {
+        bag.delete(k);
+      },
+    },
     getAssetUrl: (p) => `/${p}`,
   };
 }

--- a/src/api/__tests__/proxyClient.logout.test.ts
+++ b/src/api/__tests__/proxyClient.logout.test.ts
@@ -19,6 +19,19 @@ function stub(kind: ReisPlatform['kind']): ReisPlatform {
         bag.delete(k);
       },
     },
+    // Shares the plain bag: these tests exercise the transport, not the
+    // storage guarantee — tokenStore.test.ts owns that.
+    secureStorage: {
+      async get(k) {
+        return bag.get(k);
+      },
+      async set(k, v) {
+        bag.set(k, v);
+      },
+      async remove(k) {
+        bag.delete(k);
+      },
+    },
     getAssetUrl: (p) => `/${p}`,
   };
 }

--- a/src/api/eduroam.test.ts
+++ b/src/api/eduroam.test.ts
@@ -39,6 +39,19 @@ function stubPlatform(): ReisPlatform {
         bag.delete(k);
       },
     },
+    // Shares the plain bag: these tests exercise the transport, not the
+    // storage guarantee — tokenStore.test.ts owns that.
+    secureStorage: {
+      async get(k) {
+        return bag.get(k);
+      },
+      async set(k, v) {
+        bag.set(k, v);
+      },
+      async remove(k) {
+        bag.delete(k);
+      },
+    },
     getAssetUrl: (p) => `/${p}`,
   };
 }

--- a/src/mobile/__tests__/sessionRecovery.test.ts
+++ b/src/mobile/__tests__/sessionRecovery.test.ts
@@ -2,8 +2,13 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { toast } from 'sonner';
 
 const storage = { get: vi.fn(), set: vi.fn(), remove: vi.fn() };
+// The token lives in secureStorage now (#172) — Keystore-encrypted on device,
+// never the plaintext Preferences that `storage` is. Both are stubbed so a
+// regression that reaches for the wrong one shows up as a failed assertion
+// rather than a passing test against the wrong store.
+const secureStorage = { get: vi.fn(), set: vi.fn(), remove: vi.fn() };
 vi.mock('../../platform', () => ({
-  getPlatform: vi.fn(() => ({ kind: 'capacitor', storage })),
+  getPlatform: vi.fn(() => ({ kind: 'capacitor', storage, secureStorage })),
 }));
 vi.mock('../ensureSession', () => ({ ensureSession: vi.fn() }));
 vi.mock('../inAppLoginDeps', () => ({ buildInAppLoginDeps: vi.fn(async () => ({})) }));
@@ -44,6 +49,7 @@ describe('recoverSession', () => {
     vi.mocked(getPlatform).mockReturnValue({
       kind: 'capacitor',
       storage,
+      secureStorage,
     } as unknown as ReturnType<typeof getPlatform>);
     vi.mocked(ensureSession).mockResolvedValue('TOKEN-123');
   });
@@ -55,9 +61,11 @@ describe('recoverSession', () => {
   it('clears the dead token before asking for a new one', async () => {
     await recoverSession();
 
-    expect(storage.remove).toHaveBeenCalledWith('reis.session.uisAuth');
+    expect(secureStorage.remove).toHaveBeenCalledWith('reis.session.uisAuth');
+    // And never from plaintext storage: that is where it used to live.
+    expect(storage.remove).not.toHaveBeenCalled();
 
-    const clearedAt = storage.remove.mock.invocationCallOrder[0];
+    const clearedAt = secureStorage.remove.mock.invocationCallOrder[0];
     const askedAt = vi.mocked(ensureSession).mock.invocationCallOrder[0];
     expect(clearedAt).toBeDefined();
     expect(askedAt).toBeDefined();
@@ -101,7 +109,7 @@ describe('recoverSession', () => {
 
     await expect(recoverSession()).resolves.toBe(false);
     expect(ensureSession).not.toHaveBeenCalled();
-    expect(storage.remove).not.toHaveBeenCalled();
+    expect(secureStorage.remove).not.toHaveBeenCalled();
   });
 });
 
@@ -111,6 +119,7 @@ describe('promptSessionRecovery', () => {
     vi.mocked(getPlatform).mockReturnValue({
       kind: 'capacitor',
       storage,
+      secureStorage,
     } as unknown as ReturnType<typeof getPlatform>);
   });
 
@@ -167,6 +176,7 @@ describe('re-sync after recovery', () => {
     vi.mocked(getPlatform).mockReturnValue({
       kind: 'capacitor',
       storage,
+      secureStorage,
     } as unknown as ReturnType<typeof getPlatform>);
     vi.mocked(ensureSession).mockResolvedValue('TOKEN-123');
   });
@@ -213,6 +223,7 @@ describe('stale prompts cannot destroy a fresh session', () => {
     vi.mocked(getPlatform).mockReturnValue({
       kind: 'capacitor',
       storage,
+      secureStorage,
     } as unknown as ReturnType<typeof getPlatform>);
     vi.mocked(ensureSession).mockResolvedValue('NEW-TOKEN');
   });

--- a/src/mobile/inAppLoginDeps.ts
+++ b/src/mobile/inAppLoginDeps.ts
@@ -1,5 +1,4 @@
-import { getPlatform } from '../platform';
-import { TOKEN_KEY } from '../platform/tokenStore';
+import { loadStoredToken, saveStoredToken } from '../platform/tokenStore';
 import type { SessionDeps } from './ensureSession';
 
 export const IS_LOGIN_URL = 'https://is.mendelu.cz/system/login.pl?lang=cz';
@@ -19,11 +18,14 @@ export const IS_COOKIE_URL = 'https://is.mendelu.cz/';
  */
 export async function buildInAppLoginDeps(): Promise<SessionDeps> {
   const { InAppBrowser } = await import('@capgo/capacitor-inappbrowser');
-  const storage = getPlatform().storage;
-
   return {
-    getStored: () => storage.get(TOKEN_KEY),
-    save: (token) => storage.set(TOKEN_KEY, token),
+    // Through tokenStore, never platform.storage: the login flow is what WRITES
+    // the credential, so a raw storage.set here would put a live UISAuth into
+    // plaintext Preferences no matter how the read side is secured.
+    // loadStoredToken throws on a missing/unreadable token; ensureSession wants
+    // "is there one?", so the throw becomes undefined and it presents login.
+    getStored: () => loadStoredToken().catch(() => undefined),
+    save: (token) => saveStoredToken(token),
     openLogin: async () => {
       await InAppBrowser.openWebView({
         url: IS_LOGIN_URL,

--- a/src/mobile/sessionRecovery.ts
+++ b/src/mobile/sessionRecovery.ts
@@ -1,6 +1,6 @@
 import { toast } from 'sonner';
 import { getPlatform } from '../platform';
-import { TOKEN_KEY } from '../platform/tokenStore';
+import { clearStoredToken } from '../platform/tokenStore';
 import { logError } from '../utils/reportError';
 import { translate } from '../i18n/translate';
 import { useAppStore } from '../store/useAppStore';
@@ -40,7 +40,7 @@ async function runRecovery(): Promise<string> {
   // ensureSession returns the stored token when it still looks plausible, and
   // a lapsed UISAuth looks exactly like a live one. Clearing first is what
   // makes this a re-login rather than a no-op that returns the dead token.
-  await getPlatform().storage.remove(TOKEN_KEY);
+  await clearStoredToken();
   const token = await ensureSession(await buildInAppLoginDeps());
 
   activeToken = token;

--- a/src/platform/__tests__/index.test.ts
+++ b/src/platform/__tests__/index.test.ts
@@ -17,6 +17,19 @@ function stub(kind: ReisPlatform['kind']): ReisPlatform {
         bag.delete(k);
       },
     },
+    // Credentials share the same bag here: this stub exists to exercise the
+    // platform resolver, not the storage guarantee, which tokenStore.test.ts owns.
+    secureStorage: {
+      async get(k) {
+        return bag.get(k);
+      },
+      async set(k, v) {
+        bag.set(k, v);
+      },
+      async remove(k) {
+        bag.delete(k);
+      },
+    },
     getAssetUrl: (p) => `/${p}`,
   };
 }

--- a/src/platform/__tests__/tokenStore.test.ts
+++ b/src/platform/__tests__/tokenStore.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { setPlatform, __resetPlatformForTests } from '../index';
+import {
+  TOKEN_KEY,
+  saveStoredToken,
+  loadStoredToken,
+  clearStoredToken,
+  purgePlaintextToken,
+} from '../tokenStore';
+import type { ReisPlatform } from '../types';
+
+/** A live-looking UISAuth value; isPlausibleToken rejects short/empty strings. */
+const TOKEN = 'a'.repeat(40);
+
+function makeBag() {
+  const map = new Map<string, unknown>();
+  return {
+    map,
+    api: {
+      get: vi.fn(async (k: string) => map.get(k)),
+      set: vi.fn(async (k: string, v: unknown) => void map.set(k, v)),
+      remove: vi.fn(async (k: string) => void map.delete(k)),
+    },
+  };
+}
+
+let plain: ReturnType<typeof makeBag>;
+let secure: ReturnType<typeof makeBag>;
+
+beforeEach(() => {
+  __resetPlatformForTests();
+  plain = makeBag();
+  secure = makeBag();
+  setPlatform({
+    kind: 'capacitor',
+    storage: plain.api,
+    secureStorage: secure.api,
+    getAssetUrl: (p: string) => p,
+  } as unknown as ReisPlatform);
+});
+
+describe('tokenStore', () => {
+  /**
+   * The whole point of #172: UISAuth is a live credential that authenticates as
+   * the student and never rotates, so it must not touch the ordinary key-value
+   * store — that is SharedPreferences/UserDefaults, which is plaintext.
+   */
+  it('writes the token to secure storage and never to plain storage', async () => {
+    await saveStoredToken(TOKEN);
+    expect(secure.map.get(TOKEN_KEY)).toBe(TOKEN);
+    expect(plain.api.set).not.toHaveBeenCalled();
+  });
+
+  it('reads the token back from secure storage', async () => {
+    await saveStoredToken(TOKEN);
+    expect(await loadStoredToken()).toBe(TOKEN);
+    expect(plain.api.get).not.toHaveBeenCalled();
+  });
+
+  it('clears the token from secure storage', async () => {
+    await saveStoredToken(TOKEN);
+    await clearStoredToken();
+    expect(secure.map.has(TOKEN_KEY)).toBe(false);
+  });
+
+  /**
+   * Throwing with sessionExpired rather than returning null makes a missing
+   * token indistinguishable from a lapsed one at every call site — both mean
+   * "send the student to login", and a nullable return invites a silent
+   * unauthenticated request.
+   */
+  it('throws sessionExpired when nothing is stored', async () => {
+    await expect(loadStoredToken()).rejects.toMatchObject({ sessionExpired: true });
+  });
+
+  it('throws sessionExpired for a value too short to be a real token', async () => {
+    await secure.api.set(TOKEN_KEY, 'x');
+    await expect(loadStoredToken()).rejects.toMatchObject({ sessionExpired: true });
+  });
+
+  /**
+   * A decrypt failure — key invalidated by a credential change or a restore
+   * onto new hardware — must read as "no token", not as a crash and NOT as a
+   * reason to fall back to plaintext.
+   */
+  it('treats an unreadable secure store as a lapsed session', async () => {
+    secure.api.get.mockRejectedValueOnce(new Error('KeyPermanentlyInvalidatedException'));
+    await expect(loadStoredToken()).rejects.toMatchObject({ sessionExpired: true });
+  });
+});
+
+describe('purgePlaintextToken', () => {
+  /**
+   * Upgrading installs still hold the token in plain Preferences. It is deleted
+   * rather than migrated: deletion is the outcome that matters, and copying it
+   * across first is a step that can half-succeed and leave the plaintext behind
+   * — the exact thing this work exists to remove.
+   */
+  it('removes the legacy plaintext copy', async () => {
+    await plain.api.set(TOKEN_KEY, TOKEN);
+    await purgePlaintextToken();
+    expect(plain.map.has(TOKEN_KEY)).toBe(false);
+  });
+
+  it('does not touch a token already in secure storage', async () => {
+    await saveStoredToken(TOKEN);
+    await purgePlaintextToken();
+    expect(await loadStoredToken()).toBe(TOKEN);
+  });
+
+  it('is safe to run when there is nothing to purge', async () => {
+    await expect(purgePlaintextToken()).resolves.toBeUndefined();
+  });
+
+  /**
+   * Boot must not be blocked by a storage error on a cleanup step — the app is
+   * still usable, and the next launch tries again.
+   */
+  it('swallows a storage failure rather than blocking boot', async () => {
+    plain.api.remove.mockRejectedValueOnce(new Error('nope'));
+    await expect(purgePlaintextToken()).resolves.toBeUndefined();
+  });
+});

--- a/src/platform/__tests__/tokenStore.test.ts
+++ b/src/platform/__tests__/tokenStore.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { setPlatform, __resetPlatformForTests } from '../index';
 import {
-  TOKEN_KEY,
   saveStoredToken,
   loadStoredToken,
   clearStoredToken,
@@ -11,6 +10,13 @@ import type { ReisPlatform } from '../types';
 
 /** A live-looking UISAuth value; isPlausibleToken rejects short/empty strings. */
 const TOKEN = 'a'.repeat(40);
+
+/**
+ * Duplicated rather than imported: the key is private to tokenStore so nothing
+ * can reach plain storage under it. Spelling it out here also makes a rename
+ * fail the suite, which is right — the on-disk key is migration-relevant.
+ */
+const TOKEN_KEY = 'reis.session.uisAuth';
 
 function makeBag() {
   const map = new Map<string, unknown>();

--- a/src/platform/capacitorPlatform.ts
+++ b/src/platform/capacitorPlatform.ts
@@ -1,5 +1,6 @@
 import { Preferences } from '@capacitor/preferences';
 import type { ReisPlatform } from './types';
+import { capacitorSecureStorage } from './secureStore';
 
 /**
  * Capacitor host. Preferences is UserDefaults / SharedPreferences — fine for
@@ -29,6 +30,8 @@ export function createCapacitorPlatform(): ReisPlatform {
         await Preferences.remove({ key });
       },
     },
+    // Credentials go to the Keystore-backed native plugin, never to Preferences.
+    secureStorage: capacitorSecureStorage,
     // Capacitor serves bundled assets from the WebView root.
     getAssetUrl: (path) => '/' + path.replace(/^\//, ''),
   };

--- a/src/platform/extensionPlatform.ts
+++ b/src/platform/extensionPlatform.ts
@@ -25,6 +25,20 @@ export function createExtensionPlatform(): ReisPlatform {
         await ChromeAsyncStorage.remove(key);
       },
     },
+    // The extension has no Keystore, and its threat model is the browser
+    // profile rather than a lost handset — chrome.storage.local is what it has
+    // always used and this change does not alter extension behaviour.
+    secureStorage: {
+      async get(key) {
+        return (await ChromeAsyncStorage.get(key)) ?? undefined;
+      },
+      async set(key, value) {
+        await ChromeAsyncStorage.set(key, value);
+      },
+      async remove(key) {
+        await ChromeAsyncStorage.remove(key);
+      },
+    },
     getAssetUrl: (path) => chrome.runtime.getURL(path),
   };
 }

--- a/src/platform/secureStore.ts
+++ b/src/platform/secureStore.ts
@@ -1,0 +1,42 @@
+import { registerPlugin } from '@capacitor/core';
+import type { PlatformStorage } from './types';
+
+interface SecureStoreNativePlugin {
+  set(o: { key: string; value: string }): Promise<void>;
+  get(o: { key: string }): Promise<{ value: string | null }>;
+  remove(o: { key: string }): Promise<void>;
+}
+
+/**
+ * Android-only native plugin. Values are encrypted with an AES-256-GCM key that
+ * lives in the Android Keystore and never enters the JS heap or the filesystem;
+ * only ciphertext is persisted.
+ *
+ * iOS is NOT implemented — the app has never been built for iOS (#174), and the
+ * Keychain half lands there, where it can actually be compiled and run. Calling
+ * this on iOS rejects from the bridge (no such plugin method), which is the
+ * intended outcome: a missing implementation must surface as a failure, never
+ * as a quiet fallback that writes a live credential to plaintext.
+ */
+const SecureStore = registerPlugin<SecureStoreNativePlugin>('SecureStore');
+
+/**
+ * Strings only. The native side stores bytes, and JSON-encoding here would let
+ * a caller believe arbitrary objects are supported — this exists for one short
+ * credential, and a wider contract invites storing more than belongs in it.
+ */
+export const capacitorSecureStorage: PlatformStorage = {
+  async get(key) {
+    const { value } = await SecureStore.get({ key });
+    return value ?? undefined;
+  },
+  async set(key, value) {
+    if (typeof value !== 'string') {
+      throw new Error('secureStorage holds strings only');
+    }
+    await SecureStore.set({ key, value });
+  },
+  async remove(key) {
+    await SecureStore.remove({ key });
+  },
+};

--- a/src/platform/tokenStore.ts
+++ b/src/platform/tokenStore.ts
@@ -4,26 +4,66 @@ import { isPlausibleToken } from './sessionToken';
 export const TOKEN_KEY = 'reis.session.uisAuth';
 
 /**
- * NOTE: on Capacitor this is Preferences (UserDefaults / SharedPreferences),
- * NOT Keychain or Keystore, and UISAuth is a live credential. Acceptable for a
- * debug build; moving to real secure storage is a tracked follow-up that must
- * land before any public release.
+ * The ONLY module that touches the IS session token.
+ *
+ * UISAuth authenticates as the student on its own, never rotates, and IS allows
+ * concurrent sessions — so anything that can read it can act as that student.
+ * It goes to `platform.secureStorage` (Keystore-encrypted on Capacitor), never
+ * to `platform.storage`, which is SharedPreferences/UserDefaults in the clear.
+ *
+ * Call sites used to reach `storage.get/set(TOKEN_KEY)` directly — the login
+ * flow wrote the token that way while this module was left unused. Keeping the
+ * key private to this file is what stops that from coming back.
  */
 export async function saveStoredToken(token: string): Promise<void> {
-  await getPlatform().storage.set(TOKEN_KEY, token);
+  await getPlatform().secureStorage.set(TOKEN_KEY, token);
 }
 
 /**
  * Throws with `sessionExpired` rather than returning null so callers treat a
  * missing token exactly like a lapsed one — both mean "send the student to
  * login", and a nullable return invites a silent unauthenticated request.
+ *
+ * A secure-store READ FAILURE lands here too. The Keystore key is invalidated
+ * by a credential change or a restore onto new hardware, and decryption then
+ * throws; that is a lapsed session, not a crash — and emphatically not a reason
+ * to look in plaintext storage instead.
  */
 export async function loadStoredToken(): Promise<string> {
-  const value = await getPlatform().storage.get(TOKEN_KEY);
+  let value: unknown;
+  try {
+    value = await getPlatform().secureStorage.get(TOKEN_KEY);
+  } catch {
+    value = undefined;
+  }
   if (!isPlausibleToken(value)) {
     const err = new Error('No stored IS session') as Error & { sessionExpired?: boolean };
     err.sessionExpired = true;
     throw err;
   }
   return value;
+}
+
+export async function clearStoredToken(): Promise<void> {
+  await getPlatform().secureStorage.remove(TOKEN_KEY);
+}
+
+/**
+ * One-shot cleanup for installs upgrading from before the token was encrypted,
+ * where it still sits in plain Preferences.
+ *
+ * Deleted, not migrated. Deletion is the outcome that matters, and copying it
+ * across first is a step that can half-succeed and leave the plaintext behind —
+ * the exact thing this exists to remove. The cost is one sign-in, and the
+ * re-login flow already handles a lapsed session.
+ *
+ * Failures are swallowed: this runs during boot, and a storage error on a
+ * cleanup step must not stop the app from starting. The next launch retries.
+ */
+export async function purgePlaintextToken(): Promise<void> {
+  try {
+    await getPlatform().storage.remove(TOKEN_KEY);
+  } catch {
+    // Intentionally ignored — see above.
+  }
 }

--- a/src/platform/tokenStore.ts
+++ b/src/platform/tokenStore.ts
@@ -1,7 +1,7 @@
 import { getPlatform } from './index';
 import { isPlausibleToken } from './sessionToken';
 
-export const TOKEN_KEY = 'reis.session.uisAuth';
+const TOKEN_KEY = 'reis.session.uisAuth';
 
 /**
  * The ONLY module that touches the IS session token.

--- a/src/platform/types.ts
+++ b/src/platform/types.ts
@@ -14,6 +14,20 @@ export interface ReisPlatform {
   kind: 'extension' | 'capacitor' | 'web';
   /** Settings that survive restarts. Extension: chrome.storage.local. */
   storage: PlatformStorage;
+  /**
+   * Credentials, kept apart from `storage` because the guarantee differs by
+   * host and `storage` cannot offer this one: on Capacitor it is Preferences,
+   * i.e. SharedPreferences/UserDefaults in the clear. Here the Capacitor host
+   * encrypts under a key held in the Android Keystore.
+   *
+   * The extension deliberately reuses chrome.storage.local: it has no Keystore,
+   * and its threat model is the browser profile rather than a lost handset.
+   * The dev webapp is in-memory, like the rest of its storage.
+   *
+   * Only `tokenStore` should touch this. It exists for UISAuth, which
+   * authenticates as the student on its own and never rotates.
+   */
+  secureStorage: PlatformStorage;
   /** Resolve a bundled asset to a loadable URL. */
   getAssetUrl(path: string): string;
 }

--- a/src/platform/webPlatform.ts
+++ b/src/platform/webPlatform.ts
@@ -20,6 +20,19 @@ export function createWebPlatform(): ReisPlatform {
         bag.delete(key);
       },
     },
+    // Same bag: the dev webapp has no secure store and needs none — it never
+    // holds a real IS session.
+    secureStorage: {
+      async get(key) {
+        return bag.get(key);
+      },
+      async set(key, value) {
+        bag.set(key, value);
+      },
+      async remove(key) {
+        bag.delete(key);
+      },
+    },
     getAssetUrl: (path) => '/' + path.replace(/^\//, ''),
   };
 }


### PR DESCRIPTION
Closes #172 for Android. **This is the release blocker** — everything else on the
mobile list was "incomplete"; this one was "unsafe".

## The problem, measured rather than asserted

`UISAuth` authenticates as the student on its own, never rotates, and IS allows
concurrent sessions. It lived in `@capacitor/preferences` — SharedPreferences,
in the clear. On the handset, before this change:

```
adb shell run-as cz.reis.app cat shared_prefs/CapacitorStorage.xml
→ token present in plaintext: True | chars: 56
```

Anything with that access could act as that student.

## What was actually broken beyond the storage choice

**Three call sites reached `storage.get/set/remove(TOKEN_KEY)` directly, and
`saveStoredToken` had no callers at all.** The login flow wrote the credential
straight to plaintext while the module meant to own it sat unused. Swapping only
`tokenStore`'s internals would have left login writing plaintext and reads coming
from the Keystore — a broken session, not merely a leftover copy. `TOKEN_KEY` is
now private to `tokenStore`.

## The change

`SecureStorePlugin` encrypts with AES-256-GCM under a key generated **inside** the
Android Keystore: hardware-backed where a TEE/StrongBox exists, unexportable, never
in the JS heap. Only ciphertext is persisted.

Hand-written rather than taken as a dependency for two reasons — it sits directly
on the credential path, and the obvious library for it,
`androidx.security:security-crypto` (`EncryptedSharedPreferences`), **was deprecated
in April 2025**.

`secureStorage` joins `ReisPlatform` rather than hiding inside `tokenStore`: the
guarantee genuinely differs per host, which is what that seam is for. **Required,
not optional** — an optional field would let a host silently lack it and fall back
to plaintext, the exact failure this prevents.

`setUserAuthenticationRequired` is deliberately not set: the token is read at cold
start to restore the session, and demanding an unlock there would break launch-time
sync for a credential the OS already protects at rest.

## Verified end-to-end on the handset

| Check | Result |
|---|---|
| Plaintext store before | token present, 56 chars |
| Plaintext store after boot purge | `<map />` — empty |
| Plaintext store after login | still `<map />` |
| Secure store written | `reis_secure_store.xml`, key present |
| Blob size | **74 bytes = 46 plaintext + 12 IV + 16 GCM tag**, exact |
| Shannon entropy | 5.93 bits/byte (max ≈6.21 for a 74-byte sample) |
| Longest printable run | none ≥ 8 chars — a stored token would be fully printable |
| Decrypt round-trip | plugin returns the 46-char value |
| Cold restart | session restored, **no login prompt**, calendar renders |

The 74-byte figure is the assertion that matters: it is exactly IV + ciphertext +
tag for the plaintext length the plugin reports, so the file cannot be holding the
token in any encoded-but-unencrypted form.

## Migration

Upgrading installs are purged at boot, before `ensureSession`, so the student signs
in once and the plaintext copy goes **by deletion** rather than by trusting a copy
step that can half-succeed. A decrypt failure — key invalidated by a credential
change or a restore onto new hardware — reads as a lapsed session: never a crash,
and never grounds to look in plaintext instead.

## Deliberately out of scope

- **iOS.** The app has never been built for iOS (#174), so the Keychain half lands
  there, where it can be compiled and run. Calling the plugin on iOS rejects from
  the bridge — a missing implementation must fail loudly, not quietly store a
  credential in the clear.
- **The extension is unchanged.** It has no Keystore and its threat model is the
  browser profile; it keeps `chrome.storage.local` exactly as before.
- **Google OAuth tokens** (`reis_google_tokens` in `googleAuth.ts`) are a separate
  credential still in plain storage. Filed separately rather than smuggled in here.

Full suite green (2023 tests), including 10 new `tokenStore` tests. Changed-files
eslint, prettier, `tsc -b` and the nuia gate pass.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)