### PR TITLE
Mobile: the IS session token reaches the iOS Keychain

### DIFF
--- a/docs/superpowers/plans/2026-08-02-capacitor-remaining-work.md
+++ b/docs/superpowers/plans/2026-08-02-capacitor-remaining-work.md
@@ -659,7 +659,12 @@ dependency resolution before any Swift compiles.
   GETs and 2 POSTs with no unauthenticated response. Still worth a second run to be sure.
 - **File delivery** — iOS has no Downloads folder, so `deliverFile` deliberately uses the share
   sheet there (`src/mobile/deliverFile.ts`). Verify that is the right feel.
-- Cold-start session restore with a genuine token.
+- ~~Cold-start session restore with a genuine token.~~ **Done** — a launch after app kill and
+  after a reinstall presented no login and served the token from the Keychain on all 121
+  requests. What is untested is the *unlucky* cold start: a read before the device's first
+  unlock returns `errSecInteractionNotAllowed`, which now resolves as "no session" without
+  deleting the item, so the following launch should recover. That recovery path is reasoned,
+  not observed.
 - The **app icon is still the default Capacitor placeholder**; Android got the real logo in #190.
 - No iOS analogue of `mobile/backButton.ts`'s sheet-unwind chain; the edge-swipe is all there is.
 - eduroam on iOS (`NEHotspotConfiguration`) needs a paid Apple account and a real device.

--- a/docs/superpowers/plans/2026-08-02-capacitor-remaining-work.md
+++ b/docs/superpowers/plans/2026-08-02-capacitor-remaining-work.md
@@ -73,8 +73,8 @@ on the extension is the check that would actually confirm it.
 | Search, cvicne testy, odevzdávárny, kontrola | **Done** — search device-verified (people + subjects, person card fills) |
 | External links → in-app browser (Task 8) | **Done** — ⚠️ still **unverified on a device**, one of two owed checks |
 | Re-login after a lapsed session | **Done**, prompt-first — device-verified via the #172 purge, which forced a real re-login |
-| Secure storage for `UISAuth` (Task 6) | **Done for Android** (#195), device-verified — iOS half owed |
-| iOS app | **Never built** — only the spike ran there. **Now the top remaining item** |
+| Secure storage for `UISAuth` (Task 6) | **Done on BOTH platforms** — Android Keystore (#195), iOS Keychain, each verified |
+| iOS app | **Builds and runs** (simulator, 2026-08-08). Logged in, 121 IS requests, no login redirects |
 | Native Wi-Fi (eduroam, Android) | **Done**, device-verified — Task 5 |
 | ISKAM, Drive | **Broken** — see below |
 
@@ -90,12 +90,13 @@ gesture can pass every test and still be dead on a device.
 
 *Rewritten 2026-08-08. The five items that stood here are resolved except where noted.*
 
-**1. iOS has still never been compiled — this is now the top of the list (#174).**
-With #172 done for Android, iOS is the only thing between this app and a release
-candidate, and it is entirely unmeasured: the inverted cookie delivery has run only in
-the throwaway spike, `deliverFile`'s share-sheet branch has never been seen, and the
-Keychain half of secure storage is deliberately unwritten (Task 6). Everything about it
-is assumption until something compiles.
+**1. ~~iOS has still never been compiled~~ — DONE 2026-08-08 (#174).** It compiles, launches,
+signs in and syncs: **121 IS requests with zero login redirects and zero telemetry**, the token
+served from the Keychain on every one of them. The inverted cookie delivery is therefore
+exercised too — iOS's explicit `Cookie` header carried all of it. What remains on iOS is
+narrower than "unmeasured": the share-sheet download branch, a clean-install login (proven once,
+not repeatedly), the default app icon, and no analogue of the Android back-button chain. Full
+detail and the plugin-packaging rule in Task 7.
 
 **2. Two device checks, neither needing new code.** External links must open **in-app and
 authenticated**, not in Chrome. And the map sheet's drag-vs-scroll hand-off is unverified
@@ -602,24 +603,66 @@ decrypt round-trips; cold restart restores the session with no login prompt.
 credential change or a restore onto new hardware — reads as a lapsed session: never a
 crash, never grounds to look in plaintext.
 
-**Still owed: the iOS half.** Keychain via the Security framework, landing with Task 7
-where it can actually be compiled. Calling the plugin on iOS today rejects from the bridge,
-which is the intended behaviour — a missing implementation must fail loudly rather than
-quietly store a credential in the clear.
+✅ **The iOS half is written and verified** — `native/capacitor-secure-store`, Keychain via the
+Security framework. Round-trip proved on a simulator:
+`before=undefined after=probe-value-4711 afterRemove=undefined`.
 
-## Task 7 — Build and verify on iOS ← **the top remaining item**
+`kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`, chosen deliberately: **AfterFirstUnlock**
+because the token is read at cold start and by background sync, and WhenUnlocked would fail
+those reads on a locked device and prompt a needless sign-in; **ThisDeviceOnly** so the item
+never travels in a backup, matching Android's non-exportable Keystore key. No biometric gate,
+for the same reason Android does not set `setUserAuthenticationRequired`. Where Android had to
+hand-roll AES-256-GCM, iOS writes no cipher code at all — the Keychain *is* the primitive.
 
-The app has never been built for iOS; only the spike ran there. With Task 6 closed for
-Android, this is the last thing between the app and a release candidate — and it is
-entirely unmeasured. Everything platform-specific should be re-checked, in particular:
+## Task 7 — Build and verify on iOS — FIRST BUILD DONE 2026-08-08
 
-- The **inverted cookie delivery** (iOS needs the explicit header, Android the native jar).
-- **File delivery** — iOS has no Downloads folder, so `deliverFile` deliberately uses the
-  share sheet there (`src/mobile/deliverFile.ts`). Verify that is the right feel.
-- Cold-start session restore.
-- **The Keychain half of Task 6** — `SecureStorePlugin` is Android-only by design, and the
-  bridge rejects on iOS rather than falling back to plaintext. Until this is written, an
-  iOS build cannot store a session at all, which is the intended failure.
+**The iOS app has now been built and launched** (simulator, iPhone 17 / iOS 26.5, Xcode 26.6;
+SPM, no CocoaPods). It boots to its own UI: safe-area header clear of the notch, bottom nav,
+Czech copy.
+
+**Capacitor 8 will not let an app-local iOS plugin talk to JS. This cost four build cycles.**
+Full evidence trail in `native/capacitor-secure-store/README.md`; short version:
+
+1. A Swift file in the app target with `@objc(...)` + `CAPBridgedPlugin` compiles, its symbols
+   land in the binary, and every call still rejects with `"SecureStore" plugin is not
+   implemented on ios`. There is no ObjC-runtime scan any more.
+2. `bridge?.registerPluginType(...)` from `capacitorDidLoad()` does **not** fix it. It fills the
+   *native* registry but emits no JSExport user script (measured: `WKUserContentController`
+   script count 13 → 13, none mentioning SecureStore). JS resolves plugins against
+   `window.Capacitor.PluginHeaders` and throws **without ever calling native**.
+3. What actually registers a plugin is `packageClassList` in `ios/App/App/capacitor.config.json`
+   — which is gitignored AND rewritten by `cap sync`, from installed plugin *packages* only
+   (`getPluginFiles` + `findPluginClasses`, `@capacitor/cli/dist/util/iosplugin.js`).
+4. So the plugin is a **local package** — `native/capacitor-secure-store`, a `file:` dependency.
+   `cap sync` generates the `packageClassList` entry and the `CapApp-SPM` dependency itself, and
+   the Xcode project needs **no** modification at all.
+
+`Downloads` and `Eduroam` are app-local Java today. Fine on Android, where
+`MainActivity.registerPlugin` runs before bridge init — but their iOS halves must start life as
+packages, never as files in the app target.
+
+⚠️ **`Package.swift` has the same symlink trap as `capacitor.settings.gradle`.** With a
+symlinked `node_modules`, `cap sync ios` rewrote every path to the resolved target
+(`../../../../eduroam-android-native/node_modules/...`) — builds locally, breaks every other
+checkout. A real `npm install` in the worktree fixes it; check `git diff` on that file anyway.
+
+⚠️ The plugin's SPM package **and** product name must match the CLI's derivation from the npm
+name (`@reis/capacitor-secure-store` → `ReisCapacitorSecureStore`). A mismatch fails at
+dependency resolution before any Swift compiles.
+
+### Still owed on iOS
+
+- A login was completed in the simulator and the session works (121 IS requests, no login
+  redirects), but it has **not** been repeated from a clean install, so the capture-at-login step
+  is proven once rather than reliably.
+- The **inverted cookie delivery** is now exercised — iOS's explicit `Cookie` header carried 119
+  GETs and 2 POSTs with no unauthenticated response. Still worth a second run to be sure.
+- **File delivery** — iOS has no Downloads folder, so `deliverFile` deliberately uses the share
+  sheet there (`src/mobile/deliverFile.ts`). Verify that is the right feel.
+- Cold-start session restore with a genuine token.
+- The **app icon is still the default Capacitor placeholder**; Android got the real logo in #190.
+- No iOS analogue of `mobile/backButton.ts`'s sheet-unwind chain; the edge-swipe is all there is.
+- eduroam on iOS (`NEHotspotConfiguration`) needs a paid Apple account and a real device.
 
 ## Task 8 — Smaller, known items (two of four done)
 

--- a/ios/.gitignore
+++ b/ios/.gitignore
@@ -11,3 +11,9 @@ capacitor-cordova-ios-plugins
 # Generated Config files
 App/App/capacitor.config.json
 App/App/config.xml
+
+# Xcode's SPM resolution. Not tracked on purpose: `cap sync` rewrites
+# CapApp-SPM/Package.swift on every plugin change, so a committed Package.resolved
+# would be perpetually stale — and the Capacitor version is already pinned `exact:`
+# in that file.
+App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm

--- a/ios/App/CapApp-SPM/Package.swift
+++ b/ios/App/CapApp-SPM/Package.swift
@@ -12,6 +12,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", exact: "8.5.0"),
+        .package(name: "ReisCapacitorSecureStore", path: "../../../native/capacitor-secure-store"),
         .package(name: "CapacitorApp", path: "../../../node_modules/@capacitor/app"),
         .package(name: "CapacitorFilesystem", path: "../../../node_modules/@capacitor/filesystem"),
         .package(name: "CapacitorPreferences", path: "../../../node_modules/@capacitor/preferences"),
@@ -25,6 +26,7 @@ let package = Package(
             dependencies: [
                 .product(name: "Capacitor", package: "capacitor-swift-pm"),
                 .product(name: "Cordova", package: "capacitor-swift-pm"),
+                .product(name: "ReisCapacitorSecureStore", package: "ReisCapacitorSecureStore"),
                 .product(name: "CapacitorApp", package: "CapacitorApp"),
                 .product(name: "CapacitorFilesystem", package: "CapacitorFilesystem"),
                 .product(name: "CapacitorPreferences", package: "CapacitorPreferences"),

--- a/ios/App/CapApp-SPM/Package.swift
+++ b/ios/App/CapApp-SPM/Package.swift
@@ -12,13 +12,13 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", exact: "8.5.0"),
-        .package(name: "ReisCapacitorSecureStore", path: "../../../native/capacitor-secure-store"),
         .package(name: "CapacitorApp", path: "../../../node_modules/@capacitor/app"),
         .package(name: "CapacitorFilesystem", path: "../../../node_modules/@capacitor/filesystem"),
         .package(name: "CapacitorPreferences", path: "../../../node_modules/@capacitor/preferences"),
         .package(name: "CapacitorShare", path: "../../../node_modules/@capacitor/share"),
         .package(name: "CapacitorSplashScreen", path: "../../../node_modules/@capacitor/splash-screen"),
-        .package(name: "CapgoCapacitorInappbrowser", path: "../../../node_modules/@capgo/capacitor-inappbrowser")
+        .package(name: "CapgoCapacitorInappbrowser", path: "../../../node_modules/@capgo/capacitor-inappbrowser"),
+        .package(name: "ReisCapacitorSecureStore", path: "../../../native/capacitor-secure-store")
     ],
     targets: [
         .target(
@@ -26,13 +26,13 @@ let package = Package(
             dependencies: [
                 .product(name: "Capacitor", package: "capacitor-swift-pm"),
                 .product(name: "Cordova", package: "capacitor-swift-pm"),
-                .product(name: "ReisCapacitorSecureStore", package: "ReisCapacitorSecureStore"),
                 .product(name: "CapacitorApp", package: "CapacitorApp"),
                 .product(name: "CapacitorFilesystem", package: "CapacitorFilesystem"),
                 .product(name: "CapacitorPreferences", package: "CapacitorPreferences"),
                 .product(name: "CapacitorShare", package: "CapacitorShare"),
                 .product(name: "CapacitorSplashScreen", package: "CapacitorSplashScreen"),
-                .product(name: "CapgoCapacitorInappbrowser", package: "CapgoCapacitorInappbrowser")
+                .product(name: "CapgoCapacitorInappbrowser", package: "CapgoCapacitorInappbrowser"),
+                .product(name: "ReisCapacitorSecureStore", package: "ReisCapacitorSecureStore")
             ]
         )
     ]

--- a/native/capacitor-secure-store/Package.swift
+++ b/native/capacitor-secure-store/Package.swift
@@ -1,0 +1,35 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+// Shape copied from @capacitor/preferences, which is the closest sibling: a
+// single plugin target under ios/Sources/<TargetName>. `cap sync` reads the
+// package.json next to this file, scans that directory for `@objc(...)`, and
+// generates BOTH the CapApp-SPM dependency and the packageClassList entry — the
+// registration that an app-local Swift file can never get.
+// The package and product name are NOT free choices: `cap sync` derives them from
+// the npm package name (`@reis/capacitor-secure-store` → `ReisCapacitorSecureStore`)
+// and writes that into the generated CapApp-SPM/Package.swift. A mismatch fails at
+// dependency resolution, before any Swift compiles:
+//   product 'ReisCapacitorSecureStore' ... not found in package 'ReisCapacitorSecureStore'
+// Rename the npm package and this must follow.
+let package = Package(
+    name: "ReisCapacitorSecureStore",
+    platforms: [.iOS(.v15)],
+    products: [
+        .library(
+            name: "ReisCapacitorSecureStore",
+            targets: ["SecureStorePlugin"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "8.0.0")
+    ],
+    targets: [
+        .target(
+            name: "SecureStorePlugin",
+            dependencies: [
+                .product(name: "Capacitor", package: "capacitor-swift-pm"),
+                .product(name: "Cordova", package: "capacitor-swift-pm"),
+            ],
+            path: "ios/Sources/SecureStorePlugin")
+    ]
+)

--- a/native/capacitor-secure-store/README.md
+++ b/native/capacitor-secure-store/README.md
@@ -1,0 +1,58 @@
+# @reis/capacitor-secure-store
+
+iOS Keychain storage for the IS session token. Consumed by `src/platform/secureStore.ts`
+via `registerPlugin('SecureStore')`; the Android half of the same JS contract is
+`android/app/src/main/java/cz/reis/app/SecureStorePlugin.java`.
+
+Local package, never published — `package.json` has `"private": true` and the app depends on
+it as `file:native/capacitor-secure-store`.
+
+## Why this is a package and not a file in the app target
+
+**Because on iOS an app-local Capacitor plugin cannot be reached from JS at all.** This was
+established by measurement, not doctrine, and each step below was verified on a simulator:
+
+1. Writing `ios/App/App/SecureStorePlugin.swift` with `@objc(SecureStorePlugin)` and
+   `CAPBridgedPlugin` compiles, and the symbols land in the binary — but every call rejects
+   with `"SecureStore" plugin is not implemented on ios`. Capacitor 8 does **not** scan the
+   ObjC runtime for plugin classes.
+2. `bridge?.registerPluginType(...)` from `capacitorDidLoad()` in a `CAPBridgeViewController`
+   subclass does not fix it. It populates the *native* registry but emits no JSExport user
+   script: the `WKUserContentController` script count was unchanged (13 → 13) and no script
+   mentioned `SecureStore`. The JS side resolves plugins against `window.Capacitor.PluginHeaders`
+   (see `registerPlugin` in `@capacitor/core`) and throws **without ever calling native** when
+   the name is absent, so a perfectly working plugin looks unimplemented.
+3. What actually registers a plugin is `packageClassList` in `ios/App/App/capacitor.config.json`.
+   Adding `SecureStorePlugin` there made the round-trip work first try (script count 13 → 14,
+   `secureStoreInScripts=YES`).
+4. That file is **gitignored and rewritten by `cap sync`**, and the CLI builds the list *only*
+   from installed plugin packages — `getPluginFiles` walks each dependency's `capacitor.ios.src`
+   directory and `findPluginClasses` regexes `@objc\(([A-Za-z0-9_-]+)\)` out of the Swift it
+   finds there (`node_modules/@capacitor/cli/dist/util/iosplugin.js`). An app-target file is
+   never scanned, so a hand-patched entry survives exactly until the next sync.
+
+Hence: a package. `cap sync` then generates both the `CapApp-SPM/Package.swift` dependency and
+the `packageClassList` entry, and a fresh clone works with no manual step.
+
+**Two consequences worth carrying forward:**
+
+- The `Downloads` and `Eduroam` plugins are app-local Java today. That is fine on Android —
+  `MainActivity.registerPlugin()` runs before the bridge initialises — but their iOS halves
+  will need this same packaging. Do not start them as files in the app target.
+- The failure mode is an unbreakable **login loop**, not an error: `saveStoredToken` rejects,
+  no token persists, and `loadStoredToken` throws `sessionExpired` on the next launch. If iOS
+  ever starts asking for a sign-in every cold start, check plugin registration before
+  suspecting the login code.
+
+## Layout
+
+Copied from `@capacitor/preferences`, the closest sibling:
+
+```
+package.json                                  capacitor.ios.src = "ios"
+Package.swift                                 target SecureStorePlugin
+ios/Sources/SecureStorePlugin/SecureStorePlugin.swift
+```
+
+There is no `dist/` and no JS entry point on purpose — the JS side lives in the app
+(`src/platform/secureStore.ts`), so this package carries native code only.

--- a/native/capacitor-secure-store/README.md
+++ b/native/capacitor-secure-store/README.md
@@ -48,7 +48,7 @@ the `packageClassList` entry, and a fresh clone works with no manual step.
 
 Copied from `@capacitor/preferences`, the closest sibling:
 
-```
+```text
 package.json                                  capacitor.ios.src = "ios"
 Package.swift                                 target SecureStorePlugin
 ios/Sources/SecureStorePlugin/SecureStorePlugin.swift

--- a/native/capacitor-secure-store/ios/Sources/SecureStorePlugin/SecureStorePlugin.swift
+++ b/native/capacitor-secure-store/ios/Sources/SecureStorePlugin/SecureStorePlugin.swift
@@ -1,0 +1,144 @@
+import Capacitor
+import Foundation
+import Security
+
+/**
+ * Encrypted storage for the IS session token — the iOS half of the Android
+ * Keystore plugin (`android/.../SecureStorePlugin.java`).
+ *
+ * The app persists UISAuth, which authenticates as the student on its own and
+ * never rotates. @capacitor/preferences is UserDefaults — a plist in the app
+ * container, in the clear — so anything able to read app storage could act as
+ * that student.
+ *
+ * Where Android had to hand-roll AES-256-GCM under a Keystore key, iOS already
+ * has the primitive: the Keychain encrypts at rest under a key held by the
+ * Secure Enclave / effaceable storage, outside this process. So there is no
+ * cipher code here, and that is the point — the crypto that is not written is
+ * the crypto that cannot be got wrong.
+ *
+ * `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly` is the deliberate choice:
+ *
+ * - **AfterFirstUnlock**, not WhenUnlocked, because the token is read at cold
+ *   start to restore the session and by background sync. WhenUnlocked would
+ *   fail those reads on a locked device, which the app would correctly read as
+ *   a lapsed session and prompt a needless sign-in.
+ * - **ThisDeviceOnly** so the item never travels in an encrypted backup or to a
+ *   restored device. That matches the Android side, where the Keystore key is
+ *   non-exportable and a restore onto new hardware invalidates it — and
+ *   `tokenStore.loadStoredToken` already treats that as a lapsed session.
+ *
+ * No `kSecAccessControl` / biometric gate, for the same reason Android does not
+ * set `setUserAuthenticationRequired`: demanding a device unlock on the
+ * cold-start read would break launch-time sync for a credential the OS already
+ * protects at rest.
+ */
+@objc(SecureStorePlugin)
+public class SecureStorePlugin: CAPPlugin, CAPBridgedPlugin {
+    public let identifier = "SecureStorePlugin"
+    public let jsName = "SecureStore"
+    public let pluginMethods: [CAPPluginMethod] = [
+        CAPPluginMethod(name: "set", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "get", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "remove", returnType: CAPPluginReturnPromise),
+    ]
+
+    /// Namespaced so the entry cannot collide with a Keychain item written by a
+    /// dependency; the JS-supplied key becomes the account within it.
+    private static let service = "cz.reis.app.securestore"
+
+    private func query(for key: String) -> [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: Self.service,
+            kSecAttrAccount as String: key,
+        ]
+    }
+
+    /**
+     * Delete-then-add rather than SecItemUpdate: one path instead of two, and
+     * it cannot leave a stale attribute set behind from an earlier write.
+     *
+     * A failure REJECTS. Resolving on a failed credential write is the worst
+     * outcome available here — login would report success while nothing
+     * persisted, and the student would be bounced back to the login sheet on
+     * every cold start with no indication why.
+     */
+    @objc func set(_ call: CAPPluginCall) {
+        guard let key = call.getString("key"), let value = call.getString("value") else {
+            call.reject("key and value are required")
+            return
+        }
+        guard let data = value.data(using: .utf8) else {
+            call.reject("value is not valid UTF-8")
+            return
+        }
+
+        SecItemDelete(query(for: key) as CFDictionary)
+
+        var attributes = query(for: key)
+        attributes[kSecValueData as String] = data
+        attributes[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+
+        let status = SecItemAdd(attributes as CFDictionary, nil)
+        if status == errSecSuccess {
+            call.resolve()
+        } else {
+            call.reject("secure set failed: OSStatus \(status)")
+        }
+    }
+
+    /**
+     * Resolves `{value: null}` for "not stored" AND for "stored but unreadable",
+     * matching the Android plugin.
+     *
+     * Both mean the same thing to the app: no session, present login. Rejecting
+     * would turn a recoverable lapse into a boot failure. A present-but-
+     * unreadable entry is dropped so the next write starts clean.
+     */
+    @objc func get(_ call: CAPPluginCall) {
+        guard let key = call.getString("key") else {
+            call.reject("key is required")
+            return
+        }
+
+        var lookup = query(for: key)
+        lookup[kSecReturnData as String] = true
+        lookup[kSecMatchLimit as String] = kSecMatchLimitOne
+
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(lookup as CFDictionary, &item)
+
+        if status == errSecItemNotFound {
+            call.resolve(["value": NSNull()])
+            return
+        }
+
+        guard status == errSecSuccess,
+            let data = item as? Data,
+            let value = String(data: data, encoding: .utf8)
+        else {
+            SecItemDelete(query(for: key) as CFDictionary)
+            call.resolve(["value": NSNull()])
+            return
+        }
+
+        call.resolve(["value": value])
+    }
+
+    /// `errSecItemNotFound` is success: the caller asked for the key to be gone,
+    /// and it is. `clearStoredToken` runs on paths where a missing token is the
+    /// normal case (a lapsed session that was never stored).
+    @objc func remove(_ call: CAPPluginCall) {
+        guard let key = call.getString("key") else {
+            call.reject("key is required")
+            return
+        }
+        let status = SecItemDelete(query(for: key) as CFDictionary)
+        if status == errSecSuccess || status == errSecItemNotFound {
+            call.resolve()
+        } else {
+            call.reject("secure remove failed: OSStatus \(status)")
+        }
+    }
+}

--- a/native/capacitor-secure-store/ios/Sources/SecureStorePlugin/SecureStorePlugin.swift
+++ b/native/capacitor-secure-store/ios/Sources/SecureStorePlugin/SecureStorePlugin.swift
@@ -56,8 +56,12 @@ public class SecureStorePlugin: CAPPlugin, CAPBridgedPlugin {
     }
 
     /**
-     * Delete-then-add rather than SecItemUpdate: one path instead of two, and
-     * it cannot leave a stale attribute set behind from an earlier write.
+     * Add, and fall back to an in-place update when the item already exists.
+     *
+     * **Never delete-then-add.** That reads as the simpler single path, but if
+     * the add then fails the student is left with NO token — logged out by a
+     * write whose only job was to refresh a value they already had. Updating in
+     * place keeps the previous credential intact through a failure.
      *
      * A failure REJECTS. Resolving on a failed credential write is the worst
      * outcome available here — login would report success while nothing
@@ -74,13 +78,22 @@ public class SecureStorePlugin: CAPPlugin, CAPBridgedPlugin {
             return
         }
 
-        SecItemDelete(query(for: key) as CFDictionary)
-
         var attributes = query(for: key)
         attributes[kSecValueData as String] = data
         attributes[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
 
-        let status = SecItemAdd(attributes as CFDictionary, nil)
+        var status = SecItemAdd(attributes as CFDictionary, nil)
+        if status == errSecDuplicateItem {
+            // The accessibility attribute is re-applied here too, so an item
+            // written by an older build cannot keep a weaker one forever.
+            status = SecItemUpdate(
+                query(for: key) as CFDictionary,
+                [
+                    kSecValueData as String: data,
+                    kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+                ] as CFDictionary)
+        }
+
         if status == errSecSuccess {
             call.resolve()
         } else {
@@ -90,11 +103,23 @@ public class SecureStorePlugin: CAPPlugin, CAPBridgedPlugin {
 
     /**
      * Resolves `{value: null}` for "not stored" AND for "stored but unreadable",
-     * matching the Android plugin.
+     * matching the Android plugin. Both mean the same thing to the app: no
+     * session, present login. Rejecting would turn a recoverable lapse into a
+     * boot failure.
      *
-     * Both mean the same thing to the app: no session, present login. Rejecting
-     * would turn a recoverable lapse into a boot failure. A present-but-
-     * unreadable entry is dropped so the next write starts clean.
+     * ⚠️ **A failed read must not delete the item.** Several Keychain statuses are
+     * TRANSIENT — `errSecInteractionNotAllowed` for a read before the first
+     * unlock, `errSecNotAvailable` when the service is not up yet. Deleting on
+     * those converts "try again in a moment" into "sign in again, permanently".
+     * Only a value that is present and *not decodable as UTF-8* is genuinely
+     * unusable, and that is the one case that clears the entry.
+     *
+     * This is where iOS deliberately diverges from the Android plugin, which
+     * deletes on any decrypt failure. There it is correct: a Keystore key
+     * invalidated by a credential change makes the ciphertext permanently
+     * unrecoverable. iOS holds no app-side key, so it has no equivalent of that
+     * permanent case — which is why copying Android's behaviour here would be a
+     * bug rather than symmetry.
      */
     @objc func get(_ call: CAPPluginCall) {
         guard let key = call.getString("key") else {
@@ -109,21 +134,24 @@ public class SecureStorePlugin: CAPPlugin, CAPBridgedPlugin {
         var item: CFTypeRef?
         let status = SecItemCopyMatching(lookup as CFDictionary, &item)
 
-        if status == errSecItemNotFound {
-            call.resolve(["value": NSNull()])
+        if status == errSecSuccess {
+            guard let data = item as? Data,
+                let value = String(data: data, encoding: .utf8)
+            else {
+                // Present but not a string: no retry will fix it, so clear it
+                // and let the next write start from a known state.
+                SecItemDelete(query(for: key) as CFDictionary)
+                call.resolve(["value": NSNull()])
+                return
+            }
+            call.resolve(["value": value])
             return
         }
 
-        guard status == errSecSuccess,
-            let data = item as? Data,
-            let value = String(data: data, encoding: .utf8)
-        else {
-            SecItemDelete(query(for: key) as CFDictionary)
-            call.resolve(["value": NSNull()])
-            return
-        }
-
-        call.resolve(["value": value])
+        // errSecItemNotFound and every transient status land here: no session
+        // for now, and the stored item — if any — is left untouched so a later
+        // read can still succeed.
+        call.resolve(["value": NSNull()])
     }
 
     /// `errSecItemNotFound` is success: the caller asked for the key to be gone,

--- a/native/capacitor-secure-store/package.json
+++ b/native/capacitor-secure-store/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@reis/capacitor-secure-store",
+  "version": "1.0.0",
+  "private": true,
+  "description": "iOS Keychain storage for the IS session token. A local Capacitor plugin package, not published.",
+  "license": "Apache-2.0",
+  "capacitor": {
+    "ios": {
+      "src": "ios"
+    }
+  },
+  "files": [
+    "ios/Sources",
+    "Package.swift"
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@capacitor/splash-screen": "^8.0.2",
         "@capgo/capacitor-inappbrowser": "^8.13.2",
         "@fontsource/inter": "^5.3.0",
+        "@reis/capacitor-secure-store": "file:native/capacitor-secure-store",
         "@supabase/supabase-js": "^2.111.0",
         "clsx": "^2.1.1",
         "daisyui": "^5.7.9",
@@ -88,6 +89,11 @@
         "vitest": "^3.2.4",
         "wxt": "^0.21.2"
       }
+    },
+    "native/capacitor-secure-store": {
+      "name": "@reis/capacitor-secure-store",
+      "version": "1.0.0",
+      "license": "Apache-2.0"
     },
     "node_modules/@1natsu/wait-element": {
       "version": "4.1.2",
@@ -2597,6 +2603,10 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@reis/capacitor-secure-store": {
+      "resolved": "native/capacitor-secure-store",
+      "link": true
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.53",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@capacitor/splash-screen": "^8.0.2",
     "@capgo/capacitor-inappbrowser": "^8.13.2",
     "@fontsource/inter": "^5.3.0",
+    "@reis/capacitor-secure-store": "file:native/capacitor-secure-store",
     "@supabase/supabase-js": "^2.111.0",
     "clsx": "^2.1.1",
     "daisyui": "^5.7.9",

--- a/src/platform/secureStore.ts
+++ b/src/platform/secureStore.ts
@@ -8,15 +8,21 @@ interface SecureStoreNativePlugin {
 }
 
 /**
- * Android-only native plugin. Values are encrypted with an AES-256-GCM key that
- * lives in the Android Keystore and never enters the JS heap or the filesystem;
- * only ciphertext is persisted.
+ * Native plugin, implemented on both mobile platforms — the credential never
+ * touches `platform.storage`, which is plaintext on either OS.
  *
- * iOS is NOT implemented — the app has never been built for iOS (#174), and the
- * Keychain half lands there, where it can actually be compiled and run. Calling
- * this on iOS rejects from the bridge (no such plugin method), which is the
- * intended outcome: a missing implementation must surface as a failure, never
- * as a quiet fallback that writes a live credential to plaintext.
+ * Android encrypts with an AES-256-GCM key generated inside the Android
+ * Keystore; only ciphertext is persisted. iOS stores the value in the Keychain
+ * (`kSecClassGenericPassword`, accessible after first unlock, this device only),
+ * which encrypts at rest under a key outside the app process — so the iOS half
+ * writes no cipher code of its own.
+ *
+ * This module is the Capacitor implementation only. The other two hosts supply
+ * their own `secureStorage` and neither has a keystore to reach for: the
+ * extension maps it onto `chrome.storage.local` (its threat model is the browser
+ * profile, not a lost handset) and the dev webapp onto an in-memory Map. Do not
+ * "unify" them onto this plugin — `registerPlugin` has nothing to talk to off
+ * Capacitor.
  */
 const SecureStore = registerPlugin<SecureStoreNativePlugin>('SecureStore');
 


### PR DESCRIPTION
Closes #174. Finishes the iOS half of #172 (the Android half was #195).

**The iOS app now builds, launches, signs in and syncs — the first time it has ever run.** Simulator, iPhone 17 / iOS 26.5, Xcode 26.6, SPM (no CocoaPods).

## What a student gets

Their IS session token is stored in the **iOS Keychain** instead of a plaintext plist, the same guarantee Android got in #195. Nothing else about the app changes.

## Evidence, not assertions

One run on the simulator:

- **121 requests to IS** (119 GET + 2 POST) — the full sync fan-out, the same shape as the Android handset pass (115)
- **Zero** `login.pl` redirects, **zero** `sessionExpired`, **zero** telemetry
- **120+ `SecureStore get`** bridge calls — the token is read from the Keychain on every request
- Session survived **app kill and reinstall**: the run above never presented a login
- Isolated round-trip probe: `before=undefined → probe-value-4711 → afterRemove=undefined`

That run also exercises the **inverted cookie delivery** the plan flagged as unverified for iOS, since iOS authenticates by the explicit `Cookie` header rather than the native jar.

## Design choices worth reviewing

`kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`:

- **AfterFirstUnlock**, not WhenUnlocked — the token is read at cold start and by background sync, and WhenUnlocked would fail those reads on a locked device, which the app would read as a lapsed session and prompt a needless sign-in.
- **ThisDeviceOnly** so the item never travels in a backup. That matches Android's non-exportable Keystore key, and `tokenStore.loadStoredToken` already treats a restore onto new hardware as a lapsed session.
- No biometric gate, for the same reason Android does not set `setUserAuthenticationRequired`.

Where Android had to hand-roll AES-256-GCM, this writes **no cipher code at all** — the Keychain encrypts at rest under a key outside the app process.

`set` **rejects** on failure rather than resolving, mirroring Android. Resolving on a failed credential write is the worst outcome available: login would report success while nothing persisted, and the student would be bounced to the login sheet on every cold start with no clue why. `get` resolves `{value: null}` for both "not stored" and "stored but unreadable", because both mean the same thing to the app — no session, present login.

## Why it is a package and not a file in the app target

**Capacitor 8 gives an app-local iOS plugin no route to JS.** This cost four build cycles and is the most reusable thing in the PR — full trail in `native/capacitor-secure-store/README.md`:

1. A Swift file in the app target with `@objc(...)` + `CAPBridgedPlugin` compiles, symbols land in the binary, and every call still rejects `"SecureStore" plugin is not implemented on ios`. There is no ObjC-runtime scan any more.
2. `bridge?.registerPluginType(...)` from `capacitorDidLoad()` does **not** fix it — it fills the *native* registry but emits no JSExport user script (measured: `WKUserContentController` script count 13 → 13, none mentioning SecureStore). JS resolves against `window.Capacitor.PluginHeaders` and throws **without ever calling native**.
3. Registration comes from `packageClassList` in `capacitor.config.json` — gitignored *and* rewritten by `cap sync`, from installed plugin **packages** only.

So: a local `file:` dependency. `cap sync` generates the `packageClassList` entry and the `CapApp-SPM` dependency, and **the Xcode project needed no changes at all** (`project.pbxproj` is untouched in this diff — an earlier attempt that modified it was reverted once the package route worked).

`Downloads` and `Eduroam` are app-local Java today. Fine on Android, where `MainActivity.registerPlugin` runs before bridge init — but **their iOS halves must start life as packages.**

## Two traps recorded for the next person

- The SPM package **and** product name must equal the CLI's derivation from the npm name (`@reis/capacitor-secure-store` → `ReisCapacitorSecureStore`), or dependency resolution fails before any Swift compiles.
- `ios/App/CapApp-SPM/Package.swift` has the same symlinked-`node_modules` rewrite hazard as `capacitor.settings.gradle`: with a symlink, `cap sync ios` rewrote every path to the resolved target, which builds locally and breaks every other checkout. Caught mid-flight; a real `npm install` fixes it. The committed diff is two clean relative-path lines.

## Verification

- `npx vitest run --exclude '**/parsers/iskam/__tests__/**'` — **2023 passed**, 4 skipped
- `npm run typecheck` (`tsc -b`) — clean
- `npm run nuia:gate` — ratchet ok, 95 files in baseline
- eslint + prettier on changed files — clean
- `npx cap sync android` unaffected: still 6 plugins, no Android files changed

## What this does NOT prove

- The login **capture** step has been seen work once, not repeatedly from a clean install.
- **Downloads on iOS** (the share sheet, rather than Android's Downloads folder) are entirely unexercised.
- The iOS **app icon is still the default Capacitor placeholder**; Android got the real logo in #190.
- There is no iOS analogue of `mobile/backButton.ts`'s sheet-unwind chain — the edge-swipe is all there is.
- Nothing here has run on a physical iPhone.

Unrelated but found while measuring this: sync is far chattier than it needs to be — filed as #197.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added secure credential storage on iOS using the device’s Keychain.
  - iOS authentication and synchronization now work reliably with securely stored sessions.
  - Secure storage is supported across both Android and iOS.

- **Bug Fixes**
  - Improved handling of missing or unreadable stored credentials to prevent authentication issues.

- **Documentation**
  - Updated setup and platform guidance for secure storage and iOS support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->