### PR TITLE
Mobile: an iPad runs the phone UI, not the broken desktop one

### DIFF
--- a/docs/superpowers/plans/2026-08-02-capacitor-remaining-work.md
+++ b/docs/superpowers/plans/2026-08-02-capacitor-remaining-work.md
@@ -701,10 +701,20 @@ dependency resolution before any Swift compiles.
   importers of its own. `useFileDownload` contained every breakage class at once (bare
   `fetch`, `window.open`, `a[download]`, `saveAs`) and was the thing most likely to get
   ported by example.
-- **Tablet path is unhandled.** `resolvePhoneViewport` needs touch **and** narrow, so a
-  tablet renders the *desktop* tree — which reaches `PdfViewer.tsx:15`
-  (`chrome.runtime.getURL` → `ReferenceError`, swallowed at `:61` → permanent spinner) and
-  the ZIP path. Decide whether tablets are supported.
+- ~~**Tablet path is unhandled.**~~ ✅ **Decided and fixed: the native app is always the phone
+  tree.** `resolvePhoneViewport` needed touch **and** narrow, and an iPad is 834pt wide in
+  portrait, so a tablet rendered the *desktop* tree — which reaches `PdfViewer.tsx:15`
+  (`chrome.runtime.getURL` → `ReferenceError`, swallowed at `:61` → permanent spinner) and the
+  ZIP path. The gate now short-circuits to `true` on the Capacitor host, because the app ships
+  no desktop tree at all: being the app IS the answer to "is this a phone". A tablet on a phone
+  layout at worst looks roomy; a tablet on the desktop tree cannot open a file.
+
+  Note the accidental split this replaces: **iPad mini portrait is 744pt**, so it slipped under
+  the 767px breakpoint and got the phone tree while every larger iPad did not. Two different
+  behaviours across the iPad line, neither chosen.
+
+  The **browser** gate is unchanged — a tablet visiting IS in Safari still gets the desktop
+  tree, which is right there, since the extension's desktop tree works.
 - **ZIP stays desktop-only** by product decision. It is already unreachable on phone
   (`SubjectDrawerSheet.tsx:144` passes `selectable={false}`); no work needed, just do not
   "fix" it later.

--- a/src/hooks/ui/__tests__/usePhoneViewport.test.ts
+++ b/src/hooks/ui/__tests__/usePhoneViewport.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+vi.mock('../../../platform', () => ({ getPlatform: vi.fn(() => ({ kind: 'extension' })) }));
+
+import { getPlatform } from '../../../platform';
+import { usePhoneViewport } from '../usePhoneViewport';
+import { useAppStore } from '../../../store/useAppStore';
+
+/**
+ * `resolvePhoneViewport` is unit-tested on its own. What this file covers is the
+ * SEAM the pure function cannot see: that the hook maps
+ * `getPlatform().kind === 'capacitor'` onto `isNativeApp`.
+ *
+ * Worth its own test because a regression there is silent — it does not throw or
+ * fail a type check, it just quietly puts an iPad back on the desktop tree, where
+ * `PdfViewer` hits `chrome.runtime.getURL` and hangs on a spinner. The visible
+ * symptom is a file that never opens, three layers away from the cause.
+ */
+const setViewport = (isTouch: boolean, isNarrow: boolean) => {
+  useAppStore.setState({ isTouch, isNarrow, devPhoneOverride: null });
+};
+
+const asCapacitor = () =>
+  vi.mocked(getPlatform).mockReturnValue({ kind: 'capacitor' } as ReturnType<typeof getPlatform>);
+
+describe('usePhoneViewport', () => {
+  beforeEach(() => {
+    vi.mocked(getPlatform).mockReturnValue({ kind: 'extension' } as ReturnType<typeof getPlatform>);
+  });
+
+  it('is a phone on a WIDE screen in the native app — the iPad case', () => {
+    asCapacitor();
+    setViewport(true, false);
+    expect(renderHook(() => usePhoneViewport()).result.current).toBe(true);
+  });
+
+  it('is NOT a phone on the same wide screen in a browser', () => {
+    setViewport(true, false);
+    expect(renderHook(() => usePhoneViewport()).result.current).toBe(false);
+  });
+
+  it('is a phone on a narrow touch screen in a browser', () => {
+    setViewport(true, true);
+    expect(renderHook(() => usePhoneViewport()).result.current).toBe(true);
+  });
+
+  it('the dev override still beats the native host', () => {
+    asCapacitor();
+    setViewport(true, false);
+    useAppStore.setState({ devPhoneOverride: false });
+    expect(renderHook(() => usePhoneViewport()).result.current).toBe(false);
+  });
+});

--- a/src/hooks/ui/usePhoneViewport.ts
+++ b/src/hooks/ui/usePhoneViewport.ts
@@ -1,13 +1,19 @@
 import { useAppStore } from '../../store/useAppStore';
+import { getPlatform } from '../../platform';
 import { resolvePhoneViewport } from '../../utils/resolvePhoneViewport';
 
 /**
  * The one place the app asks "am I a phone". `isPhone` is derived, never
  * stored, so there is no second source of truth to drift from the viewport.
+ *
+ * The host is read straight from the platform rather than the store: it cannot
+ * change for the life of the process, so putting it in reactive state would
+ * imply it might.
  */
 export function usePhoneViewport(): boolean {
   const isTouch = useAppStore((s) => s.isTouch);
   const isNarrow = useAppStore((s) => s.isNarrow);
   const override = useAppStore((s) => s.devPhoneOverride);
-  return resolvePhoneViewport({ isTouch, isNarrow, override });
+  const isNativeApp = getPlatform().kind === 'capacitor';
+  return resolvePhoneViewport({ isTouch, isNarrow, isNativeApp, override });
 }

--- a/src/utils/__tests__/resolvePhoneViewport.test.ts
+++ b/src/utils/__tests__/resolvePhoneViewport.test.ts
@@ -10,8 +10,29 @@ describe('resolvePhoneViewport', () => {
     expect(resolvePhoneViewport({ isTouch: false, isNarrow: true })).toBe(false);
   });
 
-  it('is not a phone on a wide touch screen (tablet, kiosk)', () => {
+  it('is not a phone on a wide touch screen in a BROWSER (tablet, kiosk)', () => {
     expect(resolvePhoneViewport({ isTouch: true, isNarrow: false })).toBe(false);
+  });
+
+  /**
+   * The native app has no desktop tree to fall back to. An iPad is 834pt wide in
+   * portrait, so the width test alone sent it to the desktop layout — which on
+   * Capacitor reaches `chrome.runtime.getURL` in PdfViewer and hangs on a
+   * spinner forever. The app being native IS the answer to "is this a phone".
+   */
+  it('is a phone on a WIDE native app screen — an iPad runs the phone UI', () => {
+    expect(resolvePhoneViewport({ isTouch: true, isNarrow: false, isNativeApp: true })).toBe(true);
+  });
+
+  it('is a phone in the native app even without a coarse pointer', () => {
+    // A Mac running the iPad build, or a simulator with a trackpad: still the app.
+    expect(resolvePhoneViewport({ isTouch: false, isNarrow: false, isNativeApp: true })).toBe(true);
+  });
+
+  it('the dev override still wins over the native app', () => {
+    expect(
+      resolvePhoneViewport({ isTouch: true, isNarrow: false, isNativeApp: true, override: false })
+    ).toBe(false);
   });
 
   it('override true forces the phone branch regardless of viewport', () => {

--- a/src/utils/resolvePhoneViewport.ts
+++ b/src/utils/resolvePhoneViewport.ts
@@ -1,6 +1,8 @@
 export interface PhoneViewportInput {
   isTouch: boolean;
   isNarrow: boolean;
+  /** True on the Capacitor build (the iOS/Android app), false in any browser. */
+  isNativeApp?: boolean;
   /** Dev-only forced value. null/undefined defers to the viewport. */
   override?: boolean | null;
 }
@@ -8,11 +10,31 @@ export interface PhoneViewportInput {
 /**
  * Single source of truth for "is this a phone".
  *
- * Phone = coarse pointer AND narrow viewport, so a narrow desktop window stays
- * desktop and a tablet stays desktop. Kept pure and separate from the store so
- * it is testable without a DOM, and so the dev override has one place to apply.
+ * In a **browser** it is a measurement: coarse pointer AND narrow viewport, so a
+ * narrow desktop window stays desktop and a tablet visiting IS stays desktop.
+ *
+ * In the **native app it is not a measurement at all** — the app ships only the
+ * phone tree, so being the app is the whole answer. This is deliberate and not a
+ * shortcut: an iPad is 834pt wide in portrait, the width test alone therefore
+ * sent it to the desktop layout, and that layout is genuinely broken under
+ * Capacitor — `SubjectFileDrawer/PdfViewer.tsx` calls bare
+ * `chrome.runtime.getURL`, which does not exist off the extension, and the
+ * failure is swallowed into a spinner that never resolves. A tablet running a
+ * phone layout at worst looks roomy; a tablet running the desktop tree cannot
+ * open a file.
+ *
+ * Kept pure and separate from the store so it is testable without a DOM, and so
+ * the dev override has one place to apply. The override still wins over
+ * everything, native included — that is what makes the desktop tree reachable in
+ * the dev webapp.
  */
-export function resolvePhoneViewport({ isTouch, isNarrow, override }: PhoneViewportInput): boolean {
+export function resolvePhoneViewport({
+  isTouch,
+  isNarrow,
+  isNativeApp = false,
+  override,
+}: PhoneViewportInput): boolean {
   if (override === true || override === false) return override;
+  if (isNativeApp) return true;
   return isTouch && isNarrow;
 }


### PR DESCRIPTION
Closes the tablet half of #175. Follows #198, which is now in `main`.

## What a student gets

On an iPad, reIS shows the same phone interface as on a phone. Today it shows the **desktop** interface, and that one cannot open a file.

## The bug

The gate was `isTouch && isNarrow`, with `isNarrow` = `max-width: 767px`. An iPad Pro 11" is **834pt** wide in portrait, so it failed the width test and fell to the desktop tree — which does not work under Capacitor: `SubjectFileDrawer/PdfViewer.tsx:15` calls bare `chrome.runtime.getURL`, absent off the extension, and the failure is swallowed at `:61` into a spinner that never resolves.

The exception is worth naming, because it was an accident rather than a decision: **iPad mini portrait is 744pt**, so it slipped under the breakpoint and got the phone tree while every larger iPad did not. Two different behaviours across the iPad line, neither chosen.

## The fix

`resolvePhoneViewport` short-circuits to `true` on the Capacitor host.

Deliberately **not** a wider breakpoint: the native app ships no desktop tree at all, so being the app *is* the answer to "is this a phone" — a measurement would only invite the same question again at the next screen size. The dev override still wins over it, which is what keeps the desktop tree reachable in the dev webapp.

**The browser gate is untouched.** A tablet visiting IS in Safari still gets the desktop tree, which is right — there the desktop tree works.

The host comes from `getPlatform()` rather than the store: it cannot change for the life of the process, and putting it in reactive state would imply it might.

## Verification

- **Tests first.** Two new cases pin a wide native screen as a phone — with *and* without a coarse pointer, since a Mac running the iPad build has neither — plus a third pinning that the dev override still beats it. Both new cases failed before the change.
- Full suite **2026 passed**, 4 skipped. `tsc -b` clean, eslint + prettier clean, nuia ratchet ok.
- On a simulator: the **iPhone tree is unchanged** after the change (screenshot-verified), and the iPad build installs and boots to the IS login.

## What this does not prove

**The iPad's post-login layout has not been seen.** React only mounts after `ensureSession` resolves, so seeing the tablet layout needs a real login on the device, which needs the student's own credentials. The logic is unit-pinned and the reasoning is above, but the pixels are unconfirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)